### PR TITLE
Adds support for RGB colored text for chat

### DIFF
--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -1814,14 +1814,10 @@ void CBaseHudChat::ChatPrintf( int iPlayerIndex, int iFilter, const char *fmt, .
 	char *pmsg = msg;
 	while ( *pmsg && ( *pmsg == '\n' || ( *pmsg > 0 && *pmsg < COLOR_MAX ) ) )
 	{
-		//This is code I added to clear the 3 bytes that come after the custom RGB character.
-		if (*pmsg == COLOR_INPUTCUSTOMCOL)
-		{
+		if ( *pmsg == COLOR_INPUTCUSTOMCOL )
+			pmsg += 4;
+		else
 			pmsg++;
-			pmsg++;
-			pmsg++;
-		}
-		pmsg++;
 	}
 
 	if ( !*pmsg )

--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -1589,10 +1589,7 @@ void CBaseHudChatLine::InsertAndColorizeText( wchar_t *buf, int clientIndex )
 
 				m_textRanges.AddToTail(range);
 				//Pass by all color channel characters
-				++txt;
-				++txt;
-				++txt;
-				++txt;
+				txt += 4;
 				break;
 			}
 			default:

--- a/src/game/client/hud_basechat.h
+++ b/src/game/client/hud_basechat.h
@@ -132,7 +132,7 @@ public:
 	void			SetNameColor( Color cColor ){ m_clrNameColor = cColor; 	}
 		
 	virtual void	PerformFadeout( void );
-	int				CBaseHudChatLine::TranslateChannelRange(byte inputval);
+	static int		TranslateChannelRange(byte inputval);
 	virtual void	InsertAndColorizeText( wchar_t *buf, int clientIndex );
 	virtual			void Colorize( int alpha = 255 );								///< Re-inserts the text in the appropriate colors at the given alpha
 

--- a/src/game/client/hud_basechat.h
+++ b/src/game/client/hud_basechat.h
@@ -68,8 +68,9 @@ enum TextColor
 	COLOR_PLAYERNAME = 3,
 	COLOR_LOCATION = 4,
 	COLOR_ACHIEVEMENT = 5,
-	COLOR_MOD_CUSTOM = 6, 
-	COLOR_MOD_CUSTOM2 = 7,	
+	COLOR_MOD_CUSTOM = 6,
+	COLOR_MOD_CUSTOM2 = 7,
+	COLOR_INPUTCUSTOMCOL = 8,
 	COLOR_MAX
 };
 
@@ -131,6 +132,7 @@ public:
 	void			SetNameColor( Color cColor ){ m_clrNameColor = cColor; 	}
 		
 	virtual void	PerformFadeout( void );
+	int				CBaseHudChatLine::TranslateChannelRange(byte inputval);
 	virtual void	InsertAndColorizeText( wchar_t *buf, int clientIndex );
 	virtual			void Colorize( int alpha = 255 );								///< Re-inserts the text in the appropriate colors at the given alpha
 

