### PR TITLE
do not filter dedicated servers by default

### DIFF
--- a/src/game/client/swarm/gameui/swarm/vfoundpublicgames.cpp
+++ b/src/game/client/swarm/gameui/swarm/vfoundpublicgames.cpp
@@ -37,7 +37,7 @@ static ConVar ui_public_lobby_filter_challenge( "ui_public_lobby_filter_challeng
 static ConVar ui_public_lobby_filter_deathmatch( "ui_public_lobby_filter_deathmatch", "none", FCVAR_ARCHIVE, "Filter type for deathmatch on the public lobby display" );
 ConVar ui_public_lobby_filter_campaign( "ui_public_lobby_filter_campaign", "official", FCVAR_ARCHIVE, "Filter type for campaigns on the public lobby display" );
 ConVar ui_public_lobby_filter_status( "ui_public_lobby_filter_status", "", FCVAR_ARCHIVE, "Filter type for game status on the public lobby display" );
-ConVar ui_public_lobby_filter_servers( "ui_public_lobby_filter_servers", "1", FCVAR_ARCHIVE, "Filter dedicated servers from the public lobby display" );
+ConVar ui_public_lobby_filter_servers( "ui_public_lobby_filter_servers", "0", FCVAR_ARCHIVE, "Filter dedicated servers from the public lobby display" );
 extern ConVar rd_lobby_ping_low;
 extern ConVar rd_lobby_ping_high;
 

--- a/src/game/client/swarm/gameui/swarm/vfoundpublicgames.cpp
+++ b/src/game/client/swarm/gameui/swarm/vfoundpublicgames.cpp
@@ -37,7 +37,7 @@ static ConVar ui_public_lobby_filter_challenge( "ui_public_lobby_filter_challeng
 static ConVar ui_public_lobby_filter_deathmatch( "ui_public_lobby_filter_deathmatch", "none", FCVAR_ARCHIVE, "Filter type for deathmatch on the public lobby display" );
 ConVar ui_public_lobby_filter_campaign( "ui_public_lobby_filter_campaign", "official", FCVAR_ARCHIVE, "Filter type for campaigns on the public lobby display" );
 ConVar ui_public_lobby_filter_status( "ui_public_lobby_filter_status", "", FCVAR_ARCHIVE, "Filter type for game status on the public lobby display" );
-ConVar ui_public_lobby_filter_servers( "ui_public_lobby_filter_servers", "0", FCVAR_ARCHIVE, "Filter dedicated servers from the public lobby display" );
+ConVar ui_public_lobby_filter_dedicated_servers( "ui_public_lobby_filter_dedicated_servers", "0", FCVAR_NONE, "Filter dedicated servers from the public lobby display" );
 extern ConVar rd_lobby_ping_low;
 extern ConVar rd_lobby_ping_high;
 
@@ -271,7 +271,7 @@ bool FoundPublicGames::ShouldShowPublicGame( KeyValues *pGameDetails )
 	}
 
 	char const* szServer = pGameDetails->GetString( "options/server", "listen" );
-	if ( !Q_stricmp( szServer, "dedicated" ) && ui_public_lobby_filter_servers.GetBool() )
+	if ( !Q_stricmp( szServer, "dedicated" ) && ui_public_lobby_filter_dedicated_servers.GetBool() )
 	{
 		return false;
 	}


### PR DESCRIPTION
This changes the default made in https://github.com/ReactiveDrop/reactivedrop_public_src/pull/146.

Reason: new players expect to find games when they search for lobbies. Right now, games on dedicated servers are not shown.

Regarding the concerns, raised in the comments. I just tested, if I can view the client IP's on hosted lobbies:

```
$> conntrack -L | grep udp | grep 85.145.xxx.xxx

// 85.145.xxx.xxx = client
// 85.214.xxx.xxx = server
// dump is done on the firewall in front of the server

conntrack v1.4.6 (conntrack-tools): 96 flow entries have been shown.
udp      17 299 src=85.145.xxx.xxx dst=85.214.xxx.xxx sport=56402 dport=33857 src=85.214.xxx.xxx dst=85.145.xxx.xxx sport=33857 dport=56402 [ASSURED] mark=0 use=1
```

The result, as expected, the client IP just shows in the connection table of the server and firewall.

The reason is, the game is P2P. Server and clients will always directly connect to each other. For lobbies, they use NAT traversal, to help connect, but eventually the pc's connect directly. Reactive Drop doesn't implement Steam Relay, so direct connect is the only way to connect.

This also means, there is no use to 'hide' dedicated servers, since the IPs are visible on both dedicated servers as lobbies, one just has to look into the connection table of the router, firewall or os.

With this information, `ui_public_lobby_filter_servers` should be renamed to `ui_public_lobby_filter_dedicated_servers`, default to `0` without `FCVAR_ARCHIVE` flag. This way the functionality is not thrown away.

More information about NAT Traversal can be found here:
https://tailscale.com/blog/how-nat-traversal-works/

> Note: visiting a website with a browser will expose way more information (https://www.amiunique.org/fp) than a game like AS:RD ever can. If concerned about privacy, it's better to use a VPN.







