### PR TITLE
Improve asw_buzzer AI

### DIFF
--- a/src/game/server/swarm/asw_alien.cpp
+++ b/src/game/server/swarm/asw_alien.cpp
@@ -142,8 +142,6 @@ CASW_Alien::CASW_Alien( void ) :
 	m_fLastSleepCheckTime = 0;
 	m_bVisibleWhenAsleep = false;
 
-	m_fLastMarineCanSeeTime = -100;
-	m_bLastMarineCanSee = false;
 	m_bTimeToRagdoll = false;
 	m_iDeadBodyGroup = 1;
 	m_bNeverRagdoll = false;
@@ -560,34 +558,6 @@ void CASW_Alien::NPCThink( void )
 		UpdateRangedAttack();
 
 	m_flLastThinkTime = gpGlobals->curtime;
-}
-
-bool CASW_Alien::MarineNearby(float radius, bool bCheck3D)
-{
-	// find the closest marine
-	CASW_Game_Resource *pGameResource = ASWGameResource();
-	if (!pGameResource)
-		return false;
-	
-	for (int i=0;i<pGameResource->GetMaxMarineResources();i++)
-	{
-		CASW_Marine_Resource* pMarineResource = pGameResource->GetMarineResource(i);
-		if (!pMarineResource)
-			continue;
-
-		CASW_Marine* pMarine = pMarineResource->GetMarineEntity();
-		if (!pMarine || pMarine->m_bKnockedOut)
-			continue;
-		
-		Vector diff = pMarine->GetAbsOrigin() - GetAbsOrigin();
-		float dist = bCheck3D ? diff.Length() : diff.Length2D();
-
-		if (dist < radius)
-		{
-			return true;
-		}
-	}
-	return false;
 }
 
 CBaseEntity *CASW_Alien::CheckTraceHullAttack( float flDist, const Vector &mins, const Vector &maxs, float flDamage, int iDmgType, float forceScale, bool bDamageAnyNPC )
@@ -2346,19 +2316,6 @@ void CASW_Alien::UpdateEfficiency( bool bInPVS )
 	}
 
 	SetEfficiency( ( bFramerateOk ) ? AIE_EFFICIENT : AIE_VERY_EFFICIENT );
-}
-
-// checks if a marine can see us
-//  caches the results and won't recheck unless the specified interval has passed since the last check
-bool CASW_Alien::MarineCanSee(int padding, float interval)
-{
-	if (gpGlobals->curtime >= m_fLastMarineCanSeeTime + interval)
-	{
-		bool bCorpseCanSee = false;
-		m_bLastMarineCanSee = (UTIL_ASW_AnyMarineCanSee(GetAbsOrigin(), padding, bCorpseCanSee) != NULL) || bCorpseCanSee;
-		m_fLastMarineCanSeeTime = gpGlobals->curtime;
-	}
-	return m_bLastMarineCanSee;
 }
 
 void CASW_Alien::DropMoney( const CTakeDamageInfo &info )

--- a/src/game/server/swarm/asw_alien.h
+++ b/src/game/server/swarm/asw_alien.h
@@ -79,7 +79,6 @@ public:
 	CASW_AI_Senses *GetASWSenses();
 	virtual bool QuerySeeEntity( CBaseEntity *pEntity, bool bOnlyHateOrFearIfNPC );
 	void SetDistSwarmSense( float flDistSense );
-	bool MarineNearby( float radius, bool bCheck3D = false );
 	bool FInViewCone( const Vector &vecSpot );
 	bool Knockback( Vector vecForce );
 	virtual void SetDefaultEyeOffset();
@@ -234,11 +233,6 @@ public:
 	EHANDLE m_hMoveClone;
 	string_t m_iMoveCloneName;
 	matrix3x4_t m_moveCloneOffset;
-
-	// can a marine see us?
-	bool MarineCanSee( int padding, float interval );
-	float m_fLastMarineCanSeeTime;
-	bool m_bLastMarineCanSee;
 
 	int m_iNumASWOrderRetries;
 

--- a/src/game/server/swarm/asw_buzzer.cpp
+++ b/src/game/server/swarm/asw_buzzer.cpp
@@ -82,7 +82,7 @@
 #define	ASW_BUZZER_CHARGE_MIN_DIST	200
 
 #define ASW_BUZZER_SLEEP_CHECK_INTERVAL 1.0f
