### PR TITLE
Adding a two second delay before Flamer's Instant Ignition starts scaling down

### DIFF
--- a/src/game/server/swarm/asw_marine.cpp
+++ b/src/game/server/swarm/asw_marine.cpp
@@ -5076,7 +5076,8 @@ void CASW_Marine::ASW_Ignite( float flFlameLifetime, float flSize, CBaseEntity *
 
 		// Directly scaling the burn duration by the frequency of friendly fire
 		// The frequency is the difference in time between the newest ff incident and the previous one
-		float flFlameLifetimeScaled = flFlameLifetime - ( m_fLastFriendlyFireTime - m_fPrevFriendlyFireTime ) * asw_marine_burn_time_since_last_ff_scale.GetFloat();
+		// There is a two second delay before the duration starts scaling down
+		float flFlameLifetimeScaled = MIN ( flFlameLifetime, flFlameLifetime - ( m_fLastFriendlyFireTime - m_fPrevFriendlyFireTime - 2.0f ) * asw_marine_burn_time_since_last_ff_scale.GetFloat() );
 
 		flFlameLifetime = MAX ( flMinTime, flFlameLifetimeScaled );
 	}


### PR DESCRIPTION
Do verify if my math is mathing...

What's supposed to happen is that after the previous FF incident, the next Flamer FF incident within 2 seconds would be full duration. Only if the time difference between FF incidents gets longer than two seconds does it start scaling down.