### PR TITLE
fix declaration of memoverride.cpp mismatching 

### DIFF
--- a/src/public/tier0/memoverride.cpp
+++ b/src/public/tier0/memoverride.cpp
@@ -249,7 +249,7 @@ ALLOC_CALL void * __cdecl _recalloc ( void * memblock, size_t count, size_t size
 	return pMem;
 }
 
-size_t _msize_base( void *pMem )
+size_t _msize_base( void *pMem ) noexcept
 {
 	return g_pMemAlloc->GetSize(pMem);
 }


### PR DESCRIPTION
fixes: 
```
C:\Users\<username>\Projects\private\reactivedrop_public_src\src\public\tier0\memoverride.cpp(252,8): error C2382: '_msize_base': redefinition; different exception specifications
C:\Program Files (x86)\Windows Kits\10\Include\10.0.20348.0\ucrt\corecrt_malloc.h(107): message : see declaration of '_msize_base'
```

this fixes it locally, please verify this before merge.