### PR TITLE
Increase marine run speed with Devastator equipped from 70% to 90%

### DIFF
--- a/src/game/shared/swarm/asw_weapon_devastator_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_devastator_shared.cpp
@@ -92,7 +92,7 @@ int CASW_Weapon_Devastator::GetWeaponSubSkillId()
 
 float CASW_Weapon_Devastator::GetMovementScale()
 {
-	return ShouldMarineMoveSlow() ? 0.3f : 0.7f;
+	return ShouldMarineMoveSlow() ? 0.3f : 0.9f;
 }
 
 #ifndef CLIENT_DLL


### PR DESCRIPTION
70% seems to be too slow causing players to often switch to secondary gun to run faster and only switch to devastator when shooting. For reference, Autogun has 80%, minigun has 95%.

Note the marine speed when shooting with Devastator remains 30% as it was.