--- a/src/game/client/swarm/vgui/asw_hud_chat.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_chat.cpp
@@ -195,11 +195,11 @@ void CHudChat::MsgFunc_SayText( bf_read &msg )
 
 void CHudChat::MsgFunc_TextMsg( bf_read &msg )
 {
-	char szString[2048];
+	char szString[4096]; //Changed to 4096 to increase buffer size for custom color.
 	int msg_dest = msg.ReadByte();
 
-	wchar_t szBuf[5][128];
-	wchar_t outputBuf[256];
+	wchar_t szBuf[5][4096]; //Changed to 4096 to increase buffer size for custom color.
+	wchar_t outputBuf[4096]; //Changed to 4096 to increase buffer size for custom color.
 
 	for ( int i=0; i<5; ++i )
 	{

--- a/src/game/client/swarm/vgui/asw_hud_chat.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_chat.cpp
@@ -195,11 +195,11 @@ void CHudChat::MsgFunc_SayText( bf_read &msg )
 
 void CHudChat::MsgFunc_TextMsg( bf_read &msg )
 {
-	char szString[4096]; //Changed to 4096 to increase buffer size for custom color.
+	char szString[2048];
 	int msg_dest = msg.ReadByte();
 
-	wchar_t szBuf[5][4096]; //Changed to 4096 to increase buffer size for custom color.
-	wchar_t outputBuf[4096]; //Changed to 4096 to increase buffer size for custom color.
+	wchar_t szBuf[5][512]; //Changed to 512 to increase buffer size for custom color.
+	wchar_t outputBuf[512]; //Changed to 512 to increase buffer size for custom color.
 
 	for ( int i=0; i<5; ++i )
 	{

--- a/src/game/client/swarm/vgui/asw_hud_chat.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_chat.cpp
@@ -198,8 +198,8 @@ void CHudChat::MsgFunc_TextMsg( bf_read &msg )
 	char szString[2048];
 	int msg_dest = msg.ReadByte();
 
-	wchar_t szBuf[5][512]; //Changed to 512 to increase buffer size for custom color.
-	wchar_t outputBuf[512]; //Changed to 512 to increase buffer size for custom color.
+	wchar_t szBuf[5][512];
+	wchar_t outputBuf[512];
 
 	for ( int i=0; i<5; ++i )
 	{

--- a/src/game/server/vscript_server.cpp
+++ b/src/game/server/vscript_server.cpp
@@ -1202,7 +1202,7 @@ static void Script_Say( HSCRIPT hPlayer, const char *pText )
 }
 
 //This is a vscript function that converts RGB into a transmittable format for colored text
-static char* Script_TextColor(int R, int G, int B)
+static ScriptVariant_t Script_TextColor(int R, int G, int B)
 {
 	//Force channel ranges between 0 - 255
 	if (R > 255)
@@ -1249,7 +1249,7 @@ static char* Script_TextColor(int R, int G, int B)
 	char outputChars[5];
 	Q_snprintf(outputChars, sizeof(outputChars), "%c%c%c%c", Con_Char, R_Char, G_Char, B_Char);
 
-	return outputChars;
+	return ScriptVariant_t(outputChars, true);
 }
 
 static void Script_ClientPrint( HSCRIPT hPlayer, int iDest, const char *pText )

--- a/src/game/server/vscript_server.cpp
+++ b/src/game/server/vscript_server.cpp
@@ -1,4 +1,4 @@
-//========== Copyright © 2008, Valve Corporation, All rights reserved. ========
+//========== Copyright Â© 2008, Valve Corporation, All rights reserved. ========
 //
 // Purpose:
 //
@@ -1536,7 +1536,7 @@ bool VScriptServerInit()
 				ScriptRegisterFunction( g_pScriptVM, CreateProp, "Create a physics prop" );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_Say, "Say", "Have player say string" );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_ClientPrint, "ClientPrint", "Print a client message" );
-				ScriptRegisterFunctionNamed(g_pScriptVM,  Script_TextColor, "TextColor", "Gets the translated ASCII characters for an RBG input.");
+				ScriptRegisterFunctionNamed( g_pScriptVM, Script_TextColor, "TextColor", "Gets the translated ASCII characters for an RGB input." );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_StringToFile, "StringToFile", "Stores the string into the file." );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_FileToString, "FileToString", "Reads a string from file. Returns the string from the file, null if no file or file is too big." );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_AddThinkToEnt, "AddThinkToEnt", "Adds a late bound think function to the C++ think tables for the obj" );

--- a/src/game/server/vscript_server.cpp
+++ b/src/game/server/vscript_server.cpp
@@ -1237,17 +1237,12 @@ static ScriptVariant_t Script_TextColor(int R, int G, int B)
 	float outputMod_G = G / 255.0f;
 	float outputMod_B = B / 255.0f;
 
