### PR TITLE
Disable black bars by default on coop. Enbales by default on deathmatch.

### DIFF
--- a/reactivedrop/resource/challenges/rd_first_person.txt
+++ b/reactivedrop/resource/challenges/rd_first_person.txt
@@ -6,6 +6,5 @@
 
 	"convars" {
 		"asw_controls"	"0"
-		"rd_draw_restricted_rectangles_coop"	"0"
 	}
 }

--- a/reactivedrop/resource/challenges/rd_third_person.txt
+++ b/reactivedrop/resource/challenges/rd_third_person.txt
@@ -6,6 +6,5 @@
 
 	"convars" {
 		"asw_controls"	"2"
-		"rd_draw_restricted_rectangles_coop"	"0"
 	}
 }

--- a/src/game/client/swarm/vgui/asw_hud_3dmarinenames.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_3dmarinenames.cpp
@@ -49,6 +49,7 @@
 // restricted area variables and cvars
 extern int g_nRestrictedAreaLeft;
 extern bool g_bUltraWideScreen;
+extern ConVar _rd_traitors_challenge_enabled;
 extern ConVar rd_draw_restricted_rectangles_coop;
 extern ConVar rd_draw_restricted_rectangles_dm;
 
@@ -619,7 +620,7 @@ void CASWHud3DMarineNames::PaintMarineLabel( int iMyMarineNum, C_ASW_Marine *RES
 		bool bMarineOnScreen = (screenPos.x >= 0) && (screenPos.x <= nMaxX) &&
 			(screenPos.y >= 0) && (screenPos.y <= nMaxY);
 		int nRestrictedAreaOffset = 0;
-		if (g_bUltraWideScreen && ((rd_draw_restricted_rectangles_coop.GetBool() && !ASWDeathmatchMode()) || (rd_draw_restricted_rectangles_dm.GetBool() && ASWDeathmatchMode()))) {
+		if (g_bUltraWideScreen && _rd_traitors_challenge_enabled.GetBool() && ((rd_draw_restricted_rectangles_coop.GetBool() && !ASWDeathmatchMode()) || (rd_draw_restricted_rectangles_dm.GetBool() && ASWDeathmatchMode()))) {
 			bMarineOnScreen = (screenPos.x >= g_nRestrictedAreaLeft) && (screenPos.x <= nMaxX - g_nRestrictedAreaLeft) &&
 				(screenPos.y >= 0) && (screenPos.y <= nMaxY);
 			nRestrictedAreaOffset = g_nRestrictedAreaLeft;

--- a/src/game/client/swarm/vgui/asw_hud_master.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_master.cpp
@@ -38,6 +38,7 @@ extern ConVar rd_hud_hide_clips;
 
 extern bool g_ultra_wide_screen;
 extern Rect_t g_clamp_area;
+extern ConVar _rd_traitors_challenge_enabled;
 
 ConVar rd_draw_avatars_with_frags( "rd_draw_avatars_with_frags", "1",  FCVAR_ARCHIVE, "If 1 In PvP modes a panel with avatars and frags will be shown at top of the screen");
 ConVar rd_draw_portraits( "rd_draw_portraits", "1", FCVAR_NONE );
@@ -54,7 +55,7 @@ bool g_bUltraWideScreen;
 // restricted area cvars
 ConVar rd_draw_restricted_borders( "rd_draw_restricted_borders", "1", FCVAR_ARCHIVE, "Display the restricted cursor area when using ultra-wide resolution" );
 ConVar rd_draw_restricted_borders_color("rd_draw_restricted_borders_color", "128 128 128 128", 0, "Color of the restricted cursor area borders");
-ConVar rd_draw_restricted_rectangles_coop("rd_draw_restricted_rectangles_coop", "1", FCVAR_REPLICATED, "Fill extra side FOVs with black on ultra-wide resolution in coop mode.");
+ConVar rd_draw_restricted_rectangles_coop("rd_draw_restricted_rectangles_coop", "0", FCVAR_REPLICATED, "Fill extra side FOVs with black on ultra-wide resolution in coop mode.");
 ConVar rd_draw_restricted_rectangles_dm("rd_draw_restricted_rectangles_dm", "1", FCVAR_REPLICATED | FCVAR_CHEAT, "Fill extra side FOVs with black on ultra-wide resolution in deathmatch mode.");
 
 using namespace vgui;
@@ -516,7 +517,7 @@ void CASW_Hud_Master::Paint( void )
 	if ( m_pLocalMarineResource )
 	{
 		// Block extra side FOVs
-		if (g_bUltraWideScreen && ((rd_draw_restricted_rectangles_coop.GetBool() && !ASWDeathmatchMode()) || (rd_draw_restricted_rectangles_dm.GetBool() && ASWDeathmatchMode())) && !pPlayer->GetSpectatingNPC()) {
+		if (g_bUltraWideScreen && _rd_traitors_challenge_enabled.GetBool() && ((rd_draw_restricted_rectangles_coop.GetBool() && !ASWDeathmatchMode()) || (rd_draw_restricted_rectangles_dm.GetBool() && ASWDeathmatchMode())) && !pPlayer->GetSpectatingNPC()) {
 			//	(0,0)-----(L,0)       (R,0)-----(W,0)
 			//	  |//////////|            |/////////|
 			//	  |//////////|            |/////////|


### PR DESCRIPTION
This is a walkaround before final resoluation fix.

Simply set ConVar related to ultra wide screen black bar to 0. 

The code is not removed Since Traitors challenge wants to block extra fov.