### PR TITLE
Fix marine getting stuck (and server potentially crash) in a supply box near first door on Cargo Elevator 

### DIFF
--- a/contentsrc/mapsrc/ASI-Jac1-LandingBay_02.vmf
+++ b/contentsrc/mapsrc/ASI-Jac1-LandingBay_02.vmf
@@ -2,7 +2,7 @@ versioninfo
 {
 	"editorversion" "400"
 	"editorbuild" "7397"
-	"mapversion" "3603"
+	"mapversion" "3604"
 	"formatversion" "100"
 	"prefab" "0"
 }
@@ -50,7 +50,7 @@ viewsettings
 world
 {
 	"id" "394754"
-	"mapversion" "3603"
+	"mapversion" "3604"
 	"classname" "worldspawn"
 	"detailmaterial" "detail/detailsprites"
 	"detailvbsp" "detail.vbsp"
@@ -19656,7 +19656,7 @@ entity
 	"origin" "-6512 -1488 844"
 	editor
 	{
-		"color" "0 255 0"
+		"color" "220 30 220"
 		"visgroupshown" "1"
 		"visgroupautoshown" "1"
 		"logicalpos" "[0 1500]"
@@ -20791,7 +20791,7 @@ entity
 	"origin" "-6608 -1448 844"
 	editor
 	{
-		"color" "0 255 0"
+		"color" "220 30 220"
 		"visgroupshown" "1"
 		"visgroupautoshown" "1"
 		"logicalpos" "[0 1500]"
@@ -32230,7 +32230,7 @@ entity
 	"rendercolor" "255 255 255"
 	"shadowcastdist" "0"
 	"skin" "2"
-	"spawnflags" "33025"
+	"spawnflags" "33801"
 	"origin" "-5092.67 870.539 832.281"
 	editor
 	{
@@ -32264,7 +32264,7 @@ entity
 	"rendercolor" "255 255 255"
 	"shadowcastdist" "0"
 	"skin" "2"
-	"spawnflags" "33025"
+	"spawnflags" "33801"
 	"origin" "-5092.67 958.539 832.281"
 	editor
 	{
@@ -32298,7 +32298,7 @@ entity
 	"rendercolor" "255 255 255"
 	"shadowcastdist" "0"
 	"skin" "2"
-	"spawnflags" "33025"
+	"spawnflags" "33801"
 	"origin" "-5308.85 1375.9 832.281"
 	editor
 	{
@@ -32332,7 +32332,7 @@ entity
 	"rendercolor" "255 255 255"
 	"shadowcastdist" "0"
 	"skin" "2"
-	"spawnflags" "33025"
+	"spawnflags" "33801"
 	"origin" "-5308.85 1463.9 832.281"
 	editor
 	{
@@ -55843,7 +55843,7 @@ entity
 	"origin" "-6672 -1376 844"
 	editor
 	{
-		"color" "0 255 0"
+		"color" "220 30 220"
 		"visgroupshown" "1"
 		"visgroupautoshown" "1"
 		"logicalpos" "[0 1500]"
@@ -55964,7 +55964,7 @@ entity
 	"origin" "-6576 -1376 844"
 	editor
 	{
-		"color" "0 255 0"
+		"color" "220 30 220"
 		"visgroupshown" "1"
 		"visgroupautoshown" "1"
 		"logicalpos" "[0 1500]"
@@ -56066,7 +56066,7 @@ entity
 	"origin" "-6480 -1408 844"
 	editor
 	{
-		"color" "0 255 0"
+		"color" "220 30 220"
 		"visgroupshown" "1"
 		"visgroupautoshown" "1"
 		"logicalpos" "[0 1500]"
@@ -63006,7 +63006,7 @@ entity
 	"origin" "-6448 -1456 844"
 	editor
 	{
-		"color" "0 255 0"
+		"color" "220 30 220"
 		"visgroupshown" "1"
 		"visgroupautoshown" "1"
 		"logicalpos" "[0 1500]"
@@ -88336,8 +88336,8 @@ cameras
 	"activecamera" "0"
 	camera
 	{
-		"position" "[-5433.51 5556.85 1219.01]"
-		"look" "[-5553.87 6842.42 -4942.78]"
+		"position" "[-5129.34 817.108 1017.95]"
+		"look" "[-4077.25 4083.93 -4259.92]"
 	}
 }
 cordons

--- a/contentsrc/mapsrc/instances/landingbay_singleplayer_part2.vmf
+++ b/contentsrc/mapsrc/instances/landingbay_singleplayer_part2.vmf
@@ -2,7 +2,7 @@ versioninfo
 {
 	"editorversion" "400"
 	"editorbuild" "7397"
-	"mapversion" "3609"
+	"mapversion" "3610"
 	"formatversion" "100"
 	"prefab" "0"
 }
@@ -50,7 +50,7 @@ viewsettings
 world
 {
 	"id" "394754"
-	"mapversion" "3609"
+	"mapversion" "3610"
 	"classname" "worldspawn"
 	"detailmaterial" "detail/detailsprites"
 	"detailvbsp" "detail.vbsp"
@@ -31302,7 +31302,7 @@ entity
 	"rendercolor" "255 255 255"
 	"shadowcastdist" "0"
 	"skin" "2"
-	"spawnflags" "33025"
+	"spawnflags" "34057"
 	"origin" "-5092.67 870.539 832.281"
 	editor
 	{
@@ -31336,7 +31336,7 @@ entity
 	"rendercolor" "255 255 255"
 	"shadowcastdist" "0"
 	"skin" "2"
-	"spawnflags" "33025"
+	"spawnflags" "34057"
 	"origin" "-5092.67 958.539 832.281"
 	editor
 	{
@@ -31370,7 +31370,7 @@ entity
 	"rendercolor" "255 255 255"
 	"shadowcastdist" "0"
 	"skin" "2"
-	"spawnflags" "33025"
+	"spawnflags" "34057"
 	"origin" "-5308.85 1375.9 832.281"
 	editor
 	{
@@ -31404,7 +31404,7 @@ entity
 	"rendercolor" "255 255 255"
 	"shadowcastdist" "0"
 	"skin" "2"
-	"spawnflags" "33025"
+	"spawnflags" "34057"
 	"origin" "-5308.85 1463.9 832.281"
 	editor
 	{
@@ -79662,7 +79662,7 @@ entity
 	"rendercolor" "255 255 255"
 	"shadowcastdist" "0"
 	"skin" "2"
-	"spawnflags" "33025"
+	"spawnflags" "33801"
 	"origin" "-6544 896 832.281"
 	editor
 	{
@@ -85852,8 +85852,8 @@ cameras
 	"activecamera" "0"
 	camera
 	{
-		"position" "[-5477.03 5530.91 1142.71]"
-		"look" "[-4983.68 8283.34 -4497.82]"
+		"position" "[-5222.79 1209.15 974.816]"
+		"look" "[-7344.12 6255.4 -2134.87]"
 	}
 }
 cordons


### PR DESCRIPTION
When marine approaches the first asw_door on Cargo Elevator (same place on asi-jac1-landingbay_pract and rd-bonus_mission4) and uses Grenade Launcher the explosion that damages two physical supply crate boxes moves them slightly out of the wall (yes they are placed slightly inside a wall in Hammer). If marine is close enough to the box then box moves inside marine making marine stuck for some time before server un-stucks him.

Getting stuck in these boxes sometimes lead to server crash.

This commit disables motion for these 2 boxes and 2 more boxes nearby. This should prevent marine getting stuck and hopefully will fix the server crash.

As a result of this commit, 3 maps need to be recompiled:
- asi-jac1-landingbay_02
- asi-jac1-landingbay_pract
- rd-bonus_mission4