### PR TITLE
[FIX] Undefined behaviour on comparison of NaN and float at particlemgr.cpp

### DIFF
--- a/src/game/client/particlemgr.cpp
+++ b/src/game/client/particlemgr.cpp
@@ -153,6 +153,8 @@ CParticleEffectBinding::CParticleEffectBinding()
 
 	m_LastMin = m_Min;
 	m_LastMax = m_Max;
+	
+	m_flParticleCullRadius = 0.0f;
 
 	SetParticleCullRadius( 0.0f );
 	m_nActiveParticles = 0;


### PR DESCRIPTION
At particlemgr.cpp in class `CParticleEffectBinding` there is a variable named `float m_flParticleCullRadius` that (as i think valve expected to happen) are 0.0f -ed in constructor by calling `SetParticleCullRadius(0.0f)`, but looks like they didnt know that `if ( m_flParticleCullRadius != flMaxParticleRadius )` that happens in `SetParticleCullRadius` working with float NaN, which is Undefined Behaviour, and results of this thing are declared by individual compilers realization. Even differend msvc versions can handle this differendly.

As the result of the problem some particles like explosions, sparks, smoke and dust may not appear at all. There even where no drawcall at this conditions.

Hopefully it can be fixed easely, by manually 0.0f -ing `m_flParticleCullRadius` in constructor.

Also, it can be forced to happen every time. Just instead of `m_flParticleCullRadius = 0.0f;` put `m_flParticleCullRadius = nanf("");` in constructor.

If you want to actually see how this looks like, ive [recorded it in hl2 here.](http://srv.raphmap.ru/video/undef_beh_particlemgr.mp4) Exactly same happends in alien swarm. 

Ive made same push request in mapbase and [it was approved.](https://github.com/mapbase-source/source-sdk-2013/pull/342)