### PR TITLE
Infection Regular Update 2

### DIFF
--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
@@ -632,6 +632,10 @@ function Update()
 					local hPlayer = picker[random].GetCommander();
 					g_previous[hPlayer] <- 0;
 				}
+				if (picker.len() > 1)
+				{
+					picker.remove(random);
+				}
 				PlayZombieSound(picker[random], "alert");
 			}
 		}


### PR DESCRIPTION
Fixed the bug that sometimes causes only one Prime Zombie to spawn at the start of the round when the requirements are met to spawn two.