### PR TITLE
OnSetTransmit VScripts Callback hook

### DIFF
--- a/src/game/server/baseentity.h
+++ b/src/game/server/baseentity.h
@@ -749,6 +749,8 @@ public:
 	string_t m_iGlobalname; // identifier for carrying entity across level transitions
 	string_t m_iParent;	// the name of the entities parent; linked into m_pParent during Activate()
 
+	bool m_bIgnoreVScriptTransmit = false;
+
 	// This comes from the "id" key/value that Hammer adds to entities.
 	// It is used by Foundry to match up live (engine) entities with Hammer entities.
 	int		m_iHammerID; // Hammer unique edit id number

--- a/src/game/server/swarm/asw_campaign_save.cpp
+++ b/src/game/server/swarm/asw_campaign_save.cpp
@@ -92,6 +92,8 @@ CASW_Campaign_Save::CASW_Campaign_Save()
 		m_iParasitesKilled[i] = 0;
 	}
 	m_iNumDeaths = 0;
+
+	m_bIgnoreVScriptTransmit = true;
 }
 
 CASW_Campaign_Save::~CASW_Campaign_Save()

--- a/src/game/server/swarm/asw_debrief_stats.cpp
+++ b/src/game/server/swarm/asw_debrief_stats.cpp
@@ -117,6 +117,8 @@ CASW_Debrief_Stats::CASW_Debrief_Stats()
 {
 	//Msg("[S] CASW_Debrief_Stats created\n");
 	m_bBeatSpeedrunTime = false;
+
+	m_bIgnoreVScriptTransmit = true;
 }
 
 CASW_Debrief_Stats::~CASW_Debrief_Stats()

--- a/src/game/server/swarm/asw_game_resource.cpp
+++ b/src/game/server/swarm/asw_game_resource.cpp
@@ -156,6 +156,8 @@ CASW_Game_Resource::CASW_Game_Resource()
 
 	// make skills default for single mission
 	UpdateMarineSkills( NULL );
+	
+	m_bIgnoreVScriptTransmit = true;
 }
 
 CASW_Game_Resource::~CASW_Game_Resource()

--- a/src/game/server/swarm/asw_marine_resource.cpp
+++ b/src/game/server/swarm/asw_marine_resource.cpp
@@ -213,6 +213,8 @@ CASW_Marine_Resource::CASW_Marine_Resource()
 
 	memset( m_iInitialWeaponsInSlots, -1, sizeof( m_iInitialWeaponsInSlots ) );
 	memset( const_cast<int*>( m_iWeaponsInSlots.Base() ), -1, sizeof( m_iInitialWeaponsInSlots ) );
+
+	m_bIgnoreVScriptTransmit = true;
 }
 
 

--- a/src/game/server/swarm/asw_scanner_info.cpp
+++ b/src/game/server/swarm/asw_scanner_info.cpp
@@ -33,6 +33,8 @@ CASW_Scanner_Info::CASW_Scanner_Info()
 		m_index.Set(i, 0);
 		m_BlipType.Set(i, 0);
 	}
+
+	m_bIgnoreVScriptTransmit = true;
 }
 
 CASW_Scanner_Info::~CASW_Scanner_Info()

--- a/src/game/shared/swarm/asw_gamerules.cpp
+++ b/src/game/shared/swarm/asw_gamerules.cpp
@@ -9556,6 +9556,7 @@ public:
 			g_pScriptVM->SetValue( hScope, "UserConsoleCommand", SCRIPT_VARIANT_NULL );
 			g_pScriptVM->SetValue( hScope, "OnMissionStart", SCRIPT_VARIANT_NULL );
 			g_pScriptVM->SetValue( hScope, "OnGameplayStart", SCRIPT_VARIANT_NULL );
+			g_pScriptVM->SetValue(hScope, "OnSetTransmit", SCRIPT_VARIANT_NULL);
 		}
 
 		BaseClass::RunVScripts();


### PR DESCRIPTION
I was requested to make this.

Adds vscript callback OnSetTransmit(client, entity)

This callback allows blocking entity transmits to specific clients.

Example:
function OnSetTransmit(client, entity)
{
	local classname = entity.GetClassname();

	if (classname == "asw_drone")
	{
		return 0;
	}
	return 1;
}