### PR TITLE
New RGB Blending for Chat Text

### DIFF
--- a/src/game/client/hud_basechat.h
+++ b/src/game/client/hud_basechat.h
@@ -11,6 +11,7 @@
 #pragma once
 #endif
 
+#include "ColorText_Shared.h"
 #include "hudelement.h"
 #include <vgui_controls/Panel.h>
 #include "vgui_basepanel.h"
@@ -45,7 +46,7 @@ extern Color g_ColorGreen;
 extern Color g_ColorDarkGreen;
 extern Color g_ColorYellow;
 extern Color g_ColorGrey;
-extern Color g_ColoPurple;
+extern Color g_ColorPurple;
 
 extern ConVar cl_showtextmsg;
 
@@ -59,20 +60,6 @@ enum ChatFilters
 	CHAT_FILTER_TEAMCHANGE = 16
 };
 
-
-//-----------------------------------------------------------------------------
-enum TextColor
-{
-	COLOR_NORMAL = 1,
-	COLOR_USEOLDCOLORS = 2,
-	COLOR_PLAYERNAME = 3,
-	COLOR_LOCATION = 4,
-	COLOR_ACHIEVEMENT = 5,
-	COLOR_MOD_CUSTOM = 6,
-	COLOR_MOD_CUSTOM2 = 7,
-	COLOR_INPUTCUSTOMCOL = 8,
-	COLOR_MAX
-};
 
 //--------------------------------------------------------------------------------------------------------------
 struct TextRange

--- a/src/game/client/swarm/vgui/asw_hud_chat.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_chat.cpp
@@ -437,7 +437,7 @@ Color CHudChat::GetTextColorForClient( TextColor colorNum, int clientIndex )
 		}
 		break;
 	case COLOR_MOD_CUSTOM:
-		c = g_ColoPurple;
+		c = g_ColorPurple;
 		break;
 	case COLOR_MOD_CUSTOM2:
 		c = g_ColorRed;

--- a/src/game/server/vscript_server.cpp
+++ b/src/game/server/vscript_server.cpp
@@ -24,6 +24,7 @@
 #include "inetchannelinfo.h"
 #include "decals.h"
 #include "player_voice_listener.h"
+#include "ColorText_Shared.h"
 #ifdef _WIN32
 #include "vscript_server_nut.h"
 #endif
@@ -46,6 +47,8 @@ extern ScriptClassDesc_t * GetScriptDesc( CBaseEntity * );
 
 static ConVar sv_mapspawn_nut_exec( "sv_mapspawn_nut_exec", "0", FCVAR_NONE, "If set to 1, server will execute scripts/vscripts/mapspawn.nut file" );
 extern char *s_ElementNames[MAX_ARRAY_ELEMENTS];
+
+//static char COLOR_INPUTCUSTOMCOL = '\x08';
 
 //-----------------------------------------------------------------------------
 // Iterate through keys in a table and assign KeyValues on entity for spawn
@@ -1238,11 +1241,449 @@ static ScriptVariant_t Script_TextColor(int R, int G, int B)
 	float outputMod_B = B / 255.0f;
 
 	char outputChars[5]{};
-	outputChars[0] = '\x08'; // COLOR_INPUTCUSTOMCOL
+	outputChars[0] = COLOR_INPUTCUSTOMCOL; // COLOR_INPUTCUSTOMCOL
 	// pass float modifiers multiplied by max ASCII translation base then increment by 32 which is float ASCII offset
 	outputChars[1] = (char)( 32 + ( outputMod_R * 94 ) );
 	outputChars[2] = (char)( 32 + ( outputMod_G * 94 ) );
 	outputChars[3] = (char)( 32 + ( outputMod_B * 94 ) );
