### PR TITLE
Add New CASW_Player VScript Functions

### DIFF
--- a/src/game/server/swarm/asw_player.cpp
+++ b/src/game/server/swarm/asw_player.cpp
@@ -281,6 +281,12 @@ END_DATADESC()
 
 BEGIN_ENT_SCRIPTDESC( CASW_Player, CBasePlayer, "The player entity." )
 	DEFINE_SCRIPTFUNC( ResurrectMarine, "Resurrect the marine" )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptGetNPC, "GetNPC", "Returns entity the player is inhabiting" )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptGetSpectatingNPC, "GetSpectatingNPC", "Returns entity the player is spectating" )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptGetViewNPC, "GetViewNPC", "Returns entity the player is spectating, else will return inhabiting entity" )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptGetMarine, "GetMarine", "Returns the marine the player is commanding" )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptFindPickerEntity, "FindPickerEntity", "Finds the nearest entity in front of the player" )
+	DEFINE_SCRIPTFUNC( GetCrosshairTracePos, "Returns the world location directly beneath the player's crosshair" )
 END_SCRIPTDESC()
 
 // -------------------------------------------------------------------------------- //
@@ -1937,6 +1943,11 @@ CASW_Inhabitable_NPC *CASW_Player::GetNPC() const
 	return m_hInhabiting.Get();
 }
 
+HSCRIPT CASW_Player::ScriptGetNPC() const
+{
+	return ToHScript( GetNPC() );
+}
+
 void CASW_Player::SpectateNextMarine()
 {
 	CASW_Game_Resource* pGameResource = ASWGameResource();
@@ -1994,6 +2005,11 @@ CASW_Inhabitable_NPC *CASW_Player::GetSpectatingNPC() const
 	return m_hSpectating.Get();
 }
 
+HSCRIPT CASW_Player::ScriptGetSpectatingNPC() const
+{
+	return ToHScript( GetSpectatingNPC() );
+}
+
 CASW_Inhabitable_NPC *CASW_Player::GetViewNPC() const
 {
 	CASW_Inhabitable_NPC *pNPC = GetSpectatingNPC();
@@ -2001,6 +2017,11 @@ CASW_Inhabitable_NPC *CASW_Player::GetViewNPC() const
 		pNPC = GetNPC();
 
 	return pNPC;
+}
+
+HSCRIPT CASW_Player::ScriptGetViewNPC() const
+{
+	return ToHScript( GetViewNPC() );
 }
 
 void CASW_Player::SelectNextMarine(bool bReverse)
@@ -3178,6 +3199,11 @@ CBaseEntity* CASW_Player::FindPickerEntity()
 	return pNearestEntity;
 }
 
+HSCRIPT CASW_Player::ScriptFindPickerEntity()
+{
+	return ToHScript( FindPickerEntity() );
+}
+
 const Vector& CASW_Player::GetCrosshairTracePos()
 {
 	if ( GetASWControls() != ASWC_TOPDOWN && GetNPC() )
@@ -3217,4 +3243,20 @@ HSCRIPT CASW_Player::ResurrectMarine( const Vector position, bool bEffect )
 	}
 
 	return ToHScript( pMarine );
+}
+
+HSCRIPT CASW_Player::ScriptGetMarine()
+{
+	const int numMarineResources = ASWGameResource()->GetMaxMarineResources();
+
+	for ( int i = 0; i < numMarineResources; i++ )
+	{
+		CASW_Marine_Resource* pMR = ASWGameResource()->GetMarineResource( i );
+		if ( pMR && pMR->IsInhabited() && pMR->GetCommander() == this )
+		{
+			return ToHScript( pMR->GetMarineEntity() );
+		}
+	}
+
+	return NULL;
 }

--- a/src/game/server/swarm/asw_player.h
+++ b/src/game/server/swarm/asw_player.h
@@ -86,6 +86,7 @@ public:
 	void SpectateNextMarine();
 	void SetSpectatingNPC( CASW_Inhabitable_NPC *pSpectating );
 	CASW_Inhabitable_NPC *GetSpectatingNPC() const;
+	HSCRIPT ScriptGetSpectatingNPC() const;
 	CNetworkHandle( CASW_Inhabitable_NPC, m_hSpectating );
 	bool m_bLastAttackButton;	// used to detect left clicks for cycling through marines
 	bool m_bLastAttack2Button;	// used to detect right clicks for cycling through marines
@@ -99,6 +100,7 @@ public:
 	void OnNPCCommanded( CASW_Inhabitable_NPC *pNPC );
 	void SetNPC( CASW_Inhabitable_NPC *pNPC );
 	CASW_Inhabitable_NPC *GetNPC() const;
+	HSCRIPT ScriptGetNPC() const;
 	void SelectNextMarine( bool bReverse );
 	bool CanSwitchToMarine( int num );
 	// BenLubar(deathmatch-improvements)
@@ -109,6 +111,7 @@ public:
 	void LeaveMarines();
 	bool HasLiveMarines();
 	virtual bool IsAlive( void );
+	HSCRIPT ScriptGetMarine();
 
 	CNetworkHandle( CASW_Marine, m_hOrderingMarine );
 
@@ -136,6 +139,7 @@ public:
 
 	// shared code
 	CASW_Inhabitable_NPC *GetViewNPC() const;
+	HSCRIPT ScriptGetViewNPC() const;
 	void ItemPostFrame();
 	void ASWSelectWeapon(CBaseCombatWeapon* pWeapon, int subtype);	// for switching weapons on the current marine
 	virtual bool Weapon_CanUse( CBaseCombatWeapon *pWeapon );
@@ -228,6 +232,7 @@ public:
 	CNetworkVar( float, m_fMapGenerationProgress );			// how far this player is through generating their local copy of the next random map
 
 	virtual CBaseEntity* FindPickerEntity();
+	HSCRIPT ScriptFindPickerEntity();
 
 	// entity this player is highlighting with his mouse cursor
 	void SetHighlightEntity( CBaseEntity* pEnt ) { m_hHighlightEntity = pEnt; }


### PR DESCRIPTION
- Add new VScript functions for CASW_Player.

Returns entity the player is inhabiting
`CBaseEntity GetNPC()`

Returns entity the player is spectating
`CBaseEntity GetSpectatingNPC()`

Returns entity the player is spectating, else will return inhabiting entity
`CBaseEntity GetViewNPC()`

Returns the marine the player is commanding
`CASW_Marine GetMarine()`

Finds the nearest entity in front of the player
`CBaseEntity FindPickerEntity()`

Returns the world location directly beneath the player's crosshair
`Vector GetCrosshairTracePos()`