### PR TITLE
Infection Patch 12/9

### DIFF
--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
@@ -974,7 +974,7 @@ function JoinZombie(hMarine)
 		hMarine.SetHealth(newHealth);
 	}
 	hMarine.SetModel("models/swarm/marine/infected_marine.mdl");
-	hMarine.SetOrigin(hMarine.GetOrigin() + Vector(0, 0, 16));
+	hMarine.SetOrigin(hMarine.GetOrigin() + Vector(0, 0, 32));
 	return;
 }
 

--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
@@ -287,6 +287,7 @@ function Update()
 					}
 					else
 					{
+						hHud.SetInt(7, -1);
 						hHud.SetFloat(0, 0);
 						hHud.SetFloat(1, 0);
 					}

--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_hud.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_hud.nut
@@ -247,7 +247,10 @@ function Paint()
 						ScreenPosY( 0.6550 ),
 						200, 255, 255, 255
 					);
-					local dist = self.GetInt(7);
+				}
+				local dist = self.GetInt(7);
+				if (dist >= 0)
+				{
 					local distText = "⌕ " + dist;
 					for (local i = 0; i < 2; i++)
 					{

--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_hud.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_hud.nut
@@ -253,7 +253,7 @@ function Paint()
 					{
 						self.PaintText(
 							ScreenPosX( 0.5000 ) - self.GetTextWide(FONT_COUNTDOWNBLUR, distText)*0.5,
-							ScreenPosY( 0.9000 ),
+							ScreenPosY( 0.8250 ),
 							0, 255, 0, 255,
 							FONT_COUNTDOWNBLUR,
 							distText


### PR DESCRIPTION
- Attempt #2 to fix zombie noclipping through ground upon model replacement
- Fixed human distance tracker not working on Classic variant
- Adjusted the display location of Prime Zombies' human distance tracker