### PR TITLE
fix briefing camera not transmitting with a parent

### DIFF
--- a/src/game/server/swarm/rd_briefing_camera.cpp
+++ b/src/game/server/swarm/rd_briefing_camera.cpp
@@ -12,6 +12,11 @@ END_DATADESC();
 
 LINK_ENTITY_TO_CLASS( rd_briefing_camera, CRD_Briefing_Camera );
 
+CRD_Briefing_Camera::CRD_Briefing_Camera()
+{
+	AddEFlags( EFL_FORCE_CHECK_TRANSMIT );
+}
+
 int CRD_Briefing_Camera::ShouldTransmit( const CCheckTransmitInfo *pInfo )
 {
 	return FL_EDICT_PVSCHECK;

--- a/src/game/server/swarm/rd_briefing_camera.h
+++ b/src/game/server/swarm/rd_briefing_camera.h
@@ -2,8 +2,10 @@
 
 class CRD_Briefing_Camera : public CBaseEntity
 {
-	DECLARE_CLASS( CRD_Briefing_Camera, CBaseEntity );
 public:
+	CRD_Briefing_Camera();
+	
+	DECLARE_CLASS( CRD_Briefing_Camera, CBaseEntity );
 	DECLARE_DATADESC();
 
 	virtual int ShouldTransmit( const CCheckTransmitInfo *pInfo ) override;


### PR DESCRIPTION
this is what happens when only documentation is comments in the source code. end up testing things for hours with nothing working and one evening after a couple months suddently find a flag in other classes with a comment that says this is why its been not working