+
+	return ScriptVariant_t(outputChars, true);
+}
+
+static ScriptVariant_t Script_TextColorBlend(int R1, int G1, int B1, int R2, int G2, int B2)
+{
+	//Force channel ranges between 0 - 255
+	if (R1 > 255)
+	{
+		R1 = 255;
+	}
+	else if (R1 < 0)
+	{
+		R1 = 0;
+	}
+
+	if (G1 > 255)
+	{
+		G1 = 255;
+	}
+	else if (G1 < 0)
+	{
+		G1 = 0;
+	}
+
+	if (B1 > 255)
+	{
+		B1 = 255;
+	}
+	else if (B1 < 0)
+	{
+		B1 = 0;
+	}
+
+	if (R2 > 255)
+	{
+		R2 = 255;
+	}
+	else if (R2 < 0)
+	{
+		R2 = 0;
+	}
+
+	if (G2 > 255)
+	{
+		G2 = 255;
+	}
+	else if (G2 < 0)
+	{
+		G2 = 0;
+	}
+
+	if (B2 > 255)
+	{
+		B2 = 255;
+	}
+	else if (B2 < 0)
+	{
+		B2 = 0;
+	}
+
+	//create float modifiers at range 0 - 255 for conversion output
+	float outputMod_R1 = R1 / 255.0f;
+	float outputMod_G1 = G1 / 255.0f;
+	float outputMod_B1 = B1 / 255.0f;
+
+	float outputMod_R2 = R2 / 255.0f;
+	float outputMod_G2 = G2 / 255.0f;
+	float outputMod_B2 = B2 / 255.0f;
+
+	char outputChars[10]{};
+	outputChars[0] = COLOR_INPUTCUSTOMCOL; // COLOR_INPUTCUSTOMCOL
+	outputChars[1] = COLOR_INPUTCUSTOMCOL; // COLOR_INPUTCUSTOMCOL
+	outputChars[2] = BLEND_NORMAL;
+	// pass float modifiers multiplied by max ASCII translation base then increment by 32 which is float ASCII offset
+	outputChars[3] = (char)(32 + (outputMod_R1 * 94));
+	outputChars[4] = (char)(32 + (outputMod_G1 * 94));
+	outputChars[5] = (char)(32 + (outputMod_B1 * 94));
+
+	outputChars[6] = (char)(32 + (outputMod_R2 * 94));
+	outputChars[7] = (char)(32 + (outputMod_G2 * 94));
+	outputChars[8] = (char)(32 + (outputMod_B2 * 94));
+
+	return ScriptVariant_t(outputChars, true);
+}
+
+static ScriptVariant_t Script_TextColorBlendCycle(int iBlendLength, int R1, int G1, int B1, int R2, int G2, int B2)
+{
+	//Force channel ranges between 0 - 255
+	if (R1 > 255)
+	{
+		R1 = 255;
+	}
+	else if (R1 < 0)
+	{
+		R1 = 0;
+	}
+
+	if (G1 > 255)
+	{
+		G1 = 255;
+	}
+	else if (G1 < 0)
+	{
+		G1 = 0;
+	}
+
+	if (B1 > 255)
+	{
+		B1 = 255;
+	}
+	else if (B1 < 0)
+	{
+		B1 = 0;
+	}
+
+	if (R2 > 255)
+	{
+		R2 = 255;
+	}
+	else if (R2 < 0)
+	{
+		R2 = 0;
+	}
+
+	if (G2 > 255)
+	{
+		G2 = 255;
+	}
+	else if (G2 < 0)
+	{
+		G2 = 0;
+	}
+
+	if (B2 > 255)
+	{
+		B2 = 255;
+	}
+	else if (B2 < 0)
+	{
+		B2 = 0;
+	}
+
+	if (iBlendLength > 96)
+	{
+		iBlendLength = 96;
+	}
+	else if (iBlendLength < 2)
+	{
+		iBlendLength = 2;
+	}
+
+	iBlendLength -= 2;
+
+	//iBlendLength -= 2; //align offset
+
+	//create float modifiers at range 0 - 255 for conversion output
+	float outputMod_R1 = R1 / 255.0f;
+	float outputMod_G1 = G1 / 255.0f;
+	float outputMod_B1 = B1 / 255.0f;
+
+	float outputMod_R2 = R2 / 255.0f;
+	float outputMod_G2 = G2 / 255.0f;
+	float outputMod_B2 = B2 / 255.0f;
+
+	char outputChars[11]{};
+	outputChars[0] = COLOR_INPUTCUSTOMCOL; // COLOR_INPUTCUSTOMCOL
+	outputChars[1] = COLOR_INPUTCUSTOMCOL; // COLOR_INPUTCUSTOMCOL
+	outputChars[2] = BLEND_CYCLE;
+	outputChars[3] = iBlendLength + 32;
+	// pass float modifiers multiplied by max ASCII translation base then increment by 32 which is float ASCII offset
+	outputChars[4] = (char)(32 + (outputMod_R1 * 94));
+	outputChars[5] = (char)(32 + (outputMod_G1 * 94));
+	outputChars[6] = (char)(32 + (outputMod_B1 * 94));
+
+	outputChars[7] = (char)(32 + (outputMod_R2 * 94));
+	outputChars[8] = (char)(32 + (outputMod_G2 * 94));
+	outputChars[9] = (char)(32 + (outputMod_B2 * 94));
+
+	return ScriptVariant_t(outputChars, true);
+}
+
+static ScriptVariant_t Script_TextColorBlendSmoothCycle(int iBlendLength, int R1, int G1, int B1, int R2, int G2, int B2)
+{
+	//Force channel ranges between 0 - 255
+	if (R1 > 255)
+	{
+		R1 = 255;
+	}
+	else if (R1 < 0)
+	{
+		R1 = 0;
+	}
+
+	if (G1 > 255)
+	{
+		G1 = 255;
+	}
+	else if (G1 < 0)
+	{
+		G1 = 0;
+	}
+
+	if (B1 > 255)
+	{
+		B1 = 255;
+	}
+	else if (B1 < 0)
+	{
+		B1 = 0;
+	}
+
+	if (R2 > 255)
+	{
+		R2 = 255;
+	}
+	else if (R2 < 0)
+	{
+		R2 = 0;
+	}
+
+	if (G2 > 255)
+	{
+		G2 = 255;
+	}
+	else if (G2 < 0)
+	{
+		G2 = 0;
+	}
+
+	if (B2 > 255)
+	{
+		B2 = 255;
+	}
+	else if (B2 < 0)
+	{
+		B2 = 0;
+	}
+
+	if (iBlendLength > 96)
+	{
+		iBlendLength = 96;
+	}
+	else if (iBlendLength < 2)
+	{
+		iBlendLength = 2;
+	}
+
+	iBlendLength -= 2;
+
+	//iBlendLength -= 2; //align offset
+
+	//create float modifiers at range 0 - 255 for conversion output
+	float outputMod_R1 = R1 / 255.0f;
+	float outputMod_G1 = G1 / 255.0f;
+	float outputMod_B1 = B1 / 255.0f;
+
+	float outputMod_R2 = R2 / 255.0f;
+	float outputMod_G2 = G2 / 255.0f;
+	float outputMod_B2 = B2 / 255.0f;
+
+	char outputChars[11]{};
+	outputChars[0] = COLOR_INPUTCUSTOMCOL; // COLOR_INPUTCUSTOMCOL
+	outputChars[1] = COLOR_INPUTCUSTOMCOL; // COLOR_INPUTCUSTOMCOL
+	outputChars[2] = BLEND_SMOOTHCYCLE;
+	outputChars[3] = iBlendLength + 32;
+	// pass float modifiers multiplied by max ASCII translation base then increment by 32 which is float ASCII offset
+	outputChars[4] = (char)(32 + (outputMod_R1 * 94));
+	outputChars[5] = (char)(32 + (outputMod_G1 * 94));
+	outputChars[6] = (char)(32 + (outputMod_B1 * 94));
+
+	outputChars[7] = (char)(32 + (outputMod_R2 * 94));
+	outputChars[8] = (char)(32 + (outputMod_G2 * 94));
+	outputChars[9] = (char)(32 + (outputMod_B2 * 94));
+
+	return ScriptVariant_t(outputChars, true);
+}
+
+static ScriptVariant_t Script_TextColorBlendInvert(int R1, int G1, int B1)
+{
+	//Force channel ranges between 0 - 255
+	if (R1 > 255)
+	{
+		R1 = 255;
+	}
+	else if (R1 < 0)
+	{
+		R1 = 0;
+	}
+
+	if (G1 > 255)
+	{
+		G1 = 255;
+	}
+	else if (G1 < 0)
+	{
+		G1 = 0;
+	}
+
+	if (B1 > 255)
+	{
+		B1 = 255;
+	}
+	else if (B1 < 0)
+	{
+		B1 = 0;
+	}
+
+	//create float modifiers at range 0 - 255 for conversion output
+	float outputMod_R1 = R1 / 255.0f;
+	float outputMod_G1 = G1 / 255.0f;
+	float outputMod_B1 = B1 / 255.0f;
+
+	char outputChars[7]{};
+	outputChars[0] = COLOR_INPUTCUSTOMCOL;
+	outputChars[1] = COLOR_INPUTCUSTOMCOL;
+	outputChars[2] = BLEND_INVERT;
+	// pass float modifiers multiplied by max ASCII translation base then increment by 32 which is float ASCII offset
+	outputChars[3] = (char)(32 + (outputMod_R1 * 94));
+	outputChars[4] = (char)(32 + (outputMod_G1 * 94));
+	outputChars[5] = (char)(32 + (outputMod_B1 * 94));
+
+	return ScriptVariant_t(outputChars, true);
+}
+
+static ScriptVariant_t Script_TextColorBlend3(int R1, int G1, int B1, int R2, int G2, int B2, int R3, int G3, int B3)
+{
+	//Force channel ranges between 0 - 255
+	if (R1 > 255)
+	{
+		R1 = 255;
+	}
+	else if (R1 < 0)
+	{
+		R1 = 0;
+	}
+
+	if (G1 > 255)
+	{
+		G1 = 255;
+	}
+	else if (G1 < 0)
+	{
+		G1 = 0;
+	}
+
+	if (B1 > 255)
+	{
+		B1 = 255;
+	}
+	else if (B1 < 0)
+	{
+		B1 = 0;
+	}
+
+	if (R2 > 255)
+	{
+		R2 = 255;
+	}
+	else if (R2 < 0)
+	{
+		R2 = 0;
+	}
+
+	if (G2 > 255)
+	{
+		G2 = 255;
+	}
+	else if (G2 < 0)
+	{
+		G2 = 0;
+	}
+
+	if (B2 > 255)
+	{
+		B2 = 255;
+	}
+	else if (B2 < 0)
+	{
+		B2 = 0;
+	}
+
+	if (R3 > 255)
+	{
+		R3 = 255;
+	}
+	else if (R3 < 0)
+	{
+		R3 = 0;
+	}
+
+	if (G3 > 255)
+	{
+		G3 = 255;
+	}
+	else if (G3 < 0)
+	{
+		G3 = 0;
+	}
+
+	if (B3 > 255)
+	{
+		B3 = 255;
+	}
+	else if (B3 < 0)
+	{
+		B3 = 0;
+	}
+
+	//create float modifiers at range 0 - 255 for conversion output
+	float outputMod_R1 = R1 / 255.0f;
+	float outputMod_G1 = G1 / 255.0f;
+	float outputMod_B1 = B1 / 255.0f;
+
+	float outputMod_R2 = R2 / 255.0f;
+	float outputMod_G2 = G2 / 255.0f;
+	float outputMod_B2 = B2 / 255.0f;
+
+	float outputMod_R3 = R3 / 255.0f;
+	float outputMod_G3 = G3 / 255.0f;
+	float outputMod_B3 = B3 / 255.0f;
+
+	char outputChars[13]{};
+	outputChars[0] = COLOR_INPUTCUSTOMCOL; // COLOR_INPUTCUSTOMCOL
+	outputChars[1] = COLOR_INPUTCUSTOMCOL; // COLOR_INPUTCUSTOMCOL
+	outputChars[2] = BLEND_3COLOR;
+	// pass float modifiers multiplied by max ASCII translation base then increment by 32 which is float ASCII offset
+	outputChars[3] = (char)(32 + (outputMod_R1 * 94));
+	outputChars[4] = (char)(32 + (outputMod_G1 * 94));
+	outputChars[5] = (char)(32 + (outputMod_B1 * 94));
+
+	outputChars[6] = (char)(32 + (outputMod_R2 * 94));
+	outputChars[7] = (char)(32 + (outputMod_G2 * 94));
+	outputChars[8] = (char)(32 + (outputMod_B2 * 94));
+
+	outputChars[9] = (char)(32 + (outputMod_R3 * 94));
+	outputChars[10] = (char)(32 + (outputMod_G3 * 94));
+	outputChars[11] = (char)(32 + (outputMod_B3 * 94));
 
 	return ScriptVariant_t(outputChars, true);
 }
