### PR TITLE
Reduce number of Stun Grenades to 7

### DIFF
--- a/src/game/shared/swarm/asw_equipment_list.cpp
+++ b/src/game/shared/swarm/asw_equipment_list.cpp
@@ -144,7 +144,7 @@ ConVar asw_ammo_count_gas_grenades( "asw_ammo_count_gas_grenades", "5", FCVAR_CH
 ConVar asw_ammo_count_t75( "asw_ammo_count_t75", "5", FCVAR_CHEAT | FCVAR_REPLICATED );
 ConVar asw_ammo_count_jump_jet( "asw_ammo_count_jump_jet", "5", FCVAR_CHEAT | FCVAR_REPLICATED );
 ConVar asw_ammo_count_bait( "asw_ammo_count_bait", "9", FCVAR_CHEAT | FCVAR_REPLICATED );
-ConVar asw_ammo_count_stun_grenades( "asw_ammo_count_stun_grenades", "10", FCVAR_CHEAT | FCVAR_REPLICATED );
+ConVar asw_ammo_count_stun_grenades( "asw_ammo_count_stun_grenades", "7", FCVAR_CHEAT | FCVAR_REPLICATED );
 ConVar asw_ammo_count_incendiary_grenades( "asw_ammo_count_incendiary_grenades", "7", FCVAR_CHEAT | FCVAR_REPLICATED );
 ConVar asw_ammo_count_shield_bubble( "asw_ammo_count_shield_bubble", "3", FCVAR_CHEAT | FCVAR_REPLICATED );
 ConVar asw_ammo_count_rifle_burst( "asw_ammo_count_rifle_burst", "99", FCVAR_CHEAT | FCVAR_REPLICATED );


### PR DESCRIPTION
We can always increase it later if necessary. Early playtest show that these grenades are not as weak as they were thought to be.

See #525