### PR TITLE
set `rd_challenge` timing

### DIFF
--- a/src/game/shared/swarm/asw_gamerules.cpp
+++ b/src/game/shared/swarm/asw_gamerules.cpp
@@ -9932,7 +9932,10 @@ void CAlienSwarm::EnableChallenge( const char *szChallengeName )
 	KeyValues::AutoDelete pKV( "CHALLENGE" );
 	bool bEnabled = ReactiveDropChallenges::ReadData( pKV, szChallengeName );
 
+	rd_challenge.SetValue("");
 	ResetChallengeConVars();
+	rd_challenge.SetValue(szChallengeName);
+
 	if ( ASWDeathmatchMode() )
 	{
 		ASWDeathmatchMode()->ApplyDeathmatchConVars();
@@ -9972,7 +9975,6 @@ void CAlienSwarm::EnableChallenge( const char *szChallengeName )
 	// if rd_max_marines changed we need to update marines limits using SetMaxMarines
 	SetMaxMarines();
 	EnforceMaxMarines();
-	rd_challenge.SetValue( szChallengeName );
 	OnSkillLevelChanged( m_iSkillLevel );
 
 	if ( V_strcmp( rd_challenge.GetString(), "0" ) )


### PR DESCRIPTION
set the challenge name before setting convars, this fixes log order when external plugins are used