### PR TITLE
Avoid removing world entity

### DIFF
--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -5783,7 +5783,7 @@ void CC_Ent_Remove( const CCommand& args )
 	}
 
 	// Found one?
-	if ( pEntity )
+	if ( pEntity && !pEntity->IsWorld() )
 	{
 		Msg( "Removed %s(%s)\n", STRING(pEntity->m_iClassname), pEntity->GetDebugName() );
 		UTIL_Remove( pEntity );


### PR DESCRIPTION
Static prop is part of the world entity to avoid crashing the game when using command