### PR TITLE
Increase Devastator damage slightly

### DIFF
--- a/src/game/shared/swarm/asw_equipment_list.cpp
+++ b/src/game/shared/swarm/asw_equipment_list.cpp
@@ -383,7 +383,7 @@ static CASW_EquipItem s_RegularEquips[ASW_NUM_EQUIP_REGULAR] =
 		"swarm/EquipIcons/EquipDevastator",
 		&asw_ammo_count_devastator, &asw_ammo_count_devastator,
 		NULL, NULL,
-		11, 0.2f, 3.0f, 7, MARINE_CLASS_SPECIAL_WEAPONS,
+		13, 0.2f, 3.0f, 7, MARINE_CLASS_SPECIAL_WEAPONS,
 		true, false, false, ASW_OFFHAND_USE_IMMEDIATELY,
 		0.2f, 0.2f,
 	},


### PR DESCRIPTION
Increased base pellet damage from 11 to 13.
This is done to allow Wolfe to kill a drone with one hit on Brutal difficulty.
Wolfe now does 105 damage ( (13 + 2) * 7 ), Wildcat does 119 ( (13 + 4) * 7 ). FYI: Alien drone has 104 HP on Brutal.