@@ -1532,6 +1973,11 @@ bool VScriptServerInit()
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_Say, "Say", "Have player say string" );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_ClientPrint, "ClientPrint", "Print a client message" );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_TextColor, "TextColor", "Gets the translated ASCII characters for an RGB input." );
+				ScriptRegisterFunctionNamed( g_pScriptVM, Script_TextColorBlend, "TextColorBlend", "Gets the translated ASCII characters for an RGB blend input.");
+				ScriptRegisterFunctionNamed( g_pScriptVM, Script_TextColorBlendCycle, "TextColorBlendCycle", "Gets the translated ASCII characters for an RGB blend cycle input.");
+				ScriptRegisterFunctionNamed( g_pScriptVM, Script_TextColorBlendSmoothCycle, "TextColorBlendSmoothCycle", "Gets the translated ASCII characters for an RGB blend smooth cycle input.");
+				ScriptRegisterFunctionNamed( g_pScriptVM, Script_TextColorBlend3, "TextColorBlend3", "Gets the translated ASCII characters for a 3 color RGB blend input.");
+				ScriptRegisterFunctionNamed( g_pScriptVM, Script_TextColorBlendInvert, "TextColorBlendInvert", "Gets the translated ASCII characters for an RGB blend invert input.");
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_StringToFile, "StringToFile", "Stores the string into the file." );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_FileToString, "FileToString", "Reads a string from file. Returns the string from the file, null if no file or file is too big." );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_AddThinkToEnt, "AddThinkToEnt", "Adds a late bound think function to the C++ think tables for the obj" );

