### PR TITLE
add missing challenge.setvalue

### DIFF
--- a/src/game/shared/swarm/asw_gamerules.cpp
+++ b/src/game/shared/swarm/asw_gamerules.cpp
@@ -9979,6 +9979,7 @@ void CAlienSwarm::EnableChallenge( const char *szChallengeName )
 	// if rd_max_marines changed we need to update marines limits using SetMaxMarines
 	SetMaxMarines();
 	EnforceMaxMarines();
+	rd_challenge.SetValue( szChallengeName );
 	OnSkillLevelChanged( m_iSkillLevel );
 
 	if ( V_strcmp( rd_challenge.GetString(), "0" ) )


### PR DESCRIPTION
During an earlier revert, this line went missing.

```
	// if rd_max_marines changed we need to update marines limits using SetMaxMarines
	SetMaxMarines();
	EnforceMaxMarines();
	rd_challenge.SetValue( szChallengeName );
	OnSkillLevelChanged( m_iSkillLevel );
```

Copied the file from an earlier version, and the file works now as before.