### PR TITLE
Make Medical SMG more accurate when crouching

### DIFF
--- a/src/game/shared/swarm/asw_weapon_medrifle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_medrifle_shared.cpp
@@ -348,7 +348,15 @@ void CASW_Weapon_MedRifle::WeaponIdle( void )
 const Vector& CASW_Weapon_MedRifle::GetBulletSpread( void )
 {
 	static const Vector cone = Vector( 0.13053, 0.13053, 0.02 );	// VECTOR_CONE_15DEGREES with flattened Z
+	const static Vector cone_duck = Vector(0.05234, 0.05234, 0.01); // VECTOR_CONE_6DEGREES with flattened Z
 
+	CASW_Marine* marine = GetMarine();
+
+	if (marine)
+	{
+		if (marine->GetLocalVelocity().IsZero() && marine->m_bWalking)
+			return cone_duck;
+	}
 	return cone;
 }
 


### PR DESCRIPTION
Similarly to how Minigun works, Medical SMG bullet spread is decreased when marine is crouching.
Currently set to 6 degrees like Minigun.

This makes weapon slightly more useful in killing single aliens which are far from marine.