### PR TITLE
lana1: optimizations

### DIFF
--- a/utils/build_maps.py
+++ b/utils/build_maps.py
@@ -54,7 +54,7 @@ VMFs = [
 ##		MapInfo("rd-dc1_omega_city", "1500", "0"),
 ##		MapInfo("rd-dc2_breaking_an_entry", "750", "0"),
 ##		MapInfo("rd-dc3_search_and_rescue", "750", "0"),
-##		MapInfo("rd-lan1_bridge", "2500", "0"),
+##		MapInfo("rd-lan1_bridge", "2000", "0"),
 ##		MapInfo("rd-lan2_sewer", "1500", "0"),
 ##		MapInfo("rd-lan3_maintenance", "750", "0"),
 ##		MapInfo("rd-lan4_vent", "1500", "0"),


### PR DESCRIPTION
replaced a lot of asw_drone_jumper spawners with normal asw_drone, it looks like pathfinding calculations are heavy with asw_drone_jumper because the map's nodegraph for them is connected from the place they spawn (below the bridge in snowy area or near the door) all the way to the spawn, and with normal asw_drone the nodegraph is isolated into two pieces before the fall and after the fall, just like for marines.

Also the nodegraph itself was unnecesarily complex, removed half of the nodes. cut down nodegraph build time from 20 seconds to 10 seconds.

All in all the map should be a bit easier not just in terms of lack of lag but i think its worth it