### PR TITLE
Temp banned dm_residential from Infection

### DIFF
--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_props.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_props.nut
@@ -93,6 +93,8 @@ function PropInit()
 	if (g_mapName == "dm_residential")
 	{
 		g_killAltitude = -1000;
+
+		Director.RestartMission();
 	}
 }
 


### PR DESCRIPTION
Until dm_residential is compatible with Infection, this map is locked from being playable in Infection.

(There are currently exploits involving guaranteed safety for humans)

Editing a map for this mode takes a very long time. dm_deima, for example, took a very long time to get right. I would need to consider patching all the game-breaking exploits and try to balance out all the areas that are not easily accessible so they do not give newer players major disadvantages.