### PR TITLE
HARVESTER: closer to previous behaviour + a convar

### DIFF
--- a/src/game/server/swarm/asw_harvester.cpp
+++ b/src/game/server/swarm/asw_harvester.cpp
@@ -42,6 +42,7 @@ ConVar asw_harvester_new( "asw_harvester_new", "1", FCVAR_CHEAT, "If set to 1, u
 ConVar asw_harvester_spawn_height( "asw_harvester_spawn_height", "16", FCVAR_CHEAT, "Height above harvester origin to spawn xenomites at" );
 ConVar asw_harvester_spawn_interval( "asw_harvester_spawn_interval", "1.0", FCVAR_CHEAT, "Time between spawning a harvesite and starting to spawn another" );
 ConVar rd_harvester_health( "rd_harvester_health", "200", FCVAR_CHEAT, "Health of the harvester" );
+ConVar rd_harvester_always_release_xenomites( "rd_harvester_always_release_xenomites", "0", FCVAR_NONE, "If set, harvesters will always release xenomites after death" );
 
 extern ConVar rd_deagle_bigalien_dmg_scale;
 extern ConVar asw_debug_alien_damage;
@@ -613,9 +614,12 @@ void CASW_Harvester::Event_Killed( const CTakeDamageInfo &info )
 {
 	BaseClass::Event_Killed(info);
 
-	// If we died to an explosion which inflicted two times more damage than we had health (and no other damage type), the xenomites died with us.
-	if ( ( info.GetDamageType() == DMG_BLAST ) && ( m_iHealth + info.GetDamage() / 2 <= 0 ) )
-		return;
+	if ( !rd_harvester_always_release_xenomites.GetBool() )
+	{
+		// If we died to an explosion which inflicted two times more damage than we had health (and no other damage type), the xenomites died with us.
+		if ( ( info.GetDamageType() == DMG_BLAST ) && ( info.GetDamage() > 135.0f ) && ( m_iHealth + info.GetDamage() / 2 <= 0 ) )
+			return;
+	}
 
 	// spawn a bunch of xenomites
 	int iNumParasites = 4 + RandomInt(0,2);

--- a/src/game/server/swarm/asw_harvester.cpp
+++ b/src/game/server/swarm/asw_harvester.cpp
@@ -42,7 +42,7 @@ ConVar asw_harvester_new( "asw_harvester_new", "1", FCVAR_CHEAT, "If set to 1, u
 ConVar asw_harvester_spawn_height( "asw_harvester_spawn_height", "16", FCVAR_CHEAT, "Height above harvester origin to spawn xenomites at" );
 ConVar asw_harvester_spawn_interval( "asw_harvester_spawn_interval", "1.0", FCVAR_CHEAT, "Time between spawning a harvesite and starting to spawn another" );
 ConVar rd_harvester_health( "rd_harvester_health", "200", FCVAR_CHEAT, "Health of the harvester" );
-ConVar rd_harvester_always_release_xenomites( "rd_harvester_always_release_xenomites", "0", FCVAR_NONE, "If set, harvesters will always release xenomites after death" );
+ConVar rd_harvester_always_release_xenomites( "rd_harvester_always_release_xenomites", "0", FCVAR_CHEAT, "If set, harvesters will always release xenomites after death" );
 
 extern ConVar rd_deagle_bigalien_dmg_scale;
 extern ConVar asw_debug_alien_damage;


### PR DESCRIPTION
after the previous commit realised that it would be very inconsistent a.k.a hard to predict because it could lead to situations where xenomytes wouldn't be released when the nade hit was not direct

optimal but not a clean way to check if it was a direct nade hit ( info.GetDamage() > 135.0f ) ensures that the explosion which killed the harvesters was a direct nade hit, moree consistent behaviour

+a convar to make xenomytes always be released if some challenges wanna use it to make it a bit harder