### PR TITLE
restrict cursor to 16:9 area to prevent ultra-wide fov cheat

### DIFF
--- a/src/game/client/swarm/asw_in_mouse.cpp
+++ b/src/game/client/swarm/asw_in_mouse.cpp
@@ -15,6 +15,9 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
+bool g_ultra_wide_screen = false;
+Rect_t g_clamp_area = {};
+
 ConVar glow_outline_color_active( "glow_outline_color_active", "153 153 204", FCVAR_NONE );
 ConVar glow_outline_color_inactive( "glow_outline_color_inactive", "77 77 77", FCVAR_NONE );
 
@@ -86,7 +89,9 @@ void CASWInput::ApplyMouse( int nSlot, QAngle& viewangles, CUserCmd *cmd, float 
 	GetMousePos(current_posx, current_posy);
 
 	// restrict cursor to 16:9 area to prevent ultra-wide fov cheat
+	g_ultra_wide_screen = false;
 	C_BasePlayer* player = C_BasePlayer::GetLocalPlayer();
+
 	if (player && !player->IsObserver()) {
 		int screen_w = ScreenWidth();
 		int screen_h = ScreenHeight();
@@ -95,19 +100,21 @@ void CASWInput::ApplyMouse( int nSlot, QAngle& viewangles, CUserCmd *cmd, float 
 		constexpr float ratio169 = 16.0f / 9.0f;
 
 		if (aspect > ratio169) {
+			g_ultra_wide_screen = true;
+
 			int target_h = screen_h;
 			int target_w = static_cast<int>(screen_h * ratio169);
 
 			int left = (screen_w - target_w) / 2;
 			int top = 0;
 
-			int clamp_rect_left = left;
-			int clamp_rect_top = top;
-			int clamp_rect_right = left + target_w;
-			int clamp_rect_bottom = top + target_h;
+			g_clamp_area.x = left;
+			g_clamp_area.y = top;
+			g_clamp_area.width = left + target_w;
+			g_clamp_area.height = top + target_h;
 
-			current_posx = clamp(current_posx, clamp_rect_left, clamp_rect_right);
-			current_posy = clamp(current_posy, clamp_rect_top, clamp_rect_bottom);
+			current_posx = clamp(current_posx, g_clamp_area.x, g_clamp_area.width);
+			current_posy = clamp(current_posy, g_clamp_area.y, g_clamp_area.height);
 		}
 	}
 

--- a/src/game/client/swarm/asw_in_mouse.cpp
+++ b/src/game/client/swarm/asw_in_mouse.cpp
@@ -90,9 +90,9 @@ void CASWInput::ApplyMouse( int nSlot, QAngle& viewangles, CUserCmd *cmd, float 
 
 	// restrict cursor to 16:9 area to prevent ultra-wide fov cheat
 	g_ultra_wide_screen = false;
-	C_BasePlayer* player = C_BasePlayer::GetLocalPlayer();
+	C_ASW_Player* asw_player = C_ASW_Player::GetLocalASWPlayer();
 
-	if (player && !player->IsObserver()) {
+	if (asw_player && !asw_player->GetSpectatingNPC()) {
 		int screen_w = ScreenWidth();
 		int screen_h = ScreenHeight();
 		float aspect = static_cast<float>(screen_w) / screen_h;

--- a/src/game/client/swarm/asw_in_mouse.cpp
+++ b/src/game/client/swarm/asw_in_mouse.cpp
@@ -85,6 +85,32 @@ void CASWInput::ApplyMouse( int nSlot, QAngle& viewangles, CUserCmd *cmd, float 
 	int current_posx, current_posy;
 	GetMousePos(current_posx, current_posy);
 
+	// restrict cursor to 16:9 area to prevent ultra-wide fov cheat
+	C_BasePlayer* player = C_BasePlayer::GetLocalPlayer();
+	if (player && !player->IsObserver()) {
+		int screen_w = ScreenWidth();
+		int screen_h = ScreenHeight();
+		float aspect = static_cast<float>(screen_w) / screen_h;
+
+		constexpr float ratio169 = 16.0f / 9.0f;
+
+		if (aspect > ratio169) {
+			int target_h = screen_h;
+			int target_w = static_cast<int>(screen_h * ratio169);
+
+			int left = (screen_w - target_w) / 2;
+			int top = 0;
+
+			int clamp_rect_left = left;
+			int clamp_rect_top = top;
+			int clamp_rect_right = left + target_w;
+			int clamp_rect_bottom = top + target_h;
+
+			current_posx = clamp(current_posx, clamp_rect_left, clamp_rect_right);
+			current_posy = clamp(current_posy, clamp_rect_top, clamp_rect_bottom);
+		}
+	}
+
 	if ( ASWInput()->ControllerModeActiveMouse() )
 		return;
 

--- a/src/game/client/swarm/vgui/asw_hud_master.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_master.cpp
@@ -489,8 +489,8 @@ void CASW_Hud_Master::Paint( void )
 		// draw restricted borders for ultra-wide screen
 		if (rd_draw_restricted_borders.GetBool() && g_ultra_wide_screen && !pPlayer->IsObserver()) {
 			//	(x,y)-----------(w,y)
-			//	  |				  |
-			//	  |				  |
+			//	  |               |
+			//	  |               |
 			//	(x,h)-----------(w,h)
 			surface()->DrawSetColor(rd_draw_restricted_borders_color.GetColor());
 			surface()->DrawLine(g_clamp_area.x, g_clamp_area.y, g_clamp_area.x, g_clamp_area.height);

--- a/src/game/client/swarm/vgui/asw_hud_master.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_master.cpp
@@ -44,7 +44,9 @@ ConVar rd_draw_portraits( "rd_draw_portraits", "1", FCVAR_NONE );
 ConVar rd_draw_timer( "rd_draw_timer", "0", FCVAR_ARCHIVE, "Display the current mission time at the top of the screen" );
 ConVar rd_draw_timer_color( "rd_draw_timer_color", "255 255 255 255", FCVAR_ARCHIVE, "The color of the current mission time" );
 ConVar rd_draw_marine_health_counter( "rd_draw_marine_health_counter", "0", FCVAR_ARCHIVE, "Display a numeric counter for marine health on the HUD" );
+
 ConVar rd_draw_restricted_borders( "rd_draw_restricted_borders", "1", FCVAR_ARCHIVE, "Display the restricted cursor area when using ultra-wide resolution" );
+ConVar rd_draw_restricted_borders_color("rd_draw_restricted_borders_color", "128 128 128 128", 0, "Color of the restricted cursor area borders");
 
 using namespace vgui;
 
@@ -253,11 +255,6 @@ void CASW_Hud_Master::OnThink()
 	else
 	{
 		m_pLblTimer->SetVisible( false );
-	}
-
-	if (rd_draw_restricted_borders.GetBool() && g_ultra_wide_screen) {
-		surface()->DrawSetColor(Color(255, 255, 255, 192));
-		surface()->DrawLine(g_clamp_area.x, g_clamp_area.y, g_clamp_area.width, g_clamp_area.height);
 	}
 
 	// gather squad mate data
@@ -489,6 +486,17 @@ void CASW_Hud_Master::Paint( void )
 
 	if ( m_pLocalMarineResource )
 	{
+		// draw restricted borders for ultra-wide screen
+		if (rd_draw_restricted_borders.GetBool() && g_ultra_wide_screen && !pPlayer->IsObserver()) {
+			//	(x,y)-----------(w,y)
+			//	  |				  |
+			//	  |				  |
+			//	(x,h)-----------(w,h)
+			surface()->DrawSetColor(rd_draw_restricted_borders_color.GetColor());
+			surface()->DrawLine(g_clamp_area.x, g_clamp_area.y, g_clamp_area.x, g_clamp_area.height);
+			surface()->DrawLine(g_clamp_area.width, g_clamp_area.y, g_clamp_area.width, g_clamp_area.height);
+		}
+
 		C_ASW_Marine_Resource *pMR = m_pLocalMarineResource;
 
 		float flTimeToFade = 2.0f;

--- a/src/game/client/swarm/vgui/asw_hud_master.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_master.cpp
@@ -487,7 +487,7 @@ void CASW_Hud_Master::Paint( void )
 	if ( m_pLocalMarineResource )
 	{
 		// draw restricted borders for ultra-wide screen
-		if (rd_draw_restricted_borders.GetBool() && g_ultra_wide_screen && !pPlayer->IsObserver()) {
+		if (rd_draw_restricted_borders.GetBool() && g_ultra_wide_screen && !pPlayer->GetSpectatingNPC()) {
 			//	(x,y)-----------(w,y)
 			//	  |               |
 			//	  |               |

--- a/src/game/client/swarm/vgui/asw_hud_master.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_master.cpp
@@ -36,11 +36,15 @@ extern ConVar asw_hud_alpha;
 extern ConVar rd_respawn_time;
 extern ConVar rd_hud_hide_clips;
 
+extern bool g_ultra_wide_screen;
+extern Rect_t g_clamp_area;
+
 ConVar rd_draw_avatars_with_frags( "rd_draw_avatars_with_frags", "1",  FCVAR_ARCHIVE, "If 1 In PvP modes a panel with avatars and frags will be shown at top of the screen");
 ConVar rd_draw_portraits( "rd_draw_portraits", "1", FCVAR_NONE );
 ConVar rd_draw_timer( "rd_draw_timer", "0", FCVAR_ARCHIVE, "Display the current mission time at the top of the screen" );
 ConVar rd_draw_timer_color( "rd_draw_timer_color", "255 255 255 255", FCVAR_ARCHIVE, "The color of the current mission time" );
 ConVar rd_draw_marine_health_counter( "rd_draw_marine_health_counter", "0", FCVAR_ARCHIVE, "Display a numeric counter for marine health on the HUD" );
+ConVar rd_draw_restricted_borders( "rd_draw_restricted_borders", "1", FCVAR_ARCHIVE, "Display the restricted cursor area when using ultra-wide resolution" );
 
 using namespace vgui;
 
@@ -249,6 +253,11 @@ void CASW_Hud_Master::OnThink()
 	else
 	{
 		m_pLblTimer->SetVisible( false );
+	}
+
+	if (rd_draw_restricted_borders.GetBool() && g_ultra_wide_screen) {
+		surface()->DrawSetColor(Color(255, 255, 255, 192));
+		surface()->DrawLine(g_clamp_area.x, g_clamp_area.y, g_clamp_area.width, g_clamp_area.height);
 	}
 
 	// gather squad mate data


### PR DESCRIPTION
also added two new convars:
rd_draw_restricted_borders (def="1") -> Display the restricted cursor area when using ultra-wide resolution
rd_draw_restricted_borders_color (def="128 128 128 128") -> Color of the restricted cursor area borders
![image](https://github.com/user-attachments/assets/a2dec3da-fd8c-4a1b-8b11-6a6a9a1290d7)