### PR TITLE
Revert "Merge pull request #309 from BenLubar/flamer-heavy"

### DIFF
--- a/reactivedrop/resource/swarmopedia.txt
+++ b/reactivedrop/resource/swarmopedia.txt
@@ -1415,10 +1415,6 @@
 				"Caption" "#rd_weapon_fact_burning_dps"
 			}
 			"Ammo" {}
-			"Generic" {
-				"Icon" "swarm/swarmopedia/fact/heavy"
-				"Caption" "#rd_weapon_fact_slow_movement_while_held"
-			}
 			"Secondary" {
 				"Generic" {
 					"RequireCVar" "rd_flamer_infinite_extinguisher"

--- a/src/game/shared/swarm/asw_weapon_flamer_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_flamer_shared.cpp
@@ -474,11 +474,6 @@ float CASW_Weapon_Flamer::GetWeaponDamage()
 	return flDamage;
 }
 
-float CASW_Weapon_Flamer::GetMovementScale()
-{
-	return ShouldMarineMoveSlow() ? 0.5f : 0.8f;
-}
-
 #ifdef CLIENT_DLL
 const char* CASW_Weapon_Flamer::GetPartialReloadSound(int iPart)
 {

--- a/src/game/shared/swarm/asw_weapon_flamer_shared.h
+++ b/src/game/shared/swarm/asw_weapon_flamer_shared.h
@@ -33,7 +33,6 @@ public:
 	float	GetFireRate( void );
 	virtual bool SupportsBayonet();
 	virtual float GetWeaponDamage();
-	virtual float GetMovementScale();
 	
 	Activity	GetPrimaryAttackActivity( void );
 	virtual void	SecondaryAttack();


### PR DESCRIPTION
Based on community feedback in https://steamcommunity.com/app/563560/discussions/2/3361397532258307150/, the flamer should not be made heavy for now, with one of the reasons, it is a useful asset in speed runs.

This reverts commit b7428a52012b8deda7302ba62e55b95fd1be71a0, reversing changes made to 52c7a5fdde58b19a0308ac1efa128c95f21e2eb0.

