### PR TITLE
enable automated building

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,58 @@
+name: Continuous integration
+on:
+  push:
+    branches:
+      - reactivedrop_public
+  pull_request:
+    branches:
+      - reactivedrop_public
+
+# GitHub Actions usage is FREE for both public repositories and self-hosted runners.
+# We can use it to build our project and do some automated builds and in future quality tests.
+# https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions
+
+jobs:
+  build:
+    name: build release
+    runs-on: windows-2022
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      # missionchooser.dll
+      - name: Build missionchooser.dll
+        working-directory: src/game/missionchooser
+        run: MSBuild.exe swarm_dsk_missionchooser.vcxproj -property:Configuration=Release
+      - name: Store missionchooser.dll
+        uses: actions/upload-artifact@v2
+        with:
+          name: missionchooser
+          path: |
+            Release/missionchooser.dll
+            Release/missionchooser.pdb
+
+      # client.dll
+      - name: Build client.dll
+        working-directory: src/game/client
+        run: MSBuild.exe client.vcxproj -property:Configuration=Release
+      - name: Store client.dll
+        uses: actions/upload-artifact@v2
+        with:
+          name: client
+          path: |
+            Release/client.dll
+            Release/client.pdb
+
+      # server.dll
+      - name: Build server.dll
+        working-directory: src/game/server
+        run: MSBuild.exe server.vcxproj -property:Configuration=Release
+      - name: Store server.dll
+        uses: actions/upload-artifact@v2
+        with:
+          name: server
+          path: |
+            Release/server.dll
+            Release/server.pdb


### PR DESCRIPTION
Enable automated building of reactivedrop_public branch and pull requests on it. 

This makes checking if the build succeeds easier. We can add quality tests, like formatting checks easily in future.

_(setup should be correct, but can only test this after merge)_