### PR TITLE
fix crafting materials becoming invisible forever when culled by pvs

### DIFF
--- a/src/game/shared/swarm/rd_crafting_defs.cpp
+++ b/src/game/shared/swarm/rd_crafting_defs.cpp
@@ -361,6 +361,11 @@ void CRD_Crafting_Material_Pickup::Spawn()
 	}
 }
 
+int CRD_Crafting_Material_Pickup::ShouldTransmit( const CCheckTransmitInfo *pInfo )
+{
+	return FL_EDICT_ALWAYS;
+}
+
 void CRD_Crafting_Material_Pickup::ActivateUseIcon( CASW_Inhabitable_NPC *pUser, int nHoldType )
 {
 	if ( nHoldType == ASW_USE_HOLD_START )

--- a/src/game/shared/swarm/rd_crafting_defs.h
+++ b/src/game/shared/swarm/rd_crafting_defs.h
@@ -143,6 +143,7 @@ public:
 	void NPCStoppedUsing( CASW_Inhabitable_NPC *pUser ) override {}
 	void NPCUsing( CASW_Inhabitable_NPC *pUser, float fDeltaTime ) override {}
 	bool NeedsLOSCheck() override { return false; }
+	virtual int ShouldTransmit( const CCheckTransmitInfo *pInfo ) override;
 #endif
 };
 #endif


### PR DESCRIPTION
probably caused by not having a model on the server, FL_EDICT_PVS_CHECK doesnt work. source engine shenanigans?