### PR TITLE
Update Traitors Challenge - minor gameplay tewaks

### DIFF
--- a/reactivedrop/content/traitors_challenge/resource/challenges/traitors.txt
+++ b/reactivedrop/content/traitors_challenge/resource/challenges/traitors.txt
@@ -53,5 +53,7 @@
 		"asw_sentry_top_flamer_dmg_override" "50"
 		"asw_sentry_top_machinegun_dmg_override" "0"
 		"asw_sentry_top_machinegun_fire_rate" "0.1"
+		"rd_devastator_bullet_spread_duck" "30"
+		"rd_devastator_lockmode_enabled" "0"
 	}
 }

--- a/reactivedrop/content/traitors_challenge/scripts/game_sounds_rd_traitors.txt
+++ b/reactivedrop/content/traitors_challenge/scripts/game_sounds_rd_traitors.txt
@@ -92,7 +92,7 @@
 	"wave"	"explosions/t7501.wav"
 }
 
-"Traitors.Music_IAF_Win"
+"Traitors.Music_IAF_Win1"
 {
 	"channel"	"CHAN_STATIC"
 	"volume"	"1.000"
@@ -100,14 +100,10 @@
 
 	"soundlevel"	"SNDLVL_NONE"
 
-	"rndwave"
-	{
-		"wave"	"*#music/cossack_sandvich.wav"
-		"wave"	"*#music/fortress_reel.wav"
-	}
+	"wave"	"*#music/cossack_sandvich.wav"
 }
 
-"Traitors.Music_Traitor_Win"
+"Traitors.Music_IAF_Win2"
 {
 	"channel"	"CHAN_STATIC"
 	"volume"	"1.000"
@@ -115,14 +111,32 @@
 
 	"soundlevel"	"SNDLVL_NONE"
 
-	"rndwave"
-	{
-		"wave"	"*#music/mvm_lost_wave.wav"
-		"wave"	"*#music/trombonetauntv2.mp3"
-	}
+	"wave"	"*#music/fortress_reel.wav"
 }
 
-"Traitors.Announcer_IAF_Win"
+"Traitors.Music_Traitor_Win1"
+{
+	"channel"	"CHAN_STATIC"
+	"volume"	"1.000"
+	"pitch"		"100"
+
+	"soundlevel"	"SNDLVL_NONE"
+
+	"wave"	"*#music/mvm_lost_wave.wav"
+}
+
+"Traitors.Music_Traitor_Win2"
+{
+	"channel"	"CHAN_STATIC"
+	"volume"	"1.000"
+	"pitch"		"100"
+
+	"soundlevel"	"SNDLVL_NONE"
+
+	"wave"	"*#music/trombonetauntv2.mp3"
+}
+
+"Traitors.Announcer_IAF_Win1"
 {
 	"channel"	"CHAN_VOICE"
 	"volume"	"1.000"
@@ -130,14 +144,10 @@
 
 	"soundlevel"	"SNDLVL_NONE"
 
-	"rndwave"
-	{
-		"wave"	"*#vo/traitors_challenge_command/announcer_victory.wav"
-		"wave"	"*#vo/traitors_challenge_command/announcer_we_succeeded.wav"
-	}
+	"wave"	"*#vo/traitors_challenge_command/announcer_victory.wav"
 }
 
-"Traitors.Announcer_Traitor_Win"
+"Traitors.Announcer_IAF_Win2"
 {
 	"channel"	"CHAN_VOICE"
 	"volume"	"1.000"
@@ -145,9 +155,27 @@
 
 	"soundlevel"	"SNDLVL_NONE"
 
-	"rndwave"
-	{
-		"wave"	"*#vo/traitors_challenge_command/announcer_you_failed.wav"
-		"wave"	"*#vo/traitors_challenge_command/announcer_traitors_won.wav"
-	}
+	"wave"	"*#vo/traitors_challenge_command/announcer_we_succeeded.wav"
+}
+
+"Traitors.Announcer_Traitor_Win1"
+{
+	"channel"	"CHAN_VOICE"
+	"volume"	"1.000"
+	"pitch"		"100"
+
+	"soundlevel"	"SNDLVL_NONE"
+
+	"wave"	"*#vo/traitors_challenge_command/announcer_you_failed.wav"
+}
+
+"Traitors.Announcer_Traitor_Win2"
+{
+	"channel"	"CHAN_VOICE"
+	"volume"	"1.000"
+	"pitch"		"100"
+
+	"soundlevel"	"SNDLVL_NONE"
+
+	"wave"	"*#vo/traitors_challenge_command/announcer_traitors_won.wav"
 }