--- a/src/game/shared/ColorText_Shared.h
+++ b/src/game/shared/ColorText_Shared.h
@@ -1,0 +1,26 @@
+#pragma once
+//These can be values anywhere from 0x20 to 0x7E - BLEND_NONE is an exception as it isn't inserted anywhere.
+enum CHATCOLORBLENDMODE
+{
+	BLEND_NONE = 0,				//This can't be used as ASCII code
+	BLEND_NORMAL = 32,				//Normal 2 color blend mode
+	BLEND_INVERT = 33,		//Inverts color blend as it reaches tail end.
+	BLEND_3COLOR = 34,		//Blend with 3 colors
+	BLEND_CYCLE = 35,		//Blend with 2 colors that repeats at fixed length rather than by text length.
+	BLEND_SMOOTHCYCLE = 36 //Blend with 2 colors that repeats blending with smooth return.
+};
+
+//This is moved here so the consistent enum can be loaded into both client and server
+enum TextColor
+{
+	COLOR_NORMAL = 1,
+	COLOR_USEOLDCOLORS = 2,
+	COLOR_PLAYERNAME = 3,
+	COLOR_LOCATION = 4,
+	COLOR_ACHIEVEMENT = 5,
+	COLOR_MOD_CUSTOM = 6,
+	COLOR_MOD_CUSTOM2 = 7,
+	COLOR_INPUTCUSTOMCOL = 8,
+	COLOR_MAX
+};
+


