### PR TITLE
Up default projected texture limit and add Flashlight settings under "Visual Effects".

### DIFF
--- a/reactivedrop/resource/rd_advanced_settings.txt
+++ b/reactivedrop/resource/rd_advanced_settings.txt
@@ -521,6 +521,17 @@
 		}
 		TOGGLE
 		{
+			title "#RD_AdvancedSettings_VisualEffects_FlashlightShadows"
+			cvar "rd_flashlightshadows"
+			hide_unless "rd_env_projectedtexture_enabled"
+		}
+		TOGGLE
+		{
+			title "#RD_AdvancedSettings_VisualEffects_FlashlightAmbientLighting"
+			cvar "rd_flashlight_dlight_enable"
+		}
+		TOGGLE
+		{
 			title "#RD_AdvancedSettings_VisualEffects_OtherEffects"
 			cvar "rd_info_particle_system_enabled"
 		}

--- a/reactivedrop/resource/rd_advanced_settings.txt
+++ b/reactivedrop/resource/rd_advanced_settings.txt
@@ -523,7 +523,6 @@
 		{
 			title "#RD_AdvancedSettings_VisualEffects_FlashlightShadows"
 			cvar "rd_flashlightshadows"
-			hide_unless "rd_env_projectedtexture_enabled"
 		}
 		TOGGLE
 		{

--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -1,4 +1,4 @@
-//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright Â© 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //
@@ -1409,7 +1409,7 @@ void CClientShadowMgr::CalculateRenderTargetsAndSizes( void )
 		m_nDepthTextureResolution = atoi( CommandLine()->ParmValue( "-sfm_shadowmapres", defaultRes ) );
 	}
 	extern ConVar rd_max_depth_texture_shadows;
-	m_nMaxDepthTextureShadows = bTools ? MAX_DEPTH_TEXTURE_SHADOWS_TOOLS : CommandLine()->ParmValue( "-rd_max_depth_texture_shadows", MAX_DEPTH_TEXTURE_SHADOWS );	// Just one shadow depth texture in games, more in tools
+	m_nMaxDepthTextureShadows = bTools ? MAX_DEPTH_TEXTURE_SHADOWS_TOOLS : CommandLine()->ParmValue( "-rd_max_depth_texture_shadows", MAX_DEPTH_TEXTURE_SHADOWS );	// Limit shadow depth texture amount in games, more in tools
 }
 //-----------------------------------------------------------------------------
 // Constructor
@@ -1556,7 +1556,7 @@ static void RDMaxDepthTextureShadowsChanged( IConVar *var, const char *pOldValue
 	s_ClientShadowMgr.InitDepthTextureShadows();
 }
 
-ConVar rd_max_depth_texture_shadows( "rd_max_depth_texture_shadows", "1", FCVAR_ARCHIVE | FCVAR_NOT_CONNECTED, "Specifies the maximum number of high quality shadows to render. Watch out for perfomance issues", RDMaxDepthTextureShadowsChanged );
+ConVar rd_max_depth_texture_shadows( "rd_max_depth_texture_shadows", "10", FCVAR_NOT_CONNECTED, "Change via "-rd_max_depth_texture_shadows" at Command line. Specifies the maximum number of high quality shadows to render. Watch out for perfomance issues", RDMaxDepthTextureShadowsChanged );
 
 void CClientShadowMgr::InitRenderTargets()
 {


### PR DESCRIPTION
- Up max projected texture limit from 1 to 10.
- Remove ARCHIVE flag from "rd_max_depth_texture_shadows" CVAR since it causes issues due to config.cfg being executed too late.
- Add Advanced setting toggles under "Visual Effects" for Flashlight projected texture shadows and Flashlight dlight creation.

My rationale for upping the projected texture limit to such a seemly large number is because when messing around with "rd_flashlightshadows" in a full 8 slot game with everyone having flashlights I noticed that even with 9 or 10 projected textures on screen at once the game ran beautifully at 4K with max in game settings and had no visual artifacts even while action was happening so I see the current limit of "1" as pretty artificial especially since a lot of other source engine games/mods have this limit changed with little to no issues. as for why I chose "10" specifically it's because it is the minimum needed for a worst case scenario of 8 marines all with flashlights plus the current map's on-screen projected texture plus an extra one as a backup and for evening out the total number.

my suggestion for what the new strings should say are as follows although these can be worded to however is seen fit:
- RD_AdvancedSettings_VisualEffects_FlashlightShadows = Flashlight Shadows
- RD_AdvancedSettings_VisualEffects_FlashlightAmbientLighting = Flashlight Ambient Lighting

The reasons I am submitting this as a draft pull request is because:
1. I am uncertain if this should be for the public or beta branch as I couldn't find any proper information as to what kinda changes should go to which branch (also probably doesn't help that I don't know how to use github that well) although I assume the weight of my changes should be fine to push out to the next public release.
2. This pull request can't be immediately merged in as a commit is needed on the translations repo for the new strings (hopefully someone is able to do this for me as I don't know how to set that up).
3. I wanted to have the "Flashlight Shadows" setting not display unless "Dynamic Lighting" is enabled since "Dynamic Lighting" is supposed to turn off projected textures however it seems to only affect map projected textures and not ones created by the flashlights, although this is a small detail so it might be fine if no easy proper solution is available/found.
4. I want a little bit of input as maybe there is something I didn't consider however I feel pretty good about these current changes for the most part.

maybe I am misusing or misunderstanding the draft pull request feature of github? but it shouldn't be too much of an problem as I should be able to just "mark as ready for review" and have it turn into a normal pull request hopefully.