### PR TITLE
fixes a 2-5 second freeze interval on the main menu

### DIFF
--- a/src/game/shared/swarm/rd_lobby_utils.cpp
+++ b/src/game/shared/swarm/rd_lobby_utils.cpp
@@ -444,6 +444,7 @@ void CReactiveDropLobbySearch::UpdateSearch()
 		if ( rd_lobby_search_debug.GetBool() )
 			DevMsg( 3, "%s: filter: \"%s\" %s %d\n", m_pszDebugName, m_NumericalFilters[i].m_Name.Get(), LobbyComparisonName( m_NumericalFilters[i].m_Compare ), m_NumericalFilters[i].m_Value );
 	}
+
 	pMatchmaking->AddRequestLobbyListDistanceFilter( m_DistanceFilter );
 	if ( rd_lobby_search_debug.GetBool() )
 		DevMsg( 3, "%s: distance filter: %s\n", m_pszDebugName, LobbyDistanceFilterName( m_DistanceFilter ) );
@@ -475,7 +476,24 @@ void CReactiveDropLobbySearch::LobbyMatchListResult( LobbyMatchList_t *pResult, 
 	m_MatchingLobbies.SetCount( pResult->m_nLobbiesMatching );
 	for ( uint32 i = 0; i < pResult->m_nLobbiesMatching; i++ )
 	{
-		m_MatchingLobbies[i] = pMatchmaking->GetLobbyByIndex( i );
+		CSteamID lobby = pMatchmaking->GetLobbyByIndex(i);
+
+		int count = SteamMatchmaking()->GetLobbyDataCount(lobby);
+		for (int j = 0; j < count; j++)
+		{
+			char key[k_nMaxLobbyKeyLength];
+			char dummy[1]; // only big enough to hold the null terminator
+			SteamMatchmaking()->GetLobbyDataByIndex(lobby, j, key, sizeof(key), dummy, sizeof(dummy));
+			const char* value = SteamMatchmaking()->GetLobbyData(lobby, key);
+
+			if (strcmp(key, "Binary Blob") != 0) {
+				if (key == "game:dir" && value == "reactivedrop") {
+
+					// only add if this is a Reactive Drop lobby
+					m_MatchingLobbies[i] = lobby;
+				}
+			}
+		}
 	}
 
 	if ( rd_lobby_search_debug.GetBool() )


### PR DESCRIPTION
this patch fixes a possible 2-5 seconds freeze on the main menu.

the freeze comes from scanning *a lot* of lobbies, not only as:rd lobbies, but *all* internet lobbies. This comes forth from SteamMatchmaking, which does not apply an AppID filter by default.

This patch ensures only lobbies with gametype "reactivedrop" are added to the list. This limits the amount of udp calls further down the sequence, since only as:rd lobbies are scanned for details, instead of all lobbies.

not exactly sure why the lobbies are all scanned with udp, but at least this patch ensures only as:rd lobbies are scanned.