### PR TITLE
[do-not-merge] fix for a possible minigun dormant related engine crash

### DIFF
--- a/src/game/shared/swarm/asw_weapon_minigun.cpp
+++ b/src/game/shared/swarm/asw_weapon_minigun.cpp
@@ -529,10 +529,7 @@ void CASW_Weapon_Minigun::UpdateSpinningBarrel()
 	{
 		if ( m_pBarrelSpinSound )
 		{
-			if (CSoundEnvelopeController::GetController().SoundIsStillPlaying(m_pBarrelSpinSound))
-			{
-				CSoundEnvelopeController::GetController().Shutdown(m_pBarrelSpinSound);
-			}
+			CSoundEnvelopeController::GetController().SoundDestroy(m_pBarrelSpinSound);
 			m_pBarrelSpinSound = NULL;
 		}
 	}
@@ -584,8 +581,10 @@ void CASW_Weapon_Minigun::SetDormant( bool bDormant )
 	{
 		if ( m_pBarrelSpinSound )
 		{
-			CSoundEnvelopeController::GetController().SoundDestroy(m_pBarrelSpinSound);
-			m_pBarrelSpinSound = NULL;
+			if (CSoundEnvelopeController::GetController().SoundIsStillPlaying(m_pBarrelSpinSound)) 
+			{
+				CSoundEnvelopeController::GetController().Shutdown(m_pBarrelSpinSound);
+			}
 		}
 	}
 	BaseClass::SetDormant( bDormant );

--- a/src/game/shared/swarm/asw_weapon_minigun.cpp
+++ b/src/game/shared/swarm/asw_weapon_minigun.cpp
@@ -529,7 +529,10 @@ void CASW_Weapon_Minigun::UpdateSpinningBarrel()
 	{
 		if ( m_pBarrelSpinSound )
 		{
-			CSoundEnvelopeController::GetController().SoundDestroy( m_pBarrelSpinSound );
+			if (CSoundEnvelopeController::GetController().SoundIsStillPlaying(m_pBarrelSpinSound))
+			{
+				CSoundEnvelopeController::GetController().Shutdown(m_pBarrelSpinSound);
+			}
 			m_pBarrelSpinSound = NULL;
 		}
 	}
@@ -574,6 +577,7 @@ void CASW_Weapon_Minigun::CreateGunSmoke()
 	m_hGunSmoke = pEnt;
 }
 
+
 void CASW_Weapon_Minigun::SetDormant( bool bDormant )
 {
 	if ( bDormant )
@@ -586,6 +590,7 @@ void CASW_Weapon_Minigun::SetDormant( bool bDormant )
 	}
 	BaseClass::SetDormant( bDormant );
 }
+
 
 void CASW_Weapon_Minigun::UpdateOnRemove()
 {


### PR DESCRIPTION
I went through some crash dumps, that point to code outside of reactive drop. I noticed, a lot of them have one thing in common, they seem to pass:

```
CASW_Weapon_Minigun::SetDormant
```

Right before the crash in engine code.

I did notice some code was added there long ago. Just in case, I changed a `SoundDestroy` there to `Shutdown` if the sound was still playing.