### PR TITLE
sys can be empty on older windows systems

### DIFF
--- a/src/game/shared/igamesystem.cpp
+++ b/src/game/shared/igamesystem.cpp
@@ -225,7 +225,7 @@ bool IGameSystem::InitAllSystems()
 		Q_snprintf( sz, sizeof( sz ), "%s->Init():Start", sys->Name() );
 		XBX_rTimeStampLog( Plat_FloatTime(), sz );
 #endif
-		bool valid = sys->Init();
+		bool valid = sys ? sys->Init() : false;
 
 #if defined( _X360 )
 		Q_snprintf( sz, sizeof( sz ), "%s->Init():Finish", sys->Name() );


### PR DESCRIPTION
sys::init() can appearently be not set on some Windows 8.0 systems. Just set `valid` to `false` to skip it, and continue to the next in the loop. Hopefully fixes crash #14775431