### PR TITLE
MARINES: no 1hp protection if damage from blast is 3x higher than mar…

### DIFF
--- a/src/game/server/swarm/asw_marine.cpp
+++ b/src/game/server/swarm/asw_marine.cpp
@@ -1475,6 +1475,10 @@ int CASW_Marine::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 			if (newInfo.GetDamage() >= GetHealth())
 				bKillProtection = true;
 		}
+
+		// no protection when the blast damage was 3 times higher than marine's health
+		if ( newInfo.GetDamageType() == DMG_BLAST && newInfo.GetDamage() >= GetHealth() * 3 )
+			bKillProtection = false;
 	}
 
 	CBaseEntity* pInflictor = newInfo.GetInflictor();


### PR DESCRIPTION
…ine health

makes gl more dangerious on difficulties which have one health protection enabled. since the no more double explosion change, killing yourself with grenade launcher with 1 shot with health protection enabled s is not possible