### PR TITLE
remove the cheat flag from marine backpacks

### DIFF
--- a/src/game/client/swarm/c_asw_marine.cpp
+++ b/src/game/client/swarm/c_asw_marine.cpp
@@ -80,7 +80,7 @@ ConVar rd_marine_explodes_into_gibs("rd_marine_explodes_into_gibs", "1", FCVAR_A
 ConVar rd_marine_gib_lifetime( "rd_marine_gib_lifetime", "36000.0", FCVAR_NONE, "number of seconds before marine gibs fade" );
 ConVar rd_marine_gib_lifetime_dm( "rd_marine_gib_lifetime_dm", "15.0", FCVAR_NONE, "number of seconds before marine gibs fade in deathmatch mode" );
 ConVar rd_marine_gib_spin( "rd_marine_gib_spin", "500", FCVAR_NONE, "how much do marine gibs spin?" );
-ConVar rd_client_marine_backpacks( "rd_client_marine_backpacks", "0", FCVAR_NONE, "Show marine's un-equipped weapon on their back." );
+ConVar rd_client_marine_backpacks( "rd_client_marine_backpacks", "-1", FCVAR_NONE, "Show marine's un-equipped weapon on their back (0 = disabled, 1 = enabled, 2 = let the server pick)" );
 ConVar rd_server_marine_backpacks( "rd_server_marine_backpacks", "0", FCVAR_REPLICATED, "Attach unactive weapon model to marine's back" );
 ConVar rd_projected_texture_min_z( "rd_projected_texture_min_z", "-64", FCVAR_REPLICATED | FCVAR_CHEAT, "Projected textures that do not reach at least as high as this distance from the current marine's feet are considered non-visible." );
 
@@ -2450,7 +2450,7 @@ void C_ASW_Marine::CreateShoulderCone()
 
 void C_ASW_Marine::CreateBackpack( C_ASW_Weapon *pWeapon )
 {
-	if ( !rd_client_marine_backpacks.GetBool() && !rd_server_marine_backpacks.GetBool() )
+	if ( rd_client_marine_backpacks.GetInt() == 0 || (rd_client_marine_backpacks.GetInt() == -1 && !rd_server_marine_backpacks.GetBool()) )
 	{
 		RemoveBackpack();
 		return;

--- a/src/game/client/swarm/c_asw_marine.cpp
+++ b/src/game/client/swarm/c_asw_marine.cpp
@@ -80,7 +80,7 @@ ConVar rd_marine_explodes_into_gibs("rd_marine_explodes_into_gibs", "1", FCVAR_A
 ConVar rd_marine_gib_lifetime( "rd_marine_gib_lifetime", "36000.0", FCVAR_NONE, "number of seconds before marine gibs fade" );
 ConVar rd_marine_gib_lifetime_dm( "rd_marine_gib_lifetime_dm", "15.0", FCVAR_NONE, "number of seconds before marine gibs fade in deathmatch mode" );
 ConVar rd_marine_gib_spin( "rd_marine_gib_spin", "500", FCVAR_NONE, "how much do marine gibs spin?" );
-ConVar rd_client_marine_backpacks( "rd_client_marine_backpacks", "-1", FCVAR_NONE, "Show marine's un-equipped weapon on their back (0 = disabled, 1 = enabled, 2 = let the server pick)" );
+ConVar rd_client_marine_backpacks( "rd_client_marine_backpacks", "-1", FCVAR_NONE, "Show marine's un-equipped weapon on their back (0 = disabled, 1 = enabled, -1 = let the server pick)" );
 ConVar rd_server_marine_backpacks( "rd_server_marine_backpacks", "0", FCVAR_REPLICATED, "Attach unactive weapon model to marine's back" );
 ConVar rd_projected_texture_min_z( "rd_projected_texture_min_z", "-64", FCVAR_REPLICATED | FCVAR_CHEAT, "Projected textures that do not reach at least as high as this distance from the current marine's feet are considered non-visible." );
 

--- a/src/game/client/swarm/c_asw_marine.cpp
+++ b/src/game/client/swarm/c_asw_marine.cpp
@@ -81,7 +81,7 @@ ConVar rd_marine_gib_lifetime( "rd_marine_gib_lifetime", "36000.0", FCVAR_NONE, 
 ConVar rd_marine_gib_lifetime_dm( "rd_marine_gib_lifetime_dm", "15.0", FCVAR_NONE, "number of seconds before marine gibs fade in deathmatch mode" );
 ConVar rd_marine_gib_spin( "rd_marine_gib_spin", "500", FCVAR_NONE, "how much do marine gibs spin?" );
 ConVar rd_client_marine_backpacks( "rd_client_marine_backpacks", "0", FCVAR_NONE, "Show marine's un-equipped weapon on their back." );
-ConVar rd_server_marine_backpacks( "rd_server_marine_backpacks", "0", FCVAR_REPLICATED | FCVAR_CHEAT, "Attach unactive weapon model to marine's back" );
+ConVar rd_server_marine_backpacks( "rd_server_marine_backpacks", "0", FCVAR_REPLICATED, "Attach unactive weapon model to marine's back" );
 ConVar rd_projected_texture_min_z( "rd_projected_texture_min_z", "-64", FCVAR_REPLICATED | FCVAR_CHEAT, "Projected textures that do not reach at least as high as this distance from the current marine's feet are considered non-visible." );
 
 extern ConVar asw_DebugAutoAim;

--- a/src/game/server/swarm/asw_marine.cpp
+++ b/src/game/server/swarm/asw_marine.cpp
@@ -117,7 +117,7 @@ extern ConVar rd_burning_interval;
 extern ConVar rd_burning_marine_damage;
 ConVar rd_marine_ff_fist_scale( "rd_marine_ff_fist_scale", "1", FCVAR_CHEAT, "Scale CLUB type damage done to marines (requires rd_ff_marine_fist)" );
 
-ConVar rd_server_marine_backpacks("rd_server_marine_backpacks", "0", FCVAR_REPLICATED | FCVAR_CHEAT, "Attach unactive weapon model to marine's back");
+ConVar rd_server_marine_backpacks("rd_server_marine_backpacks", "0", FCVAR_REPLICATED, "Attach unactive weapon model to marine's back");
 
 ConVar rda_marine_strafe_allow_air("rda_marine_strafe_allow_air", "0", FCVAR_CHEAT, "If set to 1 marine able to strafe jump once in the air");
 ConVar rda_marine_strafe_push_hor_velocity("rda_marine_strafe_push_hor_velocity", "520", FCVAR_CHEAT, "Horizontal velocity for strafe push");


### PR DESCRIPTION
The admin(s) of the following (ranked) servers:

- [CN] [GuangZhou] GAMER Rank Server
- [CN] [ShangHai] GAMER Rank Server
- [CN] GAMER 100tick Home Server
- [CN] Moon and Stars Server  Official Rank Server

have expressed interest in enabling marine backpacks by default. Currently, the `rd_server_marine_backpacks` convar is flagged `fcvar_cheat`, which prevents modification. I advised the server owners against using tools like `sm_qcvar` to bypass this restriction.

Since enabling marine backpacks does not impact gameplay in any way, nor does it give competitive advantage, I think there is no reason to flag it as cheat. 

Removing `fcvar_cheat` from it, would allow server admins to toggle the feature.
