### PR TITLE
dont reset leader/kick votes on instant restart, add a instant restar…

### DIFF
--- a/src/game/client/swarm/c_asw_game_resource.cpp
+++ b/src/game/client/swarm/c_asw_game_resource.cpp
@@ -36,9 +36,6 @@ IMPLEMENT_CLIENTCLASS_DT( C_ASW_Game_Resource, DT_ASW_Game_Resource, CASW_Game_R
 
 	RecvPropArray( RecvPropString( RECVINFO( m_iszPlayerMedals[0] ) ), m_iszPlayerMedals ),
 
-	RecvPropArray3( RECVINFO_ARRAY( m_iKickVotes ), RecvPropInt( RECVINFO( m_iKickVotes[0] ) ) ),
-	RecvPropArray3( RECVINFO_ARRAY( m_iLeaderVotes ), RecvPropInt( RECVINFO( m_iLeaderVotes[0] ) ) ),
-
 	RecvPropInt( RECVINFO( m_iMoney ) ),
 	RecvPropInt( RECVINFO( m_iNextCampaignMission ) ),
 	RecvPropInt( RECVINFO( m_nDifficultySuggestion ) ),

--- a/src/game/client/swarm/c_asw_game_resource.h
+++ b/src/game/client/swarm/c_asw_game_resource.h
@@ -92,9 +92,6 @@ public:
 	CNetworkArray(int, m_iSkillSlot4, ASW_NUM_MARINE_PROFILES);
 	CNetworkArray(int, m_iSkillSlotSpare, ASW_NUM_MARINE_PROFILES);
 
-	int m_iKickVotes[ASW_MAX_READY_PLAYERS];
-	int m_iLeaderVotes[ASW_MAX_READY_PLAYERS];
-
 	// player medals
 	char	m_iszPlayerMedals[ ASW_MAX_READY_PLAYERS ][255];
 

--- a/src/game/client/swarm/vgui/playerlistline.cpp
+++ b/src/game/client/swarm/vgui/playerlistline.cpp
@@ -9,6 +9,7 @@
 #include "c_asw_marine.h"
 #include "c_asw_campaign_save.h"
 #include "c_asw_game_resource.h"
+#include "asw_gamerules.h"
 #include "PlayerListPanel.h"
 #include "PlayerListLine.h"
 #include "c_playerresource.h"
@@ -343,12 +344,12 @@ void PlayerListLine::UpdateVoteIcons()
 		iMaxKickVotes = 2;
 
 	int iKickVotes = 0;
-	if ( ASWGameResource() && m_iPlayerIndex < ASW_MAX_READY_PLAYERS )
-		iKickVotes = ASWGameResource()->m_iKickVotes[m_iPlayerIndex - 1];
+	if ( ASWGameRules() && m_iPlayerIndex < ASW_MAX_READY_PLAYERS )
+		iKickVotes = ASWGameRules()->m_iKickVotes[m_iPlayerIndex - 1];
 
 	int iLeaderVotes = 0;
-	if ( ASWGameResource() && m_iPlayerIndex < ASW_MAX_READY_PLAYERS )
-		iLeaderVotes = ASWGameResource()->m_iLeaderVotes[m_iPlayerIndex - 1];
+	if ( ASWGameRules() && m_iPlayerIndex < ASW_MAX_READY_PLAYERS )
+		iLeaderVotes = ASWGameRules()->m_iLeaderVotes[m_iPlayerIndex - 1];
 
 	// position the checkbox immediately to the right of our number of votes
 	float fScale = ScreenHeight() / 768.0f;

--- a/src/game/server/swarm/asw_game_resource.cpp
+++ b/src/game/server/swarm/asw_game_resource.cpp
@@ -50,9 +50,6 @@ IMPLEMENT_SERVERCLASS_ST( CASW_Game_Resource, DT_ASW_Game_Resource )
 	// player specific medals
 	SendPropArray( SendPropString( SENDINFO_ARRAY( m_iszPlayerMedals ), 0, SendProxy_String_tToString ), m_iszPlayerMedals ),
 
-	SendPropArray3( SENDINFO_ARRAY3( m_iKickVotes ), SendPropInt( SENDINFO_ARRAY( m_iKickVotes ), NumBitsForCount( ASW_MAX_READY_PLAYERS ), SPROP_UNSIGNED ) ),
-	SendPropArray3( SENDINFO_ARRAY3( m_iLeaderVotes ), SendPropInt( SENDINFO_ARRAY( m_iLeaderVotes ), NumBitsForCount( ASW_MAX_READY_PLAYERS ), SPROP_UNSIGNED ) ),
-
 	SendPropInt( SENDINFO( m_iMoney ) ),
 	SendPropInt( SENDINFO( m_iNextCampaignMission ) ),
 	SendPropInt( SENDINFO( m_nDifficultySuggestion ), 2, SPROP_UNSIGNED ),
@@ -116,8 +113,6 @@ CASW_Game_Resource::CASW_Game_Resource()
 	for ( int i = 0; i < ASW_MAX_READY_PLAYERS; i++ )
 	{
 		m_bPlayerReady.Set( i, false );
-		m_iKickVotes.Set( i, 0 );
-		m_iLeaderVotes.Set( i, 0 );
 		m_iCampaignVote[i] = -1;
 	}
 	for ( int i = 0; i < ASW_MAX_MARINE_RESOURCES; i++ )

--- a/src/game/server/swarm/asw_game_resource.h
+++ b/src/game/server/swarm/asw_game_resource.h
@@ -129,10 +129,6 @@ public:
 	// player medals
 	CNetworkArray( string_t, m_iszPlayerMedals, ASW_MAX_READY_PLAYERS );
 
-	// voting
-	CNetworkArray( int, m_iKickVotes, ASW_MAX_READY_PLAYERS );
-	CNetworkArray( int, m_iLeaderVotes, ASW_MAX_READY_PLAYERS );
-
 	// returns current number of alive (non-KOed players)
 	int CountAllAliveMarines( void );
 

--- a/src/game/server/swarm/asw_player.cpp
+++ b/src/game/server/swarm/asw_player.cpp
@@ -377,6 +377,9 @@ CASW_Player::CASW_Player()
 
 	SetViewOffset( ASW_PLAYER_VIEW_OFFSET );
 
+	m_iKickVoteIndex = -1;
+	m_iLeaderVoteIndex = -1;
+
 	m_hInhabiting = NULL;
 	m_hSpectating = NULL;
 	m_pCurrentInfoMessage = NULL;
@@ -698,8 +701,6 @@ void CASW_Player::Spawn()
 
 	SetMoveType( MOVETYPE_WALK );
 	m_takedamage = DAMAGE_NO;
-	m_iKickVoteIndex = -1;
-	m_iLeaderVoteIndex = -1;
 	BecomeNonSolid();
 
 	m_bFirstInhabit = false;

--- a/src/game/shared/swarm/asw_gamerules.h
+++ b/src/game/shared/swarm/asw_gamerules.h
@@ -221,6 +221,7 @@ public:
 	virtual void RemoveNoisyWeapons();
 	void ScheduleTechFailureRestart( float flRestartBeginTime, string_t szTechFailureSong );
 	void CheckTechFailure();
+	float m_fLastInstantRestartTime;
 	float m_fRemoveAliensTime;
 	bool m_bShouldStartMission;
 	float m_flTechFailureRestartTime;
@@ -298,6 +299,8 @@ public:
 	void ClearLeaderKickVotes(CASW_Player *pPlayer, bool bClearLeader=true, bool bClearKick=true);	// clears out any kick/leader votes aimed at this player	
 	void SetLeaderVote(CASW_Player *pPlayer, int iPlayerIndex);
 	void SetKickVote(CASW_Player *pPlayer, int iPlayerIndex);
+	CNetworkArray( int, m_iKickVotes, ASW_MAX_READY_PLAYERS );
+	CNetworkArray( int, m_iLeaderVotes, ASW_MAX_READY_PLAYERS );
 	// campaign/saved/mission voting
 	void StartVote(CASW_Player *pPlayer, int iVoteType, const char *szVoteName, int nCampaignIndex = -1);
 	void CastVote(CASW_Player *pPlayer, bool bVoteYes);
@@ -431,7 +434,12 @@ public:
 	CNetworkVar(int, m_iCurrentVoteNo);
 	CNetworkVar(int, m_iCurrentVoteType);
 	CNetworkVar(float, m_fVoteEndTime);
-	
+
+#ifdef CLIENT_DLL
+	int m_iKickVotes[ASW_MAX_READY_PLAYERS];
+	int m_iLeaderVotes[ASW_MAX_READY_PLAYERS];
+#endif
+
 	int GetCurrentVoteType() { return m_iCurrentVoteType; }
 	int GetCurrentVoteYes() { return m_iCurrentVoteYes; }
 	int GetCurrentVoteNo() { return m_iCurrentVoteNo; }


### PR DESCRIPTION
…t cooldown

meant to help against lobby leader abusing instant restart

move m_iLeaderVotes and m_iKickVotes from game resource to gamerules

limit cooldown cvar max to 10 in case of some sort of abusive addon trying to set it to a very high value. notify flag for same reason