### PR TITLE
Fix Traitors emotes not displaying on dedicated server.

### DIFF
--- a/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors.nut
+++ b/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors.nut
@@ -1,4 +1,4 @@
-DEBUG <- true; // Debug flags 调试标识
+DEBUG <- false; // Debug flags 调试标识
 INT_MAX <- 2147483647; // Constant 常量
 isServer <- true; // If the code is running server side or client side 指示代码是在服务端运行的还是在客户端运行的
 IsPaused <- false; // Not actually being used 没有实际用处
@@ -190,7 +190,14 @@ function SetTraitorIcon(interval = 10) {
 	if (g_int_Counter % interval != 0) {
 		return;
 	}
-	foreach(hMarine in g_marine_Total) {
+
+
+	local list = {};
+	for (local i = 6; i < 21; i++) {
+		list[i] <- 0;
+	}
+	local i = 11;
+	foreach(hMarine in g_marine_Traitor) {
 		if (hMarine == null || !hMarine.IsValid()) {
 			continue;
 		}
@@ -205,30 +212,34 @@ function SetTraitorIcon(interval = 10) {
 			case ROLE.INFECTED_SNIPER:
 			case ROLE.INFECTED_DEMO:
 			case ROLE.INFECTED_DESERTER:
-				NetProps.SetPropInt(hMarine, "m_iEmote", NetProps.GetPropInt(hMarine, "m_iEmote") | (1 << 8));
+				list[i] = hMarine.entindex();
+				i++;
 				break;
 			case ROLE.TRAITOR_LEADER:
-				NetProps.SetPropInt(hMarine, "m_iEmote", NetProps.GetPropInt(hMarine, "m_iEmote") | (1 << 9));
+				list[6] = hMarine.entindex();
 				break;
 			case ROLE.INFECTOR:
-				NetProps.SetPropInt(hMarine, "m_iEmote", NetProps.GetPropInt(hMarine, "m_iEmote") | (1 << 10));
+				list[7] = hMarine.entindex();
 				break;
 			case ROLE.BOOMER:
-				NetProps.SetPropInt(hMarine, "m_iEmote", NetProps.GetPropInt(hMarine, "m_iEmote") | (1 << 11));
+				list[8] = hMarine.entindex();
 				break;
 			case ROLE.SILENCER:
-				NetProps.SetPropInt(hMarine, "m_iEmote", NetProps.GetPropInt(hMarine, "m_iEmote") | (1 << 12));
+				list[9] = hMarine.entindex();
 				break;
 			case ROLE.MIMIC:
-				NetProps.SetPropInt(hMarine, "m_iEmote", NetProps.GetPropInt(hMarine, "m_iEmote") | (1 << 13));
-				break;
+				list[10] = hMarine.entindex();
 		}
 	}
 	foreach(hPlayer in g_player_TraitorHistory) {
 		if (hPlayer == null || !hPlayer.IsValid()) {
 			continue;
 		}
-		NetProps.SetPropInt(hPlayer, "m_iFrags", 99);
+
+		local hHud2 = Entities.FindByName(null, hPlayer.GetScriptScope().strHudName2);
+		for(local i = 6;i<21;i++) {
+			hHud2.SetInt(i, list[i]);
+		}
 	}
 }
 
@@ -1158,10 +1169,10 @@ function DeterminRoleCount() {
 					//g_bool_HasInfector = true;
 					break;
 				case 1:
-					g_bool_HasBoomer = true;
+			g_bool_HasBoomer = true;
 					break;
 				case 2:
-					g_bool_HasSilencer = true;
+			g_bool_HasSilencer = true;
 					break;
 			}
 			g_bool_HasShield = (RandomHQUniformIntDistribution(0, 8) == 0);
@@ -1461,6 +1472,9 @@ function CreatePlayerHud(hPlayer) {
 	hHud1.SetEntity(0, hPlayer);
 	local strHud1 = "HUD_" + UniqueString();
 	hHud1.SetName(strHud1);
+	for (local i = 6; i < 21; i++) {
+		hHud1.SetInt(i, 0);
+	}
 
 	hPlayer.GetScriptScope().strHudName1 <- strHud1;
 	hHud1.SetInt(0, ROLE.SPECTATOR);
@@ -1488,6 +1502,9 @@ function CreatePlayerHud(hPlayer) {
 	hHud2.SetEntity(0, hPlayer);
 	local strHud2 = "HUD_" + UniqueString();
 	hHud2.SetName(strHud2);
+	for (local i = 6; i < 21; i++) {
+		hHud2.SetInt(i, 0);
+	}
 
 	hPlayer.ValidateScriptScope();
 	hPlayer.GetScriptScope().strHudName2 <- strHud2;
@@ -1516,6 +1533,9 @@ function CreatePlayerHud(hPlayer) {
 	hHud4.SetEntity(0, hPlayer);
 	local strHud4 = "HUD_" + UniqueString();
 	hHud4.SetName(strHud4);
+	for (local i = 6; i < 21; i++) {
+		hHud4.SetInt(i, 0);
+	}
 
 	hPlayer.GetScriptScope().strHudName4 <- strHud4;
 	hHud4.SetInt(0, ROLE.SPECTATOR);
@@ -1543,6 +1563,9 @@ function CreatePlayerHud(hPlayer) {
 	hHud3.SetEntity(0, hPlayer);
 	local strhHud3 = "HUD_" + UniqueString();
 	hHud3.SetName(strhHud3);
+	for (local i = 6; i < 21; i++) {
+		hHud3.SetInt(i, 0);
+	}
 
 	hPlayer.ValidateScriptScope();
 	hPlayer.GetScriptScope().strHudName3 <- strhHud3;

--- a/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors_events/ontakedamage_alive_any.nut
+++ b/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors_events/ontakedamage_alive_any.nut
@@ -46,14 +46,14 @@ function OnTakeDamage_Alive_Any(victim, inflictor, attacker, weapon, damage, dam
 					factor3 = 0.10;
 					break;
 				case "asw_weapon_devastator": //毁灭者霰弹
-					factor1 = 0.33;
-					factor2 = 0.23;
-					factor3 = 0.46;
+					factor1 = 0.31;
+					factor2 = 0.21;
+					factor3 = 0.41;
 					break;
 				case "asw_weapon_vindicator": //复仇者霰弹
-					factor1 = 0.16;
-					factor2 = 0.12;
-					factor3 = 0.20;
+					factor1 = 0.20;
+					factor2 = 0.15;
+					factor3 = 0.25;
 					break;
 				default:
 					factor1 = 0.08;
@@ -105,9 +105,9 @@ function OnTakeDamage_Alive_Any(victim, inflictor, attacker, weapon, damage, dam
 					factor3 = 0.40;
 					break;
 				case "asw_weapon_minigun": //迷你机枪
-					factor1 = 0.26;
-					factor2 = 0.20;
-					factor3 = 0.32;
+					factor1 = 0.24;
+					factor2 = 0.18;
+					factor3 = 0.30;
 					break;
 				case "asw_weapon_deagle": //斗牛犬
 					factor1 = 0.26;
@@ -137,9 +137,9 @@ function OnTakeDamage_Alive_Any(victim, inflictor, attacker, weapon, damage, dam
 					factor3 = 0.145;
 					break;
 				case "asw_weapon_medrifle": //医疗冲锋枪
-					factor1 = 0.55;
-					factor2 = 0.45;
-					factor3 = 0.65;
+					factor1 = 0.50;
+					factor2 = 0.40;
+					factor3 = 0.60;
 					break;
 				case "asw_weapon_laser_mines": //激光地雷
 					damage = 6;

--- a/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors_player_info.nut
+++ b/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors_player_info.nut
@@ -4,6 +4,16 @@
 	int	 2  - 行号
 	int	 3  - 投降，当前人数
 	int	 4  - 投降，总人数
+
+	int  6  - TRAITOR_LEADER 对应的marine index
+	int  7  - INFECTOR 对应的marine index
+	int  8  - BOOMER 对应的marine index
+	int  9  - SILENCER 对应的marine index
+	int  10 - MIMIC 对应的marine index
+	int  11 - TRAITOR 对应的marine index
+	...
+	int  20 - TRAITOR 对应的marine index
+
 	int	 63 - 标识，1和2代表显示的是内鬼提示1和提示2。3代表显示的是内鬼开始投票，4代表投票中，5代表投票停止
 
 	float   0  - HUD信息显示的起始时间
@@ -45,9 +55,32 @@ IncludeScript("challenge_traitors_enums.nut");
 
 FONT_DEFAULTLARGE <- self.LookupFont("DefaultMedium");
 
+TEXTURE_TRAITOR <- self.LookupTexture("vgui/swarm/Emotes/EmoteTraitor");
+TEXTURE_TRAITORS <- {
+	[6] = self.LookupTexture("vgui/swarm/Emotes/EmoteTraitorLeader"),
+	[7] = self.LookupTexture("vgui/swarm/Emotes/EmoteInfector"),
+	[8] = self.LookupTexture("vgui/swarm/Emotes/EmoteBoomer"),
+	[9] = self.LookupTexture("vgui/swarm/Emotes/EmoteSilencer"),
+	[10] = self.LookupTexture("vgui/swarm/Emotes/EmoteMimic"),
+	[11] = TEXTURE_TRAITOR,
+	[12] = TEXTURE_TRAITOR,
+	[13] = TEXTURE_TRAITOR,
+	[14] = TEXTURE_TRAITOR,
+	[15] = TEXTURE_TRAITOR,
+	[16] = TEXTURE_TRAITOR,
+	[17] = TEXTURE_TRAITOR,
+	[18] = TEXTURE_TRAITOR,
+	[19] = TEXTURE_TRAITOR,
+	[20] = TEXTURE_TRAITOR,
+};
+
 xMargin <- 0;
 
 function Paint() {
+	for (local i = 6; i < 21; i++) {
+		PaintTraitorIcon(i);
+	}
+
 	//如果正在控制士兵，显示信息。
 	if (self.GetEntity(0) == GetLocalPlayer()) {
 		local message = self.GetString(0);
@@ -94,6 +127,33 @@ function PaintMsg(point, role, font, message) {
 		self.PaintRectangle(point[0] - textHalfWidth - 20, point[1] - 5 + line * (self.GetFontTall(font) + 10), point[0] + 20 + textHalfWidth, point[1] - 5 + (line + 1) * (self.GetFontTall(font) + 10), 0, 0, 0, 150);
 	}
 
+}
+
+function PaintTraitorIcon(idx) {
+
+	if (self.GetInt(idx) <= 0 || TEXTURE_TRAITORS[idx] == -1) {
+		return;
+	}
+	local screenPos = self.ClientGetEntityScreenPos(self.GetInt(idx));
+	if (screenPos.z < 0.5) { //无效屏幕坐标
+		return;
+	}
+
+	local xPos = screenPos.x;
+	local yPos = screenPos.y;
+
+	local fScale = (ScreenHeight() / 768.0) * 0.4;
+	local HalfW = 128.0 * fScale * 0.5;
+	local HalfH = 128.0 * fScale * 0.5;
+	yPos += 100 * (ScreenHeight() / 768.0);
+
+	local points = [
+		{x = xPos - HalfW, y = yPos - HalfH, s = 0, t = 0},
+		{x = xPos + HalfW, y = yPos - HalfH, s = 1, t = 0},
+		{x = xPos + HalfW, y = yPos + HalfH, s = 1, t = 1},
+		{x = xPos - HalfW, y = yPos + HalfH, s = 0, t = 1}
+	];
+	self.PaintPolygon(points, 255, 255, 255, 255, TEXTURE_TRAITORS[idx]);
 }
 
 function interp(i, t) {

--- a/src/game/client/swarm/vgui/asw_hud_emotes.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_emotes.cpp
@@ -56,7 +56,6 @@ public:
 	virtual void PaintEmotes();
 	virtual void PaintEmotesFor( C_ASW_Marine *pMarine );
 	virtual void PaintEmote( C_BaseEntity *pEnt, float fTime, int iTexture, float fScale = 1.0f );
-	virtual void PaintTraitorEmote(C_BaseEntity* pEnt, int iTexture, float fScale = 1.0f);
 	virtual bool ShouldDraw( void ) { return asw_draw_hud.GetBool() && CASW_HudElement::ShouldDraw(); }
 
 	CPanelAnimationVarAliasType( int, m_nMedicTexture, "MedicEmoteTexture", "vgui/swarm/Emotes/EmoteMedic", "textureid" );
@@ -74,14 +73,6 @@ public:
 	CPanelAnimationVarAliasType( int, m_nHackTexture, "HackTexture", "vgui/swarm/ClassIcons/HackIcon", "textureid" );
 	CPanelAnimationVarAliasType( int, m_nWeldTexture, "WeldTexture", "vgui/swarm/ClassIcons/WeldIcon", "textureid" );
 	CPanelAnimationVarAliasType( int, m_nReviveMarineTexture, "ReviveMarineTexture", "vgui/swarm/ClassIcons/revivemarine", "textureid" );
-
-	// Traitors emotes
-	CPanelAnimationVarAliasType(int, m_nTraitorEmoteTexture, "TraitorEmoteTexture", "vgui/swarm/Emotes/EmoteTraitor", "textureid");
-	CPanelAnimationVarAliasType(int, m_nTraitorLeaderEmoteTexture, "TraitorLeaderEmoteTexture", "vgui/swarm/Emotes/EmoteTraitorLeader", "textureid");
-	CPanelAnimationVarAliasType(int, m_nInfectorEmoteTexture, "InfectorEmoteTexture", "vgui/swarm/Emotes/EmoteInfector", "textureid");
-	CPanelAnimationVarAliasType(int, m_nBoomerEmoteTexture, "BoomerEmoteTexture", "vgui/swarm/Emotes/EmoteBoomer", "textureid");
-	CPanelAnimationVarAliasType(int, m_nSilencerEmoteTexture, "SilencerEmoteTexture", "vgui/swarm/Emotes/EmoteSilencer", "textureid");
-	CPanelAnimationVarAliasType(int, m_nMimicEmoteTexture, "MimicEmoteTexture", "vgui/swarm/Emotes/EmoteMimic", "textureid");
 };
 
 DECLARE_HUDELEMENT( CASWHudEmotes );
@@ -154,26 +145,6 @@ void CASWHudEmotes::PaintEmotesFor( C_ASW_Marine *pMarine )
 		PaintEmote( pMarine, pMarine->m_fEmoteQuestionTime, m_nQuestionTexture );
 	if ( pMarine->m_iClientEmote & ( 1 << 14 ) )
 		PaintEmote( pMarine, pMarine->m_fEmoteThanksTime, m_nThanksTexture );
-
-	if (_rd_traitors_challenge_enabled.GetBool())
-	{
-		C_ASW_Player* pPlayer = C_ASW_Player::GetLocalASWPlayer();
-		if (pPlayer && g_PR && g_PR->GetPlayerScore(pPlayer->entindex()) == 99)
-		{
-			if (pMarine->m_iEmote & (1 << 8))
-				PaintTraitorEmote(pMarine, m_nTraitorEmoteTexture, 0.35f);
-			if (pMarine->m_iEmote & (1 << 9))
-				PaintTraitorEmote(pMarine, m_nTraitorLeaderEmoteTexture, 0.35f);
-			if (pMarine->m_iEmote & (1 << 10))
-				PaintTraitorEmote(pMarine, m_nInfectorEmoteTexture, 0.35f);
-			if (pMarine->m_iEmote & (1 << 11))
-				PaintTraitorEmote(pMarine, m_nBoomerEmoteTexture, 0.35f);
-			if (pMarine->m_iEmote & (1 << 12))
-				PaintTraitorEmote(pMarine, m_nSilencerEmoteTexture, 0.35f);
-			if (pMarine->m_iEmote & (1 << 13))
-				PaintTraitorEmote(pMarine, m_nMimicEmoteTexture, 0.35f);
-		}
-	}
 
 	bool bBuildingSentry = false;
 	bool bWelding = false;
@@ -307,45 +278,6 @@ void CASWHudEmotes::PaintEmote( C_BaseEntity *pEnt, float fTime, int iTexture, f
 
 			//surface()->DrawTexturedRect(xPos - HalfW, yPos - HalfH,
 										//xPos + HalfW, yPos + HalfH);
-		}
-	}
-}
-
-void CASWHudEmotes::PaintTraitorEmote(C_BaseEntity* pEnt, int iTexture, float fEmoteScale)
-{
-	//Msg("PaintEmote scale = %f\n", fEmoteScale);
-	if (fEmoteScale < 0)
-		fEmoteScale = 0;
-	Vector screenPos;
-	Vector vecFacing;
-	AngleVectors(pEnt->GetRenderAngles(), &vecFacing);
-	vecFacing *= 5;
-	// BenLubar: Fix emotes being offset when the camera is rotated
-	float flYaw = (ASWInput() ? ASWInput()->ASW_GetCameraYaw() : 90) / 180 * M_PI;
-	Vector vecOffset(cosf(flYaw) * 40, sinf(flYaw) * 40, 70);
-	if (!debugoverlay->ScreenPosition(pEnt->GetRenderOrigin() + vecOffset + vecFacing, screenPos))
-	{
-		float xPos = screenPos[0];
-		float yPos = screenPos[1];
-
-		if (iTexture != -1)
-		{
-			float fScale = (ScreenHeight() / 768.0f) * fEmoteScale;
-			float HalfW = 128.0f * fScale * 0.5f;
-			float HalfH = 128.0f * fScale * 0.5f;
-			yPos += 100 * (ScreenHeight() / 768.0f);
-
-			surface()->DrawSetColor(Color(255, 255, 255, 255.0f));
-			surface()->DrawSetTexture(iTexture);
-
-			Vertex_t points[4] =
-			{
-			Vertex_t(Vector2D(xPos - HalfW, yPos - HalfH), Vector2D(0,0)),
-			Vertex_t(Vector2D(xPos + HalfW, yPos - HalfH), Vector2D(1,0)),
-			Vertex_t(Vector2D(xPos + HalfW, yPos + HalfH), Vector2D(1,1)),
-			Vertex_t(Vector2D(xPos - HalfW, yPos + HalfH), Vector2D(0,1))
-			};
-			surface()->DrawTexturedPolygon(4, points);
 		}
 	}
 }

--- a/src/game/shared/swarm/rd_hud_vscript_shared.cpp
+++ b/src/game/shared/swarm/rd_hud_vscript_shared.cpp
@@ -3,6 +3,7 @@
 #ifdef CLIENT_DLL
 #include "c_rd_infection_deathmatch_stats.h"
 #include "asw_util_shared.h"
+#include "asw_input.h"
 #endif
 #include <vgui/IScheme.h>
 #include <vgui/ISurface.h>
@@ -58,6 +59,8 @@ BEGIN_ENT_SCRIPTDESC( CRD_HUD_VScript, CBaseEntity, "Alien Swarm: Reactive Drop 
 	DEFINE_SCRIPTFUNC_NAMED( Script_PaintTexturedRectangle, "PaintTexturedRectangle", "Draw a textured rectangle on the heads-up display. Can only be called during Paint" )
 	DEFINE_SCRIPTFUNC_NAMED( Script_PaintTexturedRectangleAdvanced, "PaintTexturedRectangleAdvanced", "Draw a textured rectangle with advanced settings on the heads-up display. Can only be called during Paint" )
 	DEFINE_SCRIPTFUNC_NAMED( Script_PaintPolygon, "PaintPolygon", "Draw an arbitrary polygon on the heads-up display. Vertices must be in clockwise order; shape should be convex. Can only be called during Paint" )
+	DEFINE_SCRIPTFUNC_NAMED(Script_ClientGetEntityOrigin, "ClientGetEntityOrigin", "Returns the origin of an entity.")
+	DEFINE_SCRIPTFUNC_NAMED(Script_ClientGetEntityScreenPos, "ClientGetEntityScreenPos", "Converts a world position to screen coordinate. Z value of the returned vector denotes if it's a valid screen coordinate, 1 valid, 0 otherwise.")
 #else
 	DEFINE_SCRIPTFUNC( SetEntity, "Set the value of an entity parameter." )
 	DEFINE_SCRIPTFUNC( SetInt, "Set the value of an integer parameter." )
@@ -459,6 +462,47 @@ void CRD_HUD_VScript::Script_PaintPolygon( HSCRIPT vertices, int r, int g, int b
 	vgui::surface()->DrawSetTexture( texture );
 	vgui::surface()->DrawTexturedPolygon( nVerts, convertedVertices.Base() );
 }
+
+const Vector& CRD_HUD_VScript::Script_ClientGetEntityOrigin(int entIndex)
+{
+	C_BaseEntity* pEnt = C_BaseEntity::Instance(entIndex);
+	static Vector v;
+	if (pEnt)
+	{
+		v = pEnt->GetAbsOrigin();
+	}
+	else
+	{
+		v = vec3_origin;
+	}
+	return v;
+}
+
+const Vector& CRD_HUD_VScript::Script_ClientGetEntityScreenPos(int entIndex)
+{
+	C_BaseEntity* pEnt = C_BaseEntity::Instance(entIndex);
+	static Vector v;
+	if (!pEnt)
+	{
+		return vec3_origin;
+	}
+	Vector vecFacing;
+	AngleVectors(pEnt->GetRenderAngles(), &vecFacing);
+	vecFacing *= 5;
+	// BenLubar: Fix emotes being offset when the camera is rotated
+	float flYaw = (ASWInput() ? ASWInput()->ASW_GetCameraYaw() : 90) / 180 * M_PI;
+	Vector vecOffset(cosf(flYaw) * 40, sinf(flYaw) * 40, 70);
+	if (!debugoverlay->ScreenPosition(pEnt->GetRenderOrigin() + vecOffset + vecFacing, v))
+	{
+		v.z = 1; // valid screen position
+	}
+	else
+	{
+		v = vec3_origin; // invalid screen position
+	}
+	return v;
+}
+
 #else
 int CRD_HUD_VScript::ShouldTransmit( const CCheckTransmitInfo *pInfo )
 {

--- a/src/game/shared/swarm/rd_hud_vscript_shared.h
+++ b/src/game/shared/swarm/rd_hud_vscript_shared.h
@@ -35,6 +35,8 @@ public:
 	void Script_PaintTexturedRectangle( int x0, int y0, int x1, int y1, int r, int g, int b, int a, int texture );
 	void Script_PaintTexturedRectangleAdvanced( HSCRIPT table );
 	void Script_PaintPolygon( HSCRIPT vertices, int r, int g, int b, int a, int texture );
+	const Vector& Script_ClientGetEntityOrigin(int entindex);
+	const Vector& Script_ClientGetEntityScreenPos(int entIndex);
 
 	CNetworkString( m_szClientVScript, 64 );
 	CScriptScope m_ScriptScope;


### PR DESCRIPTION
- [x] Remove old traitor icon system which uses emote system.
- [x] Directly draw traitor icons in client HUD vscript.
- [x] Add 2 new client side HUD vscritp functions to CRD_HUD_VScript:  
        `const Vector ClientGetEntityOrigin(int entindex)`: Returns the origin of an entity. Returns (0, 0, 0) if it's not a valid entity.
	`const Vector ClientGetEntityScreenPos(int entIndex)`: Converts a world position to screen coordinate. Z value of the returned vector denotes if it's a valid screen coordinate, 1 - valid, 0 - otherwise.

Will revise wiki page after being merged.