-#define ASW_BUZZER_PVS_CHECK_RANGE 384.0f
+#define ASW_BUZZER_PVS_CHECK_RANGE 1024.0f
 
 ConVar	sk_asw_buzzer_health( "sk_asw_buzzer_health","30", FCVAR_CHEAT, "Health of the buzzer");
 ConVar	sk_asw_buzzer_melee_dmg( "sk_asw_buzzer_melee_dmg","15", FCVAR_CHEAT, "Damage caused by buzzer");
@@ -2224,7 +2224,7 @@ void CASW_Buzzer::NPCInit()
 
 	CASW_GameStats.Event_AlienSpawned( this );
 
-	SetDistSwarmSense(576.0f);
+	//SetDistSwarmSense(576.0f);	// is this necessary? commented for now
 }
 
 void CASW_Buzzer::NPCThink( void )
@@ -2378,20 +2378,15 @@ void CASW_Buzzer::StartTask( const Task_t *pTask )
 				if (pTask->flTaskData <= 0)		// check the taskdata to see if we should do a short spread movement when failing to build a path
 				{
 					// random nearby position
-					if ( GetNavigator()->SetWanderGoal( 90, 200 ) )
+					Vector dir( RandomFloat( -1, 1 ), RandomFloat( -1, 1 ), 0 );
+					Vector vecGoal( GetAbsOrigin() + dir * RandomFloat( 50, 150 ) );					
+					AI_NavGoal_t goal( vecGoal );
+					if ( GetNavigator()->SetGoal( goal ) )
 					{
 						TaskComplete();
 					}
 					else
-					{
-						// if we couldn't go for a full path
-						if ( GetNavigator()->SetRandomGoal( 150.0f ) )
-						{
-							TaskComplete();
-						}
-						else
-							TaskFail(FAIL_NO_ROUTE);
-					}
+						TaskFail(FAIL_NO_ROUTE);
 				}
 				else
 				{
@@ -3114,19 +3109,6 @@ int CASW_Buzzer::GetBaseHealth()
 	return sk_asw_buzzer_health.GetFloat();
 }
 
-// checks if a marine can see us
-// caches the results and won't recheck unless the specified interval has passed since the last check
-bool CASW_Buzzer::MarineCanSee(int padding, float interval)
-{
-	if (gpGlobals->curtime >= m_fLastMarineCanSeeTime + interval)
-	{
-		bool bCorpseCanSee = false;
-		m_bLastMarineCanSee = (UTIL_ASW_AnyMarineCanSee(GetAbsOrigin(), padding, bCorpseCanSee) != NULL) || bCorpseCanSee;
-		m_fLastMarineCanSeeTime = gpGlobals->curtime;
-	}
-	return m_bLastMarineCanSee;
-}
-
 // wake the buzzer up when a marine gets nearby
 void CASW_Buzzer::UpdateSleepState(bool bInPVS)
 {
@@ -3140,12 +3122,6 @@ void CASW_Buzzer::UpdateSleepState(bool bInPVS)
 			if ( VPhysicsGetObject() )
 				VPhysicsGetObject()->Wake();
 		}
