### PR TITLE
lana1: various stuff

### DIFF
--- a/reactivedrop/fgd/swarm.fgd
+++ b/reactivedrop/fgd/swarm.fgd
@@ -2432,6 +2432,7 @@
 		1 : "Infinite even on Easy mode" : 0
 		2 : "Don't spawn Uber aliens here" : 0
 		4 : "Spawned aliens never sleep" : 0
+		8 : "Not affected by carnage scale" : 0
 	]
 
 	output OnDirectorSpawned(string) : "Fires when an alien is spawned by the director. The activator is the alien."

--- a/src/game/server/swarm/asw_base_spawner.h
+++ b/src/game/server/swarm/asw_base_spawner.h
@@ -104,5 +104,6 @@ protected:
 #define ASW_SF_ALWAYS_INFINITE 1
 #define ASW_SF_NO_UBER 2
 #define ASW_SF_NEVER_SLEEP 4
+#define ASW_SF_NO_CARNAGE 8
 
 #endif /* _INCLUDED_ASW_BASE_SPAWNER_H */

--- a/src/game/server/swarm/asw_spawner.cpp
+++ b/src/game/server/swarm/asw_spawner.cpp
@@ -388,7 +388,7 @@ void ASW_ApplyCarnage_f(float fScaler)
 	while ((pEntity = gEntList.FindEntityByClassname( pEntity, "asw_spawner" )) != NULL)
 	{
 		CASW_Spawner* pSpawner = dynamic_cast<CASW_Spawner*>(pEntity);			
-		if (pSpawner)
+		if ( pSpawner && !pSpawner->HasSpawnFlags( ASW_SF_NO_CARNAGE ) )
 		{
 			if ( pSpawner->ApplyCarnageMode( fScaler, fInvScaler ) )
 			{


### PR DESCRIPTION
- add a "Not affected by carnage scale" flag to asw_spawners

lana1:
- revert back to first objective marker being shown early
- fix a bugged kill trigger for drones which made scenery drones pile up underground (not even going to attack marines) instead of dying as intended
- made scenery drone spawns not scale up with carnage scale, for optimizations
- optimised some env_projected_texture entities (some now turn off earlier, some cast smaller projected textures, some got deleted)
- fix #292