### PR DESCRIPTION
Originally, I was just messing around with this code not planning on uploading it, but peeps seemed to like it so I Improved it and added more functionality.

This new addition adds blending for chat text. It works similar to the previous RGB system and uses two of the same 0x08 characters to send data to the client. This is followed by an encoded blend type to tell the client which blend mode we are using. These new blending functions would allow a new colorful blend of colors for modders and server owners to use.

The first is the basic blend that blends two sets of RGB colors. The blend starts at the point after the encoded sequence finishes and ends after (either A. The end of the text B. Another color char is detected.)

Example:
ClientPrint(null, 3, TextColorBlend(255, 155, 0, 255, 255, 0) + "This is a test to show blended text using new color blend function. As you can see the text blends from color1 to color2 as it gets closer to the tail end of the text.");

The next is an inversion blend that blends a single RGB input to it's inverted color. Works the same way as normal blend only it doesn't need to send extra 3 bytes for second RGB input.

Example:

ClientPrint(null, 3, TextColorBlendInvert(255, 255, 125) + "This is a test to show inverted blend text. It blends into the inverted color for the supplied RGB input.");

The next is a blend of 3 colors. Works the same only has an additional RGB color.

Example:

ClientPrint(null, 3, TextColorBlend3(255, 55, 55, 255, 255, 255, 55, 55, 255) + "This is a test to show the 3 color blend text. It blends into the 3 colors for the supplied RGB inputs.");

The next is a color blend cycle. The color blend cycle's first argument is the length of a transition followed by two RGB inputs. The blend cycle allows repeating a color pattern. The pattern will jump to color 1 after it reaches the end of it's provided length.

Example:
ClientPrint(null, 3, TextColorBlendCycle(5, 122, 122, 255, 155, 155, 155) + "This is a test to show the color cycle blend text. It cycles the blend through color 1 to color 2 using the inputted length to control how long the blend is.");

The last is a color blend smooth cycle. It works the same as normal blend cycle only it smoothly returns to color 1.

Example:
ClientPrint(null, 3, TextColorBlendSmoothCycle(25, 255, 155, 155, 155, 155, 255) + "This is a test to show the color smooth cycle blend text. It cycles a smooth blend through color 1 to color 2 and back to color 1 using the inputted length to control how long the blend is.");