-	//This char must match the char used for the client's COLOR_INPUTCUSTOMCOL - in my case it's 0x08
-	char Con_Char = (char)0x08;
-	//pass float modifiers multiplied by max ASCII translation base then increment by 32 which is float ASCII offset
-	char R_Char = (char)(32 + (outputMod_R * 94));
-	char G_Char = (char)(32 + (outputMod_G * 94));
-	char B_Char = (char)(32 + (outputMod_B * 94));
-
-
-	//Format a string with results as 4 characters.
-	char outputChars[5];
-	Q_snprintf(outputChars, sizeof(outputChars), "%c%c%c%c", Con_Char, R_Char, G_Char, B_Char);
+	char outputChars[5]{};
+	outputChars[0] = '\x08'; // COLOR_INPUTCUSTOMCOL
+	// pass float modifiers multiplied by max ASCII translation base then increment by 32 which is float ASCII offset
+	outputChars[1] = (char)( 32 + ( outputMod_R * 94 ) );
+	outputChars[2] = (char)( 32 + ( outputMod_G * 94 ) );
+	outputChars[3] = (char)( 32 + ( outputMod_B * 94 ) );
 
 	return ScriptVariant_t(outputChars, true);
 }

--- a/src/game/server/vscript_server.cpp
+++ b/src/game/server/vscript_server.cpp
@@ -23,6 +23,7 @@
 #include "ai_basenpc.h"
 #include "inetchannelinfo.h"
 #include "decals.h"
+#include "player_voice_listener.h"
 #ifdef _WIN32
 #include "vscript_server_nut.h"
 #endif
@@ -1230,14 +1231,14 @@ static char* Script_TextColor(int R, int G, int B)
 	{
 		B = 0;
 	}
-	
+
 	//create float modifiers at range 0 - 255 for conversion output
 	float outputMod_R = R / 255.0f;
 	float outputMod_G = G / 255.0f;
 	float outputMod_B = B / 255.0f;
 
 	//This char must match the char used for the client's COLOR_INPUTCUSTOMCOL - in my case it's 0x08
-	char Con_Char = (char)0x08; 
+	char Con_Char = (char)0x08;
 	//pass float modifiers multiplied by max ASCII translation base then increment by 32 which is float ASCII offset
 	char R_Char = (char)(32 + (outputMod_R * 94));
 	char G_Char = (char)(32 + (outputMod_G * 94));
@@ -1574,6 +1575,7 @@ bool VScriptServerInit()
 				g_pScriptVM->RegisterInstance( &g_ScriptEntityOutputs, "EntityOutputs" );
 				g_pScriptVM->RegisterInstance( &g_ScriptInfoNodes, "InfoNodes" );
 				g_pScriptVM->RegisterInstance( &g_ScriptTempEnts, "TempEnts" );
+				g_pScriptVM->RegisterInstance( &PlayerVoiceListener(), "PlayerVoiceListener" );
 
 				// To be used with Script_ClientPrint
 				g_pScriptVM->SetValue( "HUD_PRINTNOTIFY", HUD_PRINTNOTIFY );


### PR DESCRIPTION
Uses color character with 3 additional ascii characters in range of 0x20 to 0x7E to output RGB values to the client text.

Example:
ClientPrint(null, 3, "\x08~!!RED\x08~A!ORANGE\x08~~!YELLOW\x08!~!GREEN\x08!~~AQUA\x08!A~LIGHT_BLUE\x08!!~BLUE\x08~A`PINK\x08~a~PINK");

This is further simplified by the TextColor vscript function that accepts RGB and outputs the closest ascii range.

Example:

ClientPrint(null, 3, TextColor(255, 0 0) +"RED" + " " + TextColor(163, 73, 164)+ "PURPLE" + " " + TextColor(255, 255, 255)+ "WHITE" + " " + TextColor(0, 0, 0)+ "BLACK" + " " + TextColor(155, 155, 155)+ "SILVER");