### PR TITLE
set minimum on asw_max_saves

### DIFF
--- a/src/game/missionchooser/asw_mission_chooser_source_local.cpp
+++ b/src/game/missionchooser/asw_mission_chooser_source_local.cpp
@@ -16,7 +16,7 @@ static FileFindHandle_t	g_hsavedfind = FILESYSTEM_INVALID_FIND_HANDLE;
 
 #define ASW_SKILL_POINTS_PER_MISSION 2		// keep in sync with asw_shareddefs.h (we need a h shared between missionchooser and game dlls...)
 
-ConVar asw_max_saves("asw_max_saves", "10", FCVAR_ARCHIVE, "Maximum number of multiplayer saves that will be stored on this server.");
+ConVar asw_max_saves("asw_max_saves", "10", FCVAR_ARCHIVE, "Maximum number of multiplayer saves that will be stored on this server.", true, 2, false, 0);
 
 namespace
 {


### PR DESCRIPTION
Set minimum valve for asw_max_saves to `2`. If lower, crashes or lockups may occur. Fixes #181