--- a/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors.nut
+++ b/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors.nut
@@ -447,7 +447,7 @@ function RefreshSkillMenu(interval = 1) {
 	}
 }
 
-g_float_AbetRatio <- 1.5;
+g_float_AbetRatio <- 1.6;
 function RefreshMenu(hMarine) {
 	local i = -1;
 
@@ -945,8 +945,8 @@ function PlayMissionEndSound(strWinner) {
 	local hPlayer = null;
 	local music;
 	local voice;
-	music = MISSION_END_SOUND[strWinner].MUSIC;
-	voice = MISSION_END_SOUND[strWinner].VOICE;
+	music = MISSION_END_SOUND[strWinner].MUSIC[RandomHQUniformIntDistribution(0, 1)];
+	voice = MISSION_END_SOUND[strWinner].VOICE[RandomHQUniformIntDistribution(0, 1)];
 	while (hPlayer = Entities.FindByClassname(hPlayer, "player")) {
 		hPlayer.PrecacheSoundScript(music);
 		hPlayer.PrecacheSoundScript(voice);

--- a/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors_enums.nut
+++ b/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors_enums.nut
@@ -79,12 +79,24 @@ BOOMER_SOUND <- {
 
 MISSION_END_SOUND <- {
 	IAF = {
-		MUSIC = "Traitors.Music_IAF_Win",
-		VOICE = "Traitors.Announcer_IAF_Win",
+		MUSIC = [
+			"Traitors.Music_IAF_Win1",
+			"Traitors.Music_IAF_Win2",
+		],
+		VOICE = [
+			"Traitors.Announcer_IAF_Win1",
+			"Traitors.Announcer_IAF_Win2",
+		],
 	},
 	TRAITOR = {
-		MUSIC = "Traitors.Music_Traitor_Win",
-		VOICE = "Traitors.Announcer_Traitor_Win",
+		MUSIC = [
+			"Traitors.Music_Traitor_Win1",
+			"Traitors.Music_Traitor_Win2",
+		],
+		VOICE = [
+			"Traitors.Announcer_Traitor_Win1",
+			"Traitors.Announcer_Traitor_Win2",
+		],
 	},
 };
 

--- a/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors_map_handler.nut
+++ b/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors_map_handler.nut
@@ -224,7 +224,7 @@ function SetMapHandler() {
 					if (g_int_Counter > g_int_MapKillCounter[1] && temp.y < 4950) {
 						hMarine.TakeDamage(4, DAMAGE_TYPE.DMG_FALL, null);
 					}
-					if (g_int_Counter > g_int_MapKillCounter[2] && temp.z < 6068) {
+					if (g_int_Counter > g_int_MapKillCounter[2] && temp.y < 6068) {
 						hMarine.TakeDamage(4, DAMAGE_TYPE.DMG_FALL, null);
 					}
 				}
@@ -657,7 +657,7 @@ function SetMapHandler() {
 					if (temp.x < 1800 && temp.y < -2800) {
 						hMarine.TakeDamage(5, DAMAGE_TYPE.DMG_FALL, null);
 					}
-					if (temp.x < 1500 && temp.y < -2800) {
+					if (temp.x > 500 && temp.x < 1500 && temp.y < -2800) {
 						hMarine.Die();
 					}
 				}

--- a/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors_map_handler.nut
+++ b/reactivedrop/content/traitors_challenge/scripts/vscripts/challenge_traitors_map_handler.nut
@@ -813,6 +813,16 @@ function SetMapHandler() {
 					if (temp.z > 250) {
 						hMarine.TakeDamage(1, DAMAGE_TYPE.DMG_FALL, null);
 					}
+					if (temp.x < 890 && ((temp.x>365&&temp.y>2662) || temp.y > 3085)) { //防止下地底
+						hMarine.TakeDamage(50, DAMAGE_TYPE.DMG_FALL, null);
+					}
+
+					if (g_int_MapKillCounter[0] == INT_MAX && (temp.x >= -4350 && temp.x <= -4100) && temp.y >= 2365) {
+						g_int_MapKillCounter[0] = g_int_Counter + 600;
+					}
+					if (g_int_Counter > g_int_MapKillCounter[0] && !(temp.x <= -3100 && temp.y >= 1400 && temp.z >= -500)) {
+						hMarine.TakeDamage(10, DAMAGE_TYPE.DMG_FALL, null);
+					}
 				}
 			};
 			break;


### PR DESCRIPTION
1. Fix two map damage zone bugs
2. Fix end game sound overlapping
3. Minor balance tweaks. 3.1 Disable lock-mode of devastator.
3.2 Slightly reduce devastator damage.
3.3 Slightly increace the threshold ratio of converting marines from 1.5 to 1.6