### PR TITLE
quick fix for steam io error

### DIFF
--- a/src/game/shared/swarm/asw_player_experience.cpp
+++ b/src/game/shared/swarm/asw_player_experience.cpp
@@ -919,12 +919,18 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 			return;
 	}
 
+	// XXX: for now, comment this out
+	//      steam callbacks don't seem to have a bIOError parameter?
+	//      commenting this out fixes some things for now, but this might need further investigation 
+	
+	/*
 	if ( bIOError )
 	{
 		Warning( "CASW_Player: Server failed to download stats from Steam, IO error\n" );
 		m_bPendingSteamStats = false;
 		return;
 	}
+	*/
 
 	if ( pUserStatsReceived->m_eResult != k_EResultOK )
 	{


### PR DESCRIPTION
This fixes:

```CASW_Player: Server failed to download stats from Steam, IO error```

As far as I can see, Steam callbacks don't seem to have a bIOError parameter? Commenting this out fixes some things for now, but this might need further investigation.

`pUserStatsReceived->m_eResult`  seems to have the correct response code further down the method.