### PR TITLE
Infection: Zombie grenade model replacement tweak

### DIFF
--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
@@ -480,7 +480,7 @@ function Update()
 	while((hGrenade = Entities.FindByClassname(hGrenade, "asw_grenade_cluster")) != null)
 	{
 		local hOwner = hGrenade.GetOwner();
-		if (hOwner && hOwner in g_teamZombie)
+		if (hOwner && hOwner in g_teamZombie && hGrenade.GetModelName() != "models/aliens/parasite/parasite.mdl")
 		{
 			hGrenade.SetModel("models/aliens/parasite/parasite.mdl");
 			EntFireByHandle(hGrenade, "SetBodyGroup", "1", 0, self, self);


### PR DESCRIPTION
Made it so the model replacement is only called once.
I do not know if this would fix the new issue where the zombie grenade just doesn't set off.