-
-		bInPVS = MarineCanSee(ASW_BUZZER_PVS_CHECK_RANGE, 0.1f);
-		if (bInPVS)
-			SetCondition(COND_IN_PVS);
-		else
-			ClearCondition(COND_IN_PVS);
 
 		if ( GetSleepState() != AISS_WAITING_FOR_INPUT )
 		{
@@ -3171,8 +3147,8 @@ void CASW_Buzzer::UpdateSleepState(bool bInPVS)
 		{
 			if (m_fLastSleepCheckTime < gpGlobals->curtime + ASW_BUZZER_SLEEP_CHECK_INTERVAL)
 			{
-				//if (!GetEnemy() && !MarineNearby(1024.0f) )
-				if (!GetEnemy() && !MarineCanSee(ASW_BUZZER_PVS_CHECK_RANGE, 2.0f))
+				//if (!GetEnemy() && !MarineCanSee(ASW_BUZZER_PVS_CHECK_RANGE, 2.0f))
+				if (!GetEnemy() && !MarineNearby( ASW_BUZZER_PVS_CHECK_RANGE ) )
 				{
 					SetSleepState(AISS_WAITING_FOR_PVS);
 
@@ -3232,8 +3208,8 @@ void CASW_Buzzer::UpdateEfficiency(bool bInPVS)
 
 	bool bInVisibilityPVS = (UTIL_FindClientInVisibilityPVS(edict()) != NULL);
 
-	//if ( bInPVS && MarineNearby(1024) ) 
-	if (bInPVS && MarineCanSee(ASW_BUZZER_PVS_CHECK_RANGE, 1.0f))
+	if ( bInPVS && MarineNearby( ASW_BUZZER_PVS_CHECK_RANGE ) )
+	//if (bInPVS && MarineCanSee(ASW_BUZZER_PVS_CHECK_RANGE, 1.0f))
 	{
 		SetMoveEfficiency(AIME_NORMAL);
 	}
@@ -3275,6 +3251,18 @@ void CASW_Buzzer::UpdateEfficiency(bool bInPVS)
 	SetEfficiency((bFramerateOk) ? AIE_EFFICIENT : AIE_VERY_EFFICIENT);
 }
 
+bool CASW_Buzzer::CheckPVSCondition()
+{
+	bool bInPVS = MarineNearby( ASW_BUZZER_PVS_CHECK_RANGE );
+
+	if ( bInPVS )
+		SetCondition( COND_IN_PVS );
+	else
+		ClearCondition( COND_IN_PVS );
+
+	return bInPVS;
+}
+
 void CASW_Buzzer::UpdateOnRemove()
 {
 	if (m_bRegisteredAsAwake)
@@ -3296,7 +3284,7 @@ AI_BEGIN_CUSTOM_NPC( npc_buzzer, CASW_Buzzer )
 	DECLARE_TASK( TASK_ASW_BUZZER_FIND_SQUAD_CENTER );
 	DECLARE_TASK( TASK_ASW_BUZZER_FIND_SQUAD_MEMBER );
 	DECLARE_TASK( TASK_ASW_BUZZER_MOVEAT_SAVEPOSITION );
-	DECLARE_TASK(TASK_ASW_BUZZER_BUILD_PATH_TO_ORDER);
+	DECLARE_TASK( TASK_ASW_BUZZER_BUILD_PATH_TO_ORDER );
 
 	DECLARE_CONDITION( COND_ASW_BUZZER_START_ATTACK );
 
@@ -3413,11 +3401,10 @@ DEFINE_SCHEDULE
 
 	"	Tasks"
 	"		TASK_SET_FAIL_SCHEDULE						SCHEDULE:SCHED_ASW_BUZZER_SWARM_FAILURE"		// this allows to clear orders and go to Sleep() if we cannot find route
-	"		TASK_ASW_BUZZER_BUILD_PATH_TO_ORDER	1" 	// setting 1 here sets flTaskData and prevents buzzer from wandering under the map from one skybox wall to another
-	"		TASK_WALK_PATH			9999"
+	"		TASK_ASW_BUZZER_BUILD_PATH_TO_ORDER	0" 	// setting 1 here sets flTaskData and prevents buzzer from wandering under the map from one skybox wall to another
+	"		TASK_RUN_PATH						0"
 	"		TASK_WAIT_FOR_MOVEMENT	0"		// 0 is spread if fail to build path
-	"		TASK_WAIT_PVS			0"
-	""
+	"	"
 	"	Interrupts"
 	"		COND_NEW_ENEMY"
 	"		COND_SEE_ENEMY"	// in deference to scripted schedule where the enemy was slammed, thus no COND_NEW_ENEMY
@@ -3430,5 +3417,3 @@ DEFINE_SCHEDULE
 )
 
 AI_END_CUSTOM_NPC()
-
-

--- a/src/game/server/swarm/asw_buzzer.h
+++ b/src/game/server/swarm/asw_buzzer.h
@@ -190,16 +190,13 @@ public:
 	virtual void NPCThink();
 	void ReachedEndOfSequence();
 
-	//stuff related to sleep state
-	bool MarineCanSee(int padding, float interval);// can a marine see us? //copy from asw_alien
-	float m_fLastMarineCanSeeTime;
-	bool m_bLastMarineCanSee;
 	bool m_bRegisteredAsAwake;
 	float m_fLastSleepCheckTime;
 	bool m_bVisibleWhenAsleep;
 	virtual void UpdateSleepState(bool bInPVS);
 	void UpdateEfficiency(bool bInPVS);
 	virtual void UpdateOnRemove();
+	virtual bool CheckPVSCondition() override;
 private:
 
 	bool IsInEffectiveTargetZone( CBaseEntity *pTarget );

--- a/src/game/server/swarm/asw_inhabitable_npc.cpp
+++ b/src/game/server/swarm/asw_inhabitable_npc.cpp
@@ -13,6 +13,7 @@
 #include "asw_physics_prop_statue.h"
 #include "asw_util_shared.h"
 #include "ilagcompensationmanager.h"
+#include "asw_marine_resource.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -159,6 +160,9 @@ CASW_Inhabitable_NPC::CASW_Inhabitable_NPC()
 	m_nOldButtons = 0;
 	m_iControlsOverride = -1;
 
+	m_fLastMarineCanSeeTime = -100;
+	m_bLastMarineCanSee = false;
+
 	m_bWasOnFireForStats = false;
 	m_bFlammable = true;
 	m_bTeslable = true;
@@ -293,6 +297,47 @@ int	CASW_Inhabitable_NPC::DrawDebugTextOverlays()
 		text_offset++;
 	}
 	return text_offset;
+}
+
+bool CASW_Inhabitable_NPC::MarineNearby( float radius, bool bCheck3D )
+{
+	// find the closest marine
+	CASW_Game_Resource* pGameResource = ASWGameResource();
+	if ( !pGameResource )
+		return false;
+
+	for ( int i = 0; i < pGameResource->GetMaxMarineResources(); i++ )
+	{
+		CASW_Marine_Resource* pMarineResource = pGameResource->GetMarineResource( i );
+		if ( !pMarineResource )
+			continue;
+
+		CASW_Marine* pMarine = pMarineResource->GetMarineEntity();
+		if ( !pMarine || pMarine->m_bKnockedOut )
+			continue;
+
+		Vector diff = pMarine->GetAbsOrigin() - GetAbsOrigin();
+		float dist = bCheck3D ? diff.Length() : diff.Length2D();
+
+		if ( dist < radius )
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+// checks if a marine can see us
+//  caches the results and won't recheck unless the specified interval has passed since the last check
+bool CASW_Inhabitable_NPC::MarineCanSee( int padding, float interval )
+{
+	if ( gpGlobals->curtime >= m_fLastMarineCanSeeTime + interval )
+	{
+		bool bCorpseCanSee = false;
+		m_bLastMarineCanSee = ( UTIL_ASW_AnyMarineCanSee( GetAbsOrigin(), padding, bCorpseCanSee ) != NULL ) || bCorpseCanSee;
+		m_fLastMarineCanSeeTime = gpGlobals->curtime;
+	}
+	return m_bLastMarineCanSee;
 }
 
 // sets which player commands this marine

--- a/src/game/server/swarm/asw_inhabitable_npc.h
+++ b/src/game/server/swarm/asw_inhabitable_npc.h
@@ -35,6 +35,12 @@ public:
 	virtual void UpdateOnRemove() override;
 	virtual int DrawDebugTextOverlays() override;
 
+	// util
+	bool MarineNearby( float radius, bool bCheck3D = false );
+	bool MarineCanSee( int padding, float interval );	// can a marine see us?
+	float m_fLastMarineCanSeeTime;
+	bool  m_bLastMarineCanSee;
+
 	// player control
 	void SetCommander( CASW_Player *player );
 	CASW_Player *GetCommander() const;


### PR DESCRIPTION
- Changed buzzer to sense marines using a sphere instead of using player's camera frustum. This allows to wake up buzzers that for some reason flew above player's camera frustum. Before this change many buzzers could get into infinite sleep while being relatively close to marines.
- Increased the range buzzer can detect marines and wake up to 1024 units. Before this buzzers would easily loose marines out of their sight and get into forever sleep state.
- Improved the "Spread then hibernate" order (although it still works not perfectly). Now buzzers instead of instantly sleeping move to some random position nearby the spawner and wait for player to see them.
- Improved "Move to Nearest Marine" order. Now buzzer similary to other aliens updates nearest marine position periodically and moves to that position. Before this change buzzer would move to a position where marine was when the order would issued, and if marine was not in that position buzzer would enter sleep state.
- Improved other orders: "Move to", "Move to Ignoring Marines". "Move to Ignoring Marines" still needs work as buzzers after arival do not retarget to marines (they still ignore them).

Moved code of functions MarineCanSee() and MarineNearby() into asw_inhabitable_npc to reduce code duplication.