### PR TITLE
Fix challenge selection

### DIFF
--- a/src/game/shared/swarm/rd_challenges_shared.cpp
+++ b/src/game/shared/swarm/rd_challenges_shared.cpp
@@ -166,7 +166,8 @@ const RD_Challenge_t *ReactiveDropChallenges::GetSummary( const char *pszChallen
 	}
 #endif
 
-	Assert( g_StringTableReactiveDropChallenges );
+	if( !g_StringTableReactiveDropChallenges )
+		return NULL;
 
 	int index = g_StringTableReactiveDropChallenges->FindStringIndex( pszChallengeName );
 	if ( index == INVALID_STRING_INDEX )


### PR DESCRIPTION
When selecting challenge from the mission chooser prior to creating a game it will crash game.