### PR TITLE
fix flamer and shotgun ignoring asw_auto_reload 0 on secondary attack

### DIFF
--- a/src/game/shared/swarm/asw_weapon_flamer_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_flamer_shared.cpp
@@ -190,19 +190,22 @@ void CASW_Weapon_Flamer::ItemPostFrame( void )
 	BaseClass::ItemPostFrame();
 
 	bool bAttack1, bAttack2, bReload, bOldReload, bOldAttack1;
+	static bool bOldAttack2 = false;
+
 	GetButtons(bAttack1, bAttack2, bReload, bOldReload, bOldAttack1 );
 
-	if ( !bAttack2 )
+	// we need to check for old attacks otherwise flamer will fire last pellet without sound and particles
+
+	if ( m_iClip1 == 0 && ( bOldAttack1 || bOldAttack2 ) )
 	{
+		ClearIsFiring();
+		return;
+	}
+
+	if ( !bAttack2 || ( m_iClip1 <= 1 && bOldAttack2 ) )
 		m_bIsSecondaryFiring = false;
-	}
-	else
-	{
-		if ( m_iClip1 == 0 )
-		{
-			m_bIsSecondaryFiring = false;
-		}
-	}
+
+	bOldAttack2 = bAttack2;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/swarm/asw_weapon_flamer_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_flamer_shared.cpp
@@ -333,7 +333,7 @@ void CASW_Weapon_Flamer::SecondaryAttack( void )
 	// If my clip is empty (and I use clips) start reload
 	if ( !rd_flamer_infinite_extinguisher.GetBool() && UsesClipsForAmmo1() && m_iClip1 < 2 ) 
 	{
-		Reload();
+		m_iClip1 = 0;
 		return;
 	}
 

--- a/src/game/shared/swarm/asw_weapon_flamer_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_flamer_shared.cpp
@@ -333,7 +333,18 @@ void CASW_Weapon_Flamer::SecondaryAttack( void )
 	// If my clip is empty (and I use clips) start reload
 	if ( !rd_flamer_infinite_extinguisher.GetBool() && UsesClipsForAmmo1() && m_iClip1 < 2 ) 
 	{
-		m_iClip1 = 0;
+#ifdef CLIENT_DLL
+		CASW_Player *pPlayer = GetCommander();
+#else
+		CASW_Marine *pMarine = GetMarine();
+		CASW_Player *pPlayer = GetCommander();
+		if ( !pMarine || !pMarine->IsInhabited() )
+			pPlayer = NULL;
+#endif	// CLIENT_DLL
+
+		if ( pPlayer && pPlayer->ShouldAutoReload() )
+			Reload();
+
 		return;
 	}
 

--- a/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
@@ -151,7 +151,7 @@ void CASW_Weapon_Shotgun::PrimaryAttack( void )
 	// If my clip is empty (and I use clips) start reload
 	if ( UsesClipsForAmmo1() && !m_iClip1 )
 	{
-		Reload();
+		//Reload();
 		return;
 	}
 


### PR DESCRIPTION
also most weapons have this useless if statement which checks whether you have fired a weapon with 0 ammo (impossible) but i wont be the one to remove those in case theres some hilariously absurd scenario where that can happen somehow