### PR TITLE
make m_nSentryAmmo a networked variable

### DIFF
--- a/src/game/shared/swarm/asw_weapon_sentry_shared.h
+++ b/src/game/shared/swarm/asw_weapon_sentry_shared.h
@@ -29,6 +29,8 @@ public:
 	virtual ~CASW_Weapon_Sentry();
 	void Precache();
 	
+	CNetworkVar( int, m_nSentryAmmo );
+	
 	Activity	GetPrimaryAttackActivity( void );
 
 	virtual void	PrimaryAttack();
@@ -66,9 +68,7 @@ protected:
 
 	CNetworkVar(bool, m_bDisplayValid);
 
-#ifndef CLIENT_DLL
-	int m_nSentryAmmo;
-#else
+#ifdef CLIENT_DLL
 	float m_flNextDeployCheckThink;
 	bool m_bDisplayActive;
 	EHANDLE m_hOwningMarine; // need to store this so we can destroy the effect on the marine


### PR DESCRIPTION
Didn't find a way to read sentry's ammo via vscripts when it is not deployed. GetClips() returns a wrong value.
This will increase network traffic just a bit

WARNING: didnt test this. 

