### PR TITLE
Bugfix/sv memlimit exit

### DIFF
--- a/src/game/server/swarm/rd_memlimit.cpp
+++ b/src/game/server/swarm/rd_memlimit.cpp
@@ -13,12 +13,12 @@ inline unsigned int MemoryExceededShutdown( void* pParam )
 
 	// during a level change, the server doesn't always respond
 	// repeat this command
-	for ( int i = 0; i <= 10; i++ ) 
+	for ( int i = 0; i <= 32; i++ ) 
 	{
-		ConMsg("Requesting exit due memory limit exceeded.\n", delay);
-		engine->ServerCommand("quit\n");
+		ConMsg( "Requesting exit due memory limit exceeded.\n", delay );
+		engine->ServerCommand( "quit\n" );
 
-		ThreadSleep(delay);
+		ThreadSleep( delay );
 	}
 
 	return 0;

--- a/src/game/server/swarm/rd_memlimit.cpp
+++ b/src/game/server/swarm/rd_memlimit.cpp
@@ -9,13 +9,17 @@
 
 inline unsigned int MemoryExceededShutdown( void* pParam )
 {
-	const float delay = gpGlobals->interval_per_tick * 1000;
-	DevMsg( "Shutdown delayed: %f ms\n", delay );
-	ThreadSleep( delay );
+	const float delay = gpGlobals->interval_per_tick * 5000;
 
-	// send quit and execute command within the same frame
-	engine->ServerCommand( "quit\n" );
-	engine->ServerExecute();
+	// during a level change, the server doesn't always respond
+	// repeat this command
+	for ( int i = 0; i <= 10; i++ ) 
+	{
+		ConMsg("Requesting exit due memory limit exceeded.\n", delay);
+		engine->ServerCommand("quit\n");
+
+		ThreadSleep(delay);
+	}
 
 	return 0;
 }

--- a/src/game/server/swarm/rd_memlimit.cpp
+++ b/src/game/server/swarm/rd_memlimit.cpp
@@ -9,13 +9,13 @@
 
 inline unsigned int MemoryExceededShutdown( void* pParam )
 {
-	const float delay = gpGlobals->interval_per_tick * 5000;
+	const unsigned int delay = gpGlobals->interval_per_tick * 100000;
 
 	// during a level change, the server doesn't always respond
 	// repeat this command
 	for ( int i = 0; i <= 32; i++ ) 
 	{
-		ConMsg( "Requesting exit due memory limit exceeded.\n", delay );
+		ConMsg( "Requesting exit due memory limit exceeded.\n" );
 		engine->ServerCommand( "quit\n" );
 
 		ThreadSleep( delay );


### PR DESCRIPTION
Send `quit` multiple times, it (randomly) isn't received correctly the first time.

```Memory usage: 214 MiB (224481280 bytes); limit is 215 MiB
---- Host_NewGame ----
Host_NewGame on map dm_deima
Skill level changed 2
Skill level changed 2
Set Gravity 800.0 (0.250 tolerance)
Loading global spawn selection data
No map-specific spawn selection data for dm_deima
Cannot access ISteamInventory!
Level has follow hints 1
Created class baseline: 38 classes, 6655 bytes.
Connection to Steam servers successful.
exec: couldn't exec workshop.cfg
   VAC secure mode is activated.
Memory usage: 220 MiB (231481344 bytes); limit is 215 MiB
Memory limit exceeded. Requesting exit.
Requesting exit due memory limit exceeded. <<<
---- Host_NewGame ----
Host_NewGame on map dm_deima
Skill level changed 2
Skill level changed 2
Set Gravity 800.0 (0.250 tolerance)
Loading global spawn selection data
No map-specific spawn selection data for dm_deima
Cannot access ISteamInventory!
Level has follow hints 1
Created class baseline: 38 classes, 6655 bytes.
Requesting exit due memory limit exceeded. <<<
Memory usage: 226 MiB (237006848 bytes); limit is 215 MiB
Memory limit exceeded. Requesting exit.
Requesting exit due memory limit exceeded. <<<
Datacenter::EnableUpdate( 0 ), current state = 0
Datacenter::RequestStop, time 16.05, state 0
```