### PR TITLE
AlterDeathMessage hook vscript function

### DIFF
--- a/src/game/server/swarm/asw_gamerules_vscript.cpp
+++ b/src/game/server/swarm/asw_gamerules_vscript.cpp
@@ -1324,6 +1324,7 @@ public:
 			g_pScriptVM->SetValue( hScope, "OnMissionStart", SCRIPT_VARIANT_NULL );
 			g_pScriptVM->SetValue( hScope, "OnGameplayStart", SCRIPT_VARIANT_NULL );
 			g_pScriptVM->SetValue( hScope, "OnReceivedTextMessage", SCRIPT_VARIANT_NULL );
+			g_pScriptVM->SetValue( hScope, "AlterDeathMessage", SCRIPT_VARIANT_NULL );
 
 			s_Thinkers.AddToTail( this );
 		}

--- a/src/game/server/swarm/asw_marine.cpp
+++ b/src/game/server/swarm/asw_marine.cpp
@@ -4358,6 +4358,44 @@ void CASW_Marine::Event_Killed( const CTakeDamageInfo &info )
 	if ( ASWDeathmatchMode() )
 		ASWDeathmatchMode()->OnMarineKilled( info, this );
 
+	m_bSlowHeal = false;	// no healing if we're dead!
+
+	PrintDeathMessage( info );
+}
+
+void CASW_Marine::PrintDeathMessage( const CTakeDamageInfo &info )
+{
+	CASW_Marine_Resource *pMR = GetMarineResource();
+	
+	// print a custom death message if we have one
+	CAlienSwarm *pAlienSwarm = ASWGameRules();
+	if ( pAlienSwarm )
+	{
+		ScriptVariant_t args[7];
+		ScriptVariant_t retvalue;
+
+		args[0] = ToHScript( this );
+		args[1] = ToHScript( info.GetInflictor() );
+		args[2] = ToHScript( info.GetAttacker() );
+		args[3] = ToHScript( info.GetWeapon() );
+		args[4] = info.GetDamage();
+		args[5] = info.GetDamageType();
+		args[6] = info.GetAmmoName();
+
+		pAlienSwarm->RunScriptFunctionInListenerScopes( "AlterDeathMessage", &retvalue, NELEMS( args ), args );
+		
+		if ( retvalue.m_type == FIELD_CSTRING )
+		{
+			char szName[256];
+			pMR->GetDisplayName( szName, sizeof( szName ) );
+			
+			UTIL_ClientPrintAll( ASW_HUD_PRINTTALKANDCONSOLE, retvalue.m_pszString, szName );
+
+			return;
+		}
+	}
+
+	CBaseEntity *pAttacker = info.GetAttacker();
 	// print a message if marine was killed by another marine
 	if ( pAttacker && pAttacker->Classify() == CLASS_ASW_MARINE )
 	{
@@ -4411,8 +4449,6 @@ void CASW_Marine::Event_Killed( const CTakeDamageInfo &info )
 			UTIL_ClientPrintAll( ASW_HUD_PRINTTALKANDCONSOLE, "#asw_chat_died", szName );
 		}
 	}
-
-	m_bSlowHeal = false;	// no healing if we're dead!
 }
 
 void CASW_Marine::AimGun()

--- a/src/game/server/swarm/asw_marine.h
+++ b/src/game/server/swarm/asw_marine.h
@@ -635,6 +635,7 @@ public:
 	float m_flLastBurnSoundTime;
 	float m_fNextPainSoundTime;
 	virtual void Event_Killed( const CTakeDamageInfo &info );
+	void PrintDeathMessage( const CTakeDamageInfo &info );
 	bool CanBecomeRagdoll();
 	virtual bool BecomeRagdollOnClient( const Vector &force );
 	void Suicide();


### PR DESCRIPTION
called when a death message is about to be printed. Return a string which will be printed instead, %s1 in the string being the victim's display name (in case someone wants to do localization of their custom death message). No return value or non-string return value results in default death message