### PR TITLE
Infection regular update for February

### DIFF
--- a/reactivedrop/content/infection/resource/challenges/asw_infection.txt
+++ b/reactivedrop/content/infection/resource/challenges/asw_infection.txt
@@ -44,8 +44,6 @@
 		"rd_autogun_dmg_base" "10"
 		"rd_pistol_dmg_base" "35"
 		"rd_pistols_min_delay" "0.1"
-		"asw_skill_grenades_dmg_base" "800"
-		"asw_skill_grenades_dmg_step" "125"
 		"rd_deagle_dmg_base" "104"
 	}
 }

--- a/reactivedrop/content/infection/resource/challenges/asw_infection_fp.txt
+++ b/reactivedrop/content/infection/resource/challenges/asw_infection_fp.txt
@@ -46,8 +46,6 @@
 		"rd_autogun_dmg_base" "10"
 		"rd_pistol_dmg_base" "35"
 		"rd_pistols_min_delay" "0.1"
-		"asw_skill_grenades_dmg_base" "800"
-		"asw_skill_grenades_dmg_step" "125"
 		"rd_deagle_dmg_base" "104"
 	}
 }

--- a/reactivedrop/content/infection/resource/challenges/asw_infection_tp.txt
+++ b/reactivedrop/content/infection/resource/challenges/asw_infection_tp.txt
@@ -46,8 +46,6 @@
 		"rd_autogun_dmg_base" "10"
 		"rd_pistol_dmg_base" "35"
 		"rd_pistols_min_delay" "0.1"
-		"asw_skill_grenades_dmg_base" "800"
-		"asw_skill_grenades_dmg_step" "125"
 		"rd_deagle_dmg_base" "104"
 	}
 }

--- a/reactivedrop/content/infection/resource/challenges/asw_infectionclassic.txt
+++ b/reactivedrop/content/infection/resource/challenges/asw_infectionclassic.txt
@@ -44,8 +44,6 @@
 		"rd_autogun_dmg_base" "10"
 		"rd_pistol_dmg_base" "35"
 		"rd_pistols_min_delay" "0.1"
-		"asw_skill_grenades_dmg_base" "800"
-		"asw_skill_grenades_dmg_step" "125"
 		"rd_deagle_dmg_base" "104"
 	}
 }

--- a/reactivedrop/content/infection/resource/challenges/asw_infectionclassic_fp.txt
+++ b/reactivedrop/content/infection/resource/challenges/asw_infectionclassic_fp.txt
@@ -46,8 +46,6 @@
 		"rd_autogun_dmg_base" "10"
 		"rd_pistol_dmg_base" "35"
 		"rd_pistols_min_delay" "0.1"
-		"asw_skill_grenades_dmg_base" "800"
-		"asw_skill_grenades_dmg_step" "125"
 		"rd_deagle_dmg_base" "104"
 	}
 }

--- a/reactivedrop/content/infection/resource/challenges/asw_infectionclassic_tp.txt
+++ b/reactivedrop/content/infection/resource/challenges/asw_infectionclassic_tp.txt
@@ -46,8 +46,6 @@
 		"rd_autogun_dmg_base" "10"
 		"rd_pistol_dmg_base" "35"
 		"rd_pistols_min_delay" "0.1"
-		"asw_skill_grenades_dmg_base" "800"
-		"asw_skill_grenades_dmg_step" "125"
 		"rd_deagle_dmg_base" "104"
 	}
 }

--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
@@ -382,6 +382,10 @@ function Update()
 			{
 				UseLastStand(hMarine);
 			}
+			if (g_matchTimer >= g_matchLength - 50)
+			{
+				Heal(hMarine, hMarine.GetMaxHealth() - hMarine.GetHealth());
+			}
 		}
 		else if (hMarine in g_teamZombie)
 		{
@@ -496,6 +500,11 @@ function Update()
 			parasiteProp.SetParent(hGrenade);
 			hGrenade.__KeyValueFromInt("rendermode", 10);
 		}
+	}
+	local hSentry = null;
+	while ((hSentry = Entities.FindByClassname(hSentry, "asw_sentry_base")) != null)
+	{
+		hSentry.Destroy();
 	}
 	foreach (name in g_alienClassnames)
 	{
@@ -644,6 +653,10 @@ function OnTakeDamage_Alive_Any( victim, inflictor, attacker, weapon, damage, da
 			}
 			local dir = victim.GetOrigin() - inflictor.GetOrigin();
 			local kb = dir * (damage/dir.Length()*20);
+			if (inflictor.GetClassname() == "asw_rocket")
+			{
+				kb = kb * 50;
+			}
 			if (IsOnGround(victim))
 			{
 				kb = kb + Vector(0, 0, 10);
@@ -653,6 +666,10 @@ function OnTakeDamage_Alive_Any( victim, inflictor, attacker, weapon, damage, da
 			{
 				damage = damage * 10;
 			}
+			if (inflictor.GetClassname() == "asw_rifle_grenade")
+			{
+				damage = damage * 5;
+			}
 			if (inflictor.GetClassname() == "asw_laser_mine")
 			{
 				damage = damage * 10;
@@ -661,9 +678,13 @@ function OnTakeDamage_Alive_Any( victim, inflictor, attacker, weapon, damage, da
 			{
 				damage = damage * 10;
 			}
-			if (weapon && weapon.GetClassname() == "asw_weapon_mines" && inflictor.GetClassname() == "asw_burning")
+			if (inflictor.GetClassname() == "asw_burning")
 			{
 				damage = damage * 10;
+			}
+			if (inflictor.GetClassname() == "asw_rocket")
+			{
+				damage = damage * 5;
 			}
 		}
 		if (weapon && weapon.GetClassname() == "asw_weapon_chainsaw")
@@ -1279,6 +1300,10 @@ function Heal(ent, amt)
 		return;
 	}
 	if (!(ent.IsValid()))
+	{
+		return;
+	}
+	if (ent.GetHealth() <= 0)
 	{
 		return;
 	}

--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
@@ -1307,6 +1307,7 @@ function Heal(ent, amt)
 	{
 		return;
 	}
+	ent.Extinguish();
 	if (amt <= 0)
 	{
 		return;

--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
@@ -1307,6 +1307,10 @@ function Heal(ent, amt)
 	{
 		return;
 	}
+	if (amt <= 0)
+	{
+		return;
+	}
 	local newHealth = ent.GetHealth() + amt;
 	if (newHealth > ent.GetMaxHealth())
 	{


### PR DESCRIPTION
- Rifle grenade damage bonus is now calculated after the knockback force is calculated.
- Decreased rifle grenade damage.
- Massively increased rockets' knockback force.
- Increased rocket damage.
- Damage taken during preparation phase is now immediately healed.
- Humans' burning damage against zombies now receives damage bonus regardless of whether the source of the burn is an incendiary mine.
- Constructed sentries are no longer allowed to exist.