### PR TITLE
Steam IO Error

### DIFF
--- a/src/game/shared/swarm/asw_player_experience.cpp
+++ b/src/game/shared/swarm/asw_player_experience.cpp
@@ -927,7 +927,7 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 
 	if ( bIOError )
 	{
-		Warning( "CASW_Player: Server failed to download stats from Steam, IO error\n" );
+		DevWarning( "CASW_Player: Server failed to download stats from Steam, IO error\n" );
 		m_bPendingSteamStats = false;
 		return;
 	}


### PR DESCRIPTION
This call seems to always `bIOError`. Move it from warning() to devWarning() to limit logspam for now.

Affects #149