### PR TITLE
Features: Weapons: Revised bullet spread cones.

### DIFF
--- a/reactivedrop/resource/swarmopedia.txt
+++ b/reactivedrop/resource/swarmopedia.txt
@@ -907,6 +907,11 @@
 			"StoppingPower" {}
 			"BulletSpread" {
 				"Base" "7"
+				"Flattened" "1"
+			}
+			"Generic" {
+				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
+				"Caption" "#rd_weapon_fact_more_accurate_while_crouching"
 			}
 			"FireRate" {}
 			"Ammo" {}
@@ -962,6 +967,10 @@
 			"StoppingPower" {}
 			"BulletSpread" {
 				"Base" "22"
+			}
+			"Generic" {
+				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
+				"Caption" "#rd_weapon_fact_more_accurate_while_crouching"
 			}
 			"FireRate" {}
 			"Ammo" {}
@@ -1341,6 +1350,10 @@
 			"StoppingPower" {}
 			"BulletSpread" {
 				"Base" "22"
+			}
+			"Generic" {
+				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
+				"Caption" "#rd_weapon_fact_more_accurate_while_crouching"
 			}
 			"FireRate" {}
 			"Ammo" {}
@@ -2145,6 +2158,10 @@
 			"BulletSpread" {
 				"Base" "11"
 			}
+			"Generic" {
+				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
+				"Caption" "#rd_weapon_fact_more_accurate_while_crouching"
+			}
 			"Piercing" {
 				"Precision" "1"
 				"Skill" "ASW_MARINE_SKILL_STOPPING_POWER"
@@ -2153,10 +2170,6 @@
 			"FireRate" {}
 			"Ammo" {}
 			"ReloadTime" {}
-			"Generic" {
-				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
-				"Caption" "#rd_weapon_fact_more_accurate_while_crouching"
-			}
 			"Generic" {
 				"Icon" "swarm/swarmopedia/fact/heavy"
 				"Caption" "#rd_weapon_fact_slow_movement_while_held"

--- a/reactivedrop/resource/swarmopedia.txt
+++ b/reactivedrop/resource/swarmopedia.txt
@@ -2248,6 +2248,7 @@
 				"StoppingPower" {}
 				"BulletSpread" {
 					"Base" "30"
+					"Flattened" "1"
 				}
 				"Ammo" {}
 			}

--- a/reactivedrop/resource/swarmopedia.txt
+++ b/reactivedrop/resource/swarmopedia.txt
@@ -833,6 +833,10 @@
 			"BulletSpread" {
 				"Base" "3"
 			}
+			"Generic" {
+				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
+				"Caption" "#rd_weapon_fact_more_accurate_while_crouching"
+			}
 			"FireRate" {
 				"Skill" "ASW_MARINE_SKILL_ENGINEERING"
 				"SubSkill" "ASW_MARINE_SUBSKILL_ENGINEERING_FIRERATE"
@@ -967,6 +971,7 @@
 			"StoppingPower" {}
 			"BulletSpread" {
 				"Base" "22"
+				"Flattened" "1"
 			}
 			"Generic" {
 				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
@@ -1350,6 +1355,7 @@
 			"StoppingPower" {}
 			"BulletSpread" {
 				"Base" "22"
+				"Flattened" "1"
 			}
 			"Generic" {
 				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
@@ -1541,6 +1547,10 @@
 			"StoppingPower" {}
 			"BulletSpread" {
 				"Base" "3"
+			}
+			"Generic" {
+				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
+				"Caption" "#rd_weapon_fact_more_accurate_while_crouching"
 			}
 			"FireRate" {}
 			"Ammo" {}
@@ -2210,6 +2220,13 @@
 				"SubSkill" "ASW_MARINE_SUBSKILL_ACCURACY_RIFLE_DMG"
 			}
 			"StoppingPower" {}
+			"BulletSpread" {
+				"Base"	"3"
+			}
+			"Generic" {
+				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
+				"Caption" "#rd_weapon_fact_more_accurate_while_crouching"
+			}
 			"Ammo" {}
 			"ReloadTime" {}
 			"Secondary" {
@@ -2546,6 +2563,10 @@
 			"BulletSpread" {
 				"Base" "20"
 				"Flattened" "1"
+			}
+			"Generic" {
+				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
+				"Caption" "#rd_weapon_fact_more_accurate_while_crouching"
 			}
 			"FireRate" {}
 			"Ammo" {

--- a/reactivedrop/resource/swarmopedia.txt
+++ b/reactivedrop/resource/swarmopedia.txt
@@ -2430,6 +2430,7 @@
 			"StoppingPower" {}
 			"BulletSpread" {
 				"Base" "3"
+				"Flattened" "1"
 			}
 			"Generic" {
 				"Icon" "swarm/swarmopedia/fact/accurate_crouch"

--- a/reactivedrop/resource/swarmopedia.txt
+++ b/reactivedrop/resource/swarmopedia.txt
@@ -769,6 +769,10 @@
 			"BulletSpread" {
 				"Base" "3"
 			}
+			"Generic" {
+				"Icon" "swarm/swarmopedia/fact/accurate_crouch"
+				"Caption" "#rd_weapon_fact_more_accurate_while_crouching"
+			}
 			"FireRate" {}
 			"Ammo" {}
 			"ReloadTime" {}

--- a/src/game/client/swarm/c_asw_weapon_rifle.cpp
+++ b/src/game/client/swarm/c_asw_weapon_rifle.cpp
@@ -31,6 +31,22 @@ C_ASW_Weapon_Rifle::~C_ASW_Weapon_Rifle()
 
 }
 
+
+const Vector& C_ASW_Weapon_Rifle::GetBulletSpread( void )
+{
+	static const Vector cone = VECTOR_CONE_3DEGREES;
+	static const Vector cone_duck = VECTOR_CONE_1DEGREES;
+
+	CASW_Marine* marine = GetMarine();
+
+	if ( marine )
+	{
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
+			return cone_duck;
+	}
+	return cone;
+}
+
 void C_ASW_Weapon_Rifle::SecondaryAttack( void )
 {
 	CASW_Player *pPlayer = GetCommander();

--- a/src/game/client/swarm/c_asw_weapon_rifle.h
+++ b/src/game/client/swarm/c_asw_weapon_rifle.h
@@ -26,11 +26,7 @@ public:
 	virtual void SecondaryAttack();
 	virtual bool SupportsBayonet();
 	virtual bool HasSecondaryExplosive( void ) const { return true; }
-	virtual const Vector& GetBulletSpread( void )
-	{
-		static Vector cone = VECTOR_CONE_3DEGREES;
-		return cone;
-	}
+	virtual const Vector& GetBulletSpread( void );
 
 	virtual bool SupportsGroundShooting() { return true; }
 

--- a/src/game/server/swarm/asw_weapon_rifle.cpp
+++ b/src/game/server/swarm/asw_weapon_rifle.cpp
@@ -56,6 +56,21 @@ void CASW_Weapon_Rifle::Precache( void )
 	UTIL_PrecacheOther( "env_entity_dissolver" );
 }
 
+const Vector& CASW_Weapon_Rifle::GetBulletSpread( void )
+{
+	static const Vector cone = VECTOR_CONE_3DEGREES;
+	static const Vector cone_duck = VECTOR_CONE_1DEGREES;
+
+	CASW_Marine* marine = GetMarine();
+
+	if ( marine )
+	{
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
+			return cone_duck;
+	}
+	return cone;
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 // Input  : &tr - 

--- a/src/game/server/swarm/asw_weapon_rifle.h
+++ b/src/game/server/swarm/asw_weapon_rifle.h
@@ -29,11 +29,7 @@ public:
 	
 	void	DoImpactEffect( trace_t &tr, int nDamageType );
 
-	virtual const Vector& GetBulletSpread( void )
-	{
-		static Vector cone = VECTOR_CONE_3DEGREES;
-		return cone;
-	}
+	virtual const Vector& GetBulletSpread( void );
 
 	virtual const float GetAutoAimAmount() { return AUTOAIM_2DEGREES * 0.3f; }
 	virtual bool ShouldFlareAutoaim() { return true; }

--- a/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
@@ -96,8 +96,8 @@ const Vector& CASW_Weapon_50CalMG::GetBulletSpread( void )
 
 const Vector& CASW_Weapon_50CalMG::GetAngularBulletSpread( void )
 {
-    static const Vector cone( 12, 60, 12 );									// VECTOR CONE 60 degrees with flattened X/Z (vertical) 12 degrees
-	static const Vector cone_duck( 6, 40, 6 );								// VECTOR CONE 40 degrees with flattened X/Z (vertical) 06 degrees
+    static const Vector cone( 10, 60, 10 );									// VECTOR CONE 60 degrees with flattened X/Z (vertical) 10 degrees
+	static const Vector cone_duck( 5, 40, 5 );								// VECTOR CONE 40 degrees with flattened X/Z (vertical) 05 degrees
 
 	CASW_Marine* marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
@@ -82,7 +82,7 @@ void CASW_Weapon_50CalMG::Precache()
 const Vector& CASW_Weapon_50CalMG::GetBulletSpread( void )
 {
     static const Vector cone( 0.17365, 0.08716, 0.17365 );					// VECTOR_CONE_20DEGREES with flattened Y (vertical) VECTOR_CONE_10DEGREES
-    static const Vector cone_duck = Vector( 0.13053, 0.04362, 0.13053 );	// VECTOR_CONE_15DEGREES with flattened Y (vertical) ECTOR_CONE_5DEGREES
+    static const Vector cone_duck = Vector( 0.08716, 0.04362, 0.08716 );	// VECTOR_CONE_10DEGREES with flattened Y (vertical) ECTOR_CONE_5DEGREES
 
 	CASW_Marine* marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
@@ -79,6 +79,21 @@ void CASW_Weapon_50CalMG::Precache()
 	BaseClass::Precache();
 }
 
+const Vector& CASW_Weapon_50CalMG::GetBulletSpread( void )
+{
+	static const Vector cone( 0.17365, 0.17365, 0.02 );					// VECTOR_CONE_20DEGREES with flattened Z
+	static const Vector cone_duck = Vector( 0.13053, 0.13053, 0.01 );	// VECTOR_CONE_15DEGREES with flattened Z
+
+	CASW_Marine* marine = GetMarine();
+
+	if ( marine )
+	{
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
+			return cone_duck;
+	}
+	return cone;
+}
+
 // just dry fire by default
 void CASW_Weapon_50CalMG::SecondaryAttack()
 {

--- a/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
@@ -81,8 +81,8 @@ void CASW_Weapon_50CalMG::Precache()
 
 const Vector& CASW_Weapon_50CalMG::GetBulletSpread( void )
 {
-	static const Vector cone( 0.17365, 0.02, 0.17365 );					// VECTOR_CONE_20DEGREES with flattened Y
-	static const Vector cone_duck = Vector( 0.13053, 0.01, 0.13053 );	// VECTOR_CONE_15DEGREES with flattened Y
+    static const Vector cone( 0.17365, 0.08716, 0.17365 );					// VECTOR_CONE_20DEGREES with flattened Y (vertical) from VECTOR_CONE_10DEGREES
+    static const Vector cone_duck = Vector( 0.13053, 0.04362, 0.13053 );	// VECTOR_CONE_15DEGREES with flattened Y (vertical) from VECTOR_CONE_5DEGREES
 
 	CASW_Marine* marine = GetMarine();
 
@@ -96,8 +96,8 @@ const Vector& CASW_Weapon_50CalMG::GetBulletSpread( void )
 
 const Vector& CASW_Weapon_50CalMG::GetAngularBulletSpread( void )
 {
-	static const Vector cone( 12, 60, 12 );
-	static const Vector cone_duck( 5, 40, 5 );
+    static const Vector cone( 12, 60, 12 );									// VECTOR CONE 60 degrees with flattened X/Z (vertical) 12 degrees
+	static const Vector cone_duck( 6, 40, 6 );								// VECTOR CONE 40 degrees with flattened X/Z (vertical) 06 degrees
 
 	CASW_Marine* marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
@@ -81,8 +81,23 @@ void CASW_Weapon_50CalMG::Precache()
 
 const Vector& CASW_Weapon_50CalMG::GetBulletSpread( void )
 {
-	static const Vector cone( 0.17365, 0.17365, 0.02 );					// VECTOR_CONE_20DEGREES with flattened Z
-	static const Vector cone_duck = Vector( 0.13053, 0.13053, 0.01 );	// VECTOR_CONE_15DEGREES with flattened Z
+	static const Vector cone( 0.17365, 0.02, 0.17365 );					// VECTOR_CONE_20DEGREES with flattened Y
+	static const Vector cone_duck = Vector( 0.13053, 0.01, 0.13053 );	// VECTOR_CONE_15DEGREES with flattened Y
+
+	CASW_Marine* marine = GetMarine();
+
+	if ( marine )
+	{
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
+			return cone_duck;
+	}
+	return cone;
+}
+
+const Vector& CASW_Weapon_50CalMG::GetAngularBulletSpread( void )
+{
+	static const Vector cone( 0, 60, 0 );
+	static const Vector cone_duck( 5, 40, 5 );
 
 	CASW_Marine* marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
@@ -81,8 +81,8 @@ void CASW_Weapon_50CalMG::Precache()
 
 const Vector& CASW_Weapon_50CalMG::GetBulletSpread( void )
 {
-    static const Vector cone( 0.17365, 0.08716, 0.17365 );					// VECTOR_CONE_20DEGREES with flattened Y (vertical) from VECTOR_CONE_10DEGREES
-    static const Vector cone_duck = Vector( 0.13053, 0.04362, 0.13053 );	// VECTOR_CONE_15DEGREES with flattened Y (vertical) from VECTOR_CONE_5DEGREES
+    static const Vector cone( 0.17365, 0.08716, 0.17365 );					// VECTOR_CONE_20DEGREES with flattened Y (vertical) VECTOR_CONE_10DEGREES
+    static const Vector cone_duck = Vector( 0.13053, 0.04362, 0.13053 );	// VECTOR_CONE_15DEGREES with flattened Y (vertical) ECTOR_CONE_5DEGREES
 
 	CASW_Marine* marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_50calmg_shared.cpp
@@ -96,7 +96,7 @@ const Vector& CASW_Weapon_50CalMG::GetBulletSpread( void )
 
 const Vector& CASW_Weapon_50CalMG::GetAngularBulletSpread( void )
 {
-	static const Vector cone( 0, 60, 0 );
+	static const Vector cone( 12, 60, 12 );
 	static const Vector cone_duck( 5, 40, 5 );
 
 	CASW_Marine* marine = GetMarine();

--- a/src/game/shared/swarm/asw_weapon_50calmg_shared.h
+++ b/src/game/shared/swarm/asw_weapon_50calmg_shared.h
@@ -24,12 +24,7 @@ public:
 
 	virtual void SecondaryAttack();
 
-	virtual const Vector& GetAngularBulletSpread()
-	{
-		static const Vector cone(60, 60, 10);
-		return cone;
-	}
-
+	virtual const Vector& GetAngularBulletSpread( void );
 	virtual const Vector& GetBulletSpread( void );
 
 #ifndef CLIENT_DLL

--- a/src/game/shared/swarm/asw_weapon_50calmg_shared.h
+++ b/src/game/shared/swarm/asw_weapon_50calmg_shared.h
@@ -30,11 +30,7 @@ public:
 		return cone;
 	}
 
-	virtual const Vector& GetBulletSpread( void )
-	{
-		static const Vector cone( 0.17365, 0.17365, 0.02 ); // VECTOR_CONE_20DEGREES with flattened Z
-		return cone;
-	}
+	virtual const Vector& GetBulletSpread( void );
 
 #ifndef CLIENT_DLL
 	DECLARE_DATADESC();

--- a/src/game/shared/swarm/asw_weapon_autogun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_autogun_shared.cpp
@@ -177,7 +177,16 @@ int CASW_Weapon_Autogun::GetWeaponSubSkillId()
 
 const Vector& CASW_Weapon_Autogun::GetBulletSpread( void )
 {
-	static const Vector cone = VECTOR_CONE_7DEGREES;
+	static const Vector cone = Vector( 0.06105, 0.06105, 0.02);			// VECTOR_CONE_7DEGREES with flattened Z
+    static const Vector cone_duck = Vector( 0.03490, 0.03490, 0.01 );	// VECTOR_CONE_4DEGREES with flattened Z
+
+	CASW_Marine *marine = GetMarine();
+
+	if ( marine )
+	{
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
+			return cone_duck;
+	}
 	return cone;
 }
 

--- a/src/game/shared/swarm/asw_weapon_autogun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_autogun_shared.cpp
@@ -178,7 +178,7 @@ int CASW_Weapon_Autogun::GetWeaponSubSkillId()
 const Vector& CASW_Weapon_Autogun::GetBulletSpread( void )
 {
 	static const Vector cone = Vector( 0.06105, 0.06105, 0.02);			// VECTOR_CONE_7DEGREES with flattened Z
-    static const Vector cone_duck = Vector( 0.03490, 0.03490, 0.01 );	// VECTOR_CONE_4DEGREES with flattened Z
+	static const Vector cone_duck = Vector( 0.03490, 0.03490, 0.01 );	// VECTOR_CONE_4DEGREES with flattened Z
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_autogun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_autogun_shared.cpp
@@ -177,8 +177,8 @@ int CASW_Weapon_Autogun::GetWeaponSubSkillId()
 
 const Vector& CASW_Weapon_Autogun::GetBulletSpread( void )
 {
-	static const Vector cone = Vector( 0.06105, 0.06105, 0.02);			// VECTOR_CONE_7DEGREES with flattened Z
-	static const Vector cone_duck = Vector( 0.03490, 0.03490, 0.01 );	// VECTOR_CONE_4DEGREES with flattened Z
+	static const Vector cone = Vector( 0.06105, 0.02, 0.06105 );		// VECTOR_CONE_7DEGREES with flattened Y
+	static const Vector cone_duck = Vector( 0.03490, 0.01, 0.03490 );	// VECTOR_CONE_4DEGREES with flattened Y
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_autogun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_autogun_shared.cpp
@@ -177,8 +177,8 @@ int CASW_Weapon_Autogun::GetWeaponSubSkillId()
 
 const Vector& CASW_Weapon_Autogun::GetBulletSpread( void )
 {
-	static const Vector cone = Vector( 0.06105, 0.02, 0.06105 );		// VECTOR_CONE_7DEGREES with flattened Y (vertical)
-	static const Vector cone_duck = Vector( 0.03490, 0.01, 0.03490 );	// VECTOR_CONE_4DEGREES with flattened Y (vertical)
+	static const Vector cone = Vector( 0.06105, 0.02618, 0.06105 );			// VECTOR_CONE_7DEGREES with flattened Y (vertical) VECTOR_CONE_3DEGREES
+	static const Vector cone_duck = Vector( 0.03490, 0.00873, 0.03490 );	// VECTOR_CONE_4DEGREES with flattened Y (vertical) VECTOR_CONE_1DEGREES
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_autogun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_autogun_shared.cpp
@@ -177,8 +177,8 @@ int CASW_Weapon_Autogun::GetWeaponSubSkillId()
 
 const Vector& CASW_Weapon_Autogun::GetBulletSpread( void )
 {
-	static const Vector cone = Vector( 0.06105, 0.02, 0.06105 );		// VECTOR_CONE_7DEGREES with flattened Y
-	static const Vector cone_duck = Vector( 0.03490, 0.01, 0.03490 );	// VECTOR_CONE_4DEGREES with flattened Y
+	static const Vector cone = Vector( 0.06105, 0.02, 0.06105 );		// VECTOR_CONE_7DEGREES with flattened Y (vertical)
+	static const Vector cone_duck = Vector( 0.03490, 0.01, 0.03490 );	// VECTOR_CONE_4DEGREES with flattened Y (vertical)
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_combat_rifle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_combat_rifle_shared.cpp
@@ -87,6 +87,21 @@ void CASW_Weapon_CombatRifle::Precache()
 	BaseClass::Precache();
 }
 
+const Vector& CASW_Weapon_CombatRifle::GetBulletSpread( void )
+{
+	static const Vector cone = VECTOR_CONE_3DEGREES;
+	static const Vector cone_duck = VECTOR_CONE_1DEGREES;
+
+	CASW_Marine* marine = GetMarine();
+
+	if ( marine )
+	{
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
+			return cone_duck;
+	}
+	return cone;
+}
+
 float CASW_Weapon_CombatRifle::GetWeaponBaseDamageOverride()
 {
 	extern ConVar rd_combat_rifle_dmg_base;

--- a/src/game/shared/swarm/asw_weapon_combat_rifle_shared.h
+++ b/src/game/shared/swarm/asw_weapon_combat_rifle_shared.h
@@ -24,6 +24,8 @@ public:
 
 	virtual void SecondaryAttack();
 
+	virtual const Vector& GetBulletSpread( void );
+
 	virtual const Vector& GetAngularBulletSpread()
 	{
 		static const Vector cone(60, 60, 10);

--- a/src/game/shared/swarm/asw_weapon_combat_rifle_shared.h
+++ b/src/game/shared/swarm/asw_weapon_combat_rifle_shared.h
@@ -28,7 +28,7 @@ public:
 
 	virtual const Vector& GetAngularBulletSpread()
 	{
-		static const Vector cone(60, 60, 10);
+		static const Vector cone( 10, 60, 10 );	// VECTOR CONE 60 degrees with flattened X/Z (vertical) 10 degrees
 		return cone;
 	}
 

--- a/src/game/shared/swarm/asw_weapon_deagle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_deagle_shared.cpp
@@ -175,8 +175,8 @@ void CASW_Weapon_DEagle::ItemBusyFrame()
 
 const Vector &CASW_Weapon_DEagle::GetBulletSpread( void )
 {
-	const static Vector cone = Vector( 0.13053, 0.13053, 0.02 );	// VECTOR_CONE_15DEGREES with flattened Z
-	const static Vector cone_duck = Vector( 0.05234, 0.05234, 0.01 ); // VECTOR_CONE_6DEGREES with flattened Z
+    const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y
+    const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_deagle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_deagle_shared.cpp
@@ -175,8 +175,8 @@ void CASW_Weapon_DEagle::ItemBusyFrame()
 
 const Vector &CASW_Weapon_DEagle::GetBulletSpread( void )
 {
-    const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y
-    const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y
+    const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y (vertical)
+    const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical)
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_deagle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_deagle_shared.cpp
@@ -175,8 +175,8 @@ void CASW_Weapon_DEagle::ItemBusyFrame()
 
 const Vector &CASW_Weapon_DEagle::GetBulletSpread( void )
 {
-    const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y (vertical)
-    const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical)
+	static const Vector cone = Vector( 0.13053, 0.02618, 0.13053 );			// VECTOR_CONE_15DEGREES with flattened Y (vertical) VECTOR_CONE_3DEGREES
+	static const Vector cone_duck = Vector( 0.05234, 0.00873, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical) VECTOR_CONE_1DEGREES
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_heavy_rifle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_heavy_rifle_shared.cpp
@@ -154,7 +154,7 @@ float CASW_Weapon_Heavy_Rifle::GetFireRate()
 const Vector &CASW_Weapon_Heavy_Rifle::GetBulletSpread( void )
 {
 	const static Vector vec15degrees = Vector( 0.13053, 0.02618, 0.13053 );	// VECTOR_CONE_15DEGREES with y as VECTOR_CONE_3DEGREES
-	const static Vector vec6degrees = Vector( 0.05234, 0.02618, 0.05234 );		// VECTOR_CONE_6DEGREES with y as VECTOR_CONE_3DEGREES
+	const static Vector vec6degrees = Vector( 0.05234, 0.02618, 0.05234 );	// VECTOR_CONE_6DEGREES with y as VECTOR_CONE_3DEGREES
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_heavy_rifle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_heavy_rifle_shared.cpp
@@ -153,8 +153,8 @@ float CASW_Weapon_Heavy_Rifle::GetFireRate()
 
 const Vector &CASW_Weapon_Heavy_Rifle::GetBulletSpread( void )
 {
-	const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y (vertical)
-	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical)
+	static const Vector cone = Vector( 0.13053, 0.02618, 0.13053 );			// VECTOR_CONE_15DEGREES with flattened Y (vertical) VECTOR_CONE_3DEGREES
+	static const Vector cone_duck = Vector( 0.05234, 0.00873, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical) VECTOR_CONE_1DEGREES
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_heavy_rifle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_heavy_rifle_shared.cpp
@@ -153,8 +153,8 @@ float CASW_Weapon_Heavy_Rifle::GetFireRate()
 
 const Vector &CASW_Weapon_Heavy_Rifle::GetBulletSpread( void )
 {
-	const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y
-	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y
+	const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y (vertical)
+	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical)
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_heavy_rifle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_heavy_rifle_shared.cpp
@@ -153,17 +153,17 @@ float CASW_Weapon_Heavy_Rifle::GetFireRate()
 
 const Vector &CASW_Weapon_Heavy_Rifle::GetBulletSpread( void )
 {
-	const static Vector vec15degrees = Vector( 0.13053, 0.02618, 0.13053 );	// VECTOR_CONE_15DEGREES with y as VECTOR_CONE_3DEGREES
-	const static Vector vec6degrees = Vector( 0.05234, 0.02618, 0.05234 );	// VECTOR_CONE_6DEGREES with y as VECTOR_CONE_3DEGREES
+	const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y
+	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y
 
 	CASW_Marine *marine = GetMarine();
 
 	if ( marine )
 	{
 		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking && !m_bFastFire )
-			return vec6degrees;
+			return cone_duck;
 	}
-	return vec15degrees;
+	return cone;
 }
 
 void CASW_Weapon_Heavy_Rifle::StopFastFire()

--- a/src/game/shared/swarm/asw_weapon_medrifle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_medrifle_shared.cpp
@@ -347,8 +347,8 @@ void CASW_Weapon_MedRifle::WeaponIdle( void )
 
 const Vector& CASW_Weapon_MedRifle::GetBulletSpread( void )
 {
-	static const Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y (vertical)
-	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical)
+	static const Vector cone = Vector( 0.13053, 0.02618, 0.13053 );			// VECTOR_CONE_15DEGREES with flattened Y (vertical) VECTOR_CONE_3DEGREES
+	static const Vector cone_duck = Vector( 0.05234, 0.00873, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical) VECTOR_CONE_1DEGREES
 
 	CASW_Marine* marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_medrifle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_medrifle_shared.cpp
@@ -347,14 +347,14 @@ void CASW_Weapon_MedRifle::WeaponIdle( void )
 
 const Vector& CASW_Weapon_MedRifle::GetBulletSpread( void )
 {
-	static const Vector cone = Vector( 0.13053, 0.13053, 0.02 );	// VECTOR_CONE_15DEGREES with flattened Z
-	const static Vector cone_duck = Vector(0.05234, 0.05234, 0.01); // VECTOR_CONE_6DEGREES with flattened Z
+	static const Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y
+	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y
 
 	CASW_Marine* marine = GetMarine();
 
-	if (marine)
+	if ( marine )
 	{
-		if (marine->GetLocalVelocity().IsZero() && marine->m_bWalking)
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
 			return cone_duck;
 	}
 	return cone;

--- a/src/game/shared/swarm/asw_weapon_medrifle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_medrifle_shared.cpp
@@ -347,8 +347,8 @@ void CASW_Weapon_MedRifle::WeaponIdle( void )
 
 const Vector& CASW_Weapon_MedRifle::GetBulletSpread( void )
 {
-	static const Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y
-	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y
+	static const Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y (vertical)
+	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical)
 
 	CASW_Marine* marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_minigun.cpp
+++ b/src/game/shared/swarm/asw_weapon_minigun.cpp
@@ -442,8 +442,8 @@ int CASW_Weapon_Minigun::GetWeaponSubSkillId()
 
 const Vector &CASW_Weapon_Minigun::GetBulletSpread( void )
 {
-	const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y (vertical)
-	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical)
+	const static Vector cone = Vector( 0.13053, 0.02618, 0.13053 );			// VECTOR_CONE_15DEGREES with flattened Y (vertical) VECTOR_CONE_3DEGREES
+	const static Vector cone_duck = Vector( 0.05234, 0.00873, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical) VECTOR_CONE_1DEGREES
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_minigun.cpp
+++ b/src/game/shared/swarm/asw_weapon_minigun.cpp
@@ -442,8 +442,8 @@ int CASW_Weapon_Minigun::GetWeaponSubSkillId()
 
 const Vector &CASW_Weapon_Minigun::GetBulletSpread( void )
 {
-	const static Vector cone = Vector( 0.13053, 0.13053, 0.02 );	// VECTOR_CONE_15DEGREES with flattened Z
-	const static Vector cone_duck = Vector( 0.05234, 0.05234, 0.01 ); // VECTOR_CONE_6DEGREES with flattened Z
+	const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y
+	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_minigun.cpp
+++ b/src/game/shared/swarm/asw_weapon_minigun.cpp
@@ -442,8 +442,8 @@ int CASW_Weapon_Minigun::GetWeaponSubSkillId()
 
 const Vector &CASW_Weapon_Minigun::GetBulletSpread( void )
 {
-	const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y
-	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y
+	const static Vector cone = Vector( 0.13053, 0.02, 0.13053 );		// VECTOR_CONE_15DEGREES with flattened Y (vertical)
+	const static Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical)
 
 	CASW_Marine *marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_pdw_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_pdw_shared.cpp
@@ -173,6 +173,21 @@ void CASW_Weapon_PDW::Precache()
 	BaseClass::Precache();
 }
 
+const Vector& CASW_Weapon_PDW::GetBulletSpread( void )
+{
+	static const Vector cone = VECTOR_CONE_3DEGREES;
+	static const Vector cone_duck = VECTOR_CONE_1DEGREES;
+
+	CASW_Marine* marine = GetMarine();
+
+	if ( marine )
+	{
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
+			return cone_duck;
+	}
+	return cone;
+}
+
 void CASW_Weapon_PDW::PrimaryAttack()
 {
 	// If my clip is empty (and I use clips) start reload

--- a/src/game/shared/swarm/asw_weapon_pdw_shared.h
+++ b/src/game/shared/swarm/asw_weapon_pdw_shared.h
@@ -30,12 +30,8 @@ public:
 	virtual int GetWeaponSubSkillId();
 
 	virtual const float GetAutoAimAmount() { return AUTOAIM_2DEGREES; }	
-	virtual const Vector& GetBulletSpread( void )
-	{
-		static const Vector cone = VECTOR_CONE_3DEGREES; //VECTOR_CONE_20DEGREES;
+	virtual const Vector& GetBulletSpread( void );
 
-		return cone;
-	}
 	virtual bool ShouldFlareAutoaim() { return true; }
 
 	virtual void PrimaryAttack();

--- a/src/game/shared/swarm/asw_weapon_prifle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_prifle_shared.cpp
@@ -78,6 +78,21 @@ void CASW_Weapon_PRifle::Precache()
 	BaseClass::Precache();
 }
 
+const Vector& CASW_Weapon_PRifle::GetBulletSpread( void )
+{
+	static const Vector cone = VECTOR_CONE_3DEGREES;
+	static const Vector cone_duck = VECTOR_CONE_1DEGREES;
+
+	CASW_Marine* marine = GetMarine();
+
+	if ( marine )
+	{
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
+			return cone_duck;
+	}
+	return cone;
+}
+
 float CASW_Weapon_PRifle::GetFireRate()
 {
 	float flRate = BaseClass::GetFireRate();

--- a/src/game/shared/swarm/asw_weapon_prifle_shared.h
+++ b/src/game/shared/swarm/asw_weapon_prifle_shared.h
@@ -29,6 +29,7 @@ public:
 	virtual int GetWeaponSkillId();
 	virtual int GetWeaponSubSkillId();
 	virtual void SecondaryAttack();
+	virtual const Vector& GetBulletSpread( void );
 
 	#ifndef CLIENT_DLL
 		DECLARE_DATADESC();

--- a/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
@@ -139,12 +139,12 @@ CASW_Weapon_Shotgun::~CASW_Weapon_Shotgun()
 }
 
 
-const Vector &CASW_Weapon_Shotgun::GetBulletSpread( void )
+const Vector& CASW_Weapon_Shotgun::GetBulletSpread( void )
 {
 	static const Vector cone = VECTOR_CONE_20DEGREES;
 	static const Vector cone_duck = VECTOR_CONE_15DEGREES;
 
-	CASW_Marine *marine = GetMarine();
+	CASW_Marine* marine = GetMarine();
 
 	if ( marine )
 	{
@@ -154,12 +154,12 @@ const Vector &CASW_Weapon_Shotgun::GetBulletSpread( void )
 	return cone;
 }
 
-const Vector &CASW_Weapon_Shotgun::GetAngularBulletSpread( void )
+const Vector& CASW_Weapon_Shotgun::GetAngularBulletSpread( void )
 {
 	static const Vector cone( 22, 22, 12 );
 	static const Vector cone_duck( 16, 16, 6 );
 
-	CASW_Marine *marine = GetMarine();
+	CASW_Marine* marine = GetMarine();
 
 	if ( marine )
 	{

--- a/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
@@ -138,6 +138,37 @@ CASW_Weapon_Shotgun::~CASW_Weapon_Shotgun()
 
 }
 
+
+const Vector &CASW_Weapon_Shotgun::GetBulletSpread( void )
+{
+	static const Vector cone = VECTOR_CONE_20DEGREES;
+	static const Vector cone_duck = VECTOR_CONE_15DEGREES;
+
+	CASW_Marine *marine = GetMarine();
+
+	if ( marine )
+	{
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
+			return cone_duck;
+	}
+	return cone;
+}
+
+const Vector &CASW_Weapon_Shotgun::GetAngularBulletSpread( void )
+{
+	static const Vector cone( 22, 22, 12 );
+	static const Vector cone_duck( 16, 16, 6 );
+
+	CASW_Marine *marine = GetMarine();
+
+	if ( marine )
+	{
+		if ( marine->GetLocalVelocity().IsZero() && marine->m_bWalking )
+			return cone_duck;
+	}
+	return cone;
+}
+
 Activity CASW_Weapon_Shotgun::GetPrimaryAttackActivity( void )
 {
 	return ACT_VM_PRIMARYATTACK;

--- a/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
@@ -156,7 +156,7 @@ const Vector& CASW_Weapon_Shotgun::GetBulletSpread( void )
 
 const Vector& CASW_Weapon_Shotgun::GetAngularBulletSpread( void )
 {
-	static const Vector cone( 2, 22, 2 );
+	static const Vector cone( 12, 22, 12 );
 	static const Vector cone_duck( 6, 16, 6 );
 
 	CASW_Marine* marine = GetMarine();

--- a/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
@@ -141,8 +141,8 @@ CASW_Weapon_Shotgun::~CASW_Weapon_Shotgun()
 
 const Vector& CASW_Weapon_Shotgun::GetBulletSpread( void )
 {
-	static const Vector cone = VECTOR_CONE_20DEGREES;
-	static const Vector cone_duck = VECTOR_CONE_15DEGREES;
+    static const Vector cone = Vector( 0.17365, 0.02, 0.17365 );		// VECTOR_CONE_20DEGREES with flattened Y
+    static const Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y
 
 	CASW_Marine* marine = GetMarine();
 
@@ -156,8 +156,8 @@ const Vector& CASW_Weapon_Shotgun::GetBulletSpread( void )
 
 const Vector& CASW_Weapon_Shotgun::GetAngularBulletSpread( void )
 {
-	static const Vector cone( 22, 22, 12 );
-	static const Vector cone_duck( 16, 16, 6 );
+	static const Vector cone( 2, 22, 2 );
+	static const Vector cone_duck( 6, 16, 6 );
 
 	CASW_Marine* marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
@@ -141,8 +141,8 @@ CASW_Weapon_Shotgun::~CASW_Weapon_Shotgun()
 
 const Vector& CASW_Weapon_Shotgun::GetBulletSpread( void )
 {
-    static const Vector cone = Vector( 0.17365, 0.02, 0.17365 );		// VECTOR_CONE_20DEGREES with flattened Y (vertical)
-    static const Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical)
+    static const Vector cone = Vector( 0.17365, 0.08716, 0.17365 );			// VECTOR_CONE_20DEGREES with flattened Y (vertical) VECTOR_CONE_10DEGREES
+    static const Vector cone_duck = Vector( 0.13053, 0.04362, 0.13053 );	// VECTOR_CONE_15DEGREES with flattened Y (vertical) VECTOR_CONE_5DEGREES
 
 	CASW_Marine* marine = GetMarine();
 
@@ -156,8 +156,8 @@ const Vector& CASW_Weapon_Shotgun::GetBulletSpread( void )
 
 const Vector& CASW_Weapon_Shotgun::GetAngularBulletSpread( void )
 {
-	static const Vector cone( 12, 22, 12 );								// VECTOR CONE 22 degrees with flattened X/Z (vertical) 12 degrees
-	static const Vector cone_duck( 6, 16, 6 );							// VECTOR CONE 22 degrees with flattened X/Z (vertical) 06 degrees
+	static const Vector cone( 12, 22, 12 );									// VECTOR CONE 22 degrees with flattened X/Z (vertical) 12 degrees
+	static const Vector cone_duck( 6, 16, 6 );								// VECTOR CONE 22 degrees with flattened X/Z (vertical) 06 degrees
 
 	CASW_Marine* marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
@@ -141,8 +141,8 @@ CASW_Weapon_Shotgun::~CASW_Weapon_Shotgun()
 
 const Vector& CASW_Weapon_Shotgun::GetBulletSpread( void )
 {
-    static const Vector cone = Vector( 0.17365, 0.02, 0.17365 );		// VECTOR_CONE_20DEGREES with flattened Y
-    static const Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y
+    static const Vector cone = Vector( 0.17365, 0.02, 0.17365 );		// VECTOR_CONE_20DEGREES with flattened Y (vertical)
+    static const Vector cone_duck = Vector( 0.05234, 0.01, 0.05234 );	// VECTOR_CONE_6DEGREES with flattened Y (vertical)
 
 	CASW_Marine* marine = GetMarine();
 
@@ -156,8 +156,8 @@ const Vector& CASW_Weapon_Shotgun::GetBulletSpread( void )
 
 const Vector& CASW_Weapon_Shotgun::GetAngularBulletSpread( void )
 {
-	static const Vector cone( 12, 22, 12 );
-	static const Vector cone_duck( 6, 16, 6 );
+	static const Vector cone( 12, 22, 12 );								// VECTOR CONE 22 degrees with flattened X/Z (vertical) 12 degrees
+	static const Vector cone_duck( 6, 16, 6 );							// VECTOR CONE 22 degrees with flattened X/Z (vertical) 06 degrees
 
 	CASW_Marine* marine = GetMarine();
 

--- a/src/game/shared/swarm/asw_weapon_shotgun_shared.h
+++ b/src/game/shared/swarm/asw_weapon_shotgun_shared.h
@@ -53,8 +53,8 @@ public:
 	virtual bool ShouldFlareAutoaim() { return true; }
 	virtual bool SupportsDamageModifiers() { return true; }
 
-	virtual const Vector &GetBulletSpread( void );
-	virtual const Vector &GetAngularBulletSpread( void );
+	virtual const Vector& GetBulletSpread( void );
+	virtual const Vector& GetAngularBulletSpread( void );
 
 	#ifndef CLIENT_DLL
 		DECLARE_DATADESC();

--- a/src/game/shared/swarm/asw_weapon_shotgun_shared.h
+++ b/src/game/shared/swarm/asw_weapon_shotgun_shared.h
@@ -53,17 +53,8 @@ public:
 	virtual bool ShouldFlareAutoaim() { return true; }
 	virtual bool SupportsDamageModifiers() { return true; }
 
-	virtual const Vector& GetBulletSpread()
-	{
-		static const Vector cone = VECTOR_CONE_20DEGREES;
-		return cone;
-	}
-
-	virtual const Vector& GetAngularBulletSpread()
-	{
-		static const Vector cone(22,22,22);
-		return cone;
-	}
+	virtual const Vector &GetBulletSpread( void );
+	virtual const Vector &GetAngularBulletSpread( void );
 
 	#ifndef CLIENT_DLL
 		DECLARE_DATADESC();


### PR DESCRIPTION
### Weapons: Added crouch bullet spread cones to weapons that previously lacked them
[Discussion Thread](https://discord.com/channels/310381338538541056/1415277051761397760/1415277051761397760)

---

#### Description

Introduces dedicated bullet spread cones for crouching to weapons that previously lacked them.  
This improves aiming consistency and standardizes crouch behavior across the entire weapon set.

---

#### Affected Weapons
- [x] 22A3-1 Assault Rifle
  - Normal spread: 03° (wide) × 03° (tall) **→ unchanged**.
  - Crouch spread: 03° × 03° **→ 01° × 01°**.
- [x] 22A4-2 Combat Rifle
  - Normal spread: 03° × 03° **→ unchanged**.
  - Crouch spread: 03° × 03° **→ 01° × 01°**.
- [x] 22A5 Heavy Assault Rifle
  - Normal spread: 15° × 03° **→ unchanged.**
  - Crouch spread: 06° × 03° **→ 06° × 01°**.
- [x] 22A7-Z Prototype Assault Rifle
  - Normal spread: 03° × 03° **→ unchanged**.
  - Crouch spread: 03° × 03° **→ 01° × 01°**.
- [x] 50CMG4-1
  - Normal spread: 20° × ~2.5° **bugged! → 20° × 10°**.
  - Crouch spread: 20° × ~2.5° **bugged! → 10° × 05°**.
- [x] IAF Medical SMG
  - Normal spread: 15° × ~2.5° **bugged! → 15° × 03°**.
  - Crouch spread: 06° × ~1.5° **bugged! → 06° × 01°**.
- [x] IAF Minigun
  - Normal spread: 15° × ~2.5° **bugged! → 15° × 03°**.
  - Crouch spread: 06° × ~1.5° **bugged! → 06° × 01°**.
- [x] K80 Personal Defense Weapon
  - Normal spread: 03° × 03° **→ unchanged**.
  - Crouch spread: 03° × 03° **→ 01° × 01°**.
- [x] M42 Vindicator
  - Normal spread: 22° × 22° **→ 22° × 12°**.
  - Crouch spread: 22° × 22° **→ 16° × 06°**.
- [x] Model 35 Pump-action Shotgun
  - Normal spread: 22° × 22° **→ 22° × 12°**.
  - Crouch spread: 22° × 22° **→ 16° × 06°**.
- [x] PS50 Bulldog
  - Normal spread: 15° × ~2.5° **bugged! → 15° × 03°**.
  - Crouch spread: 06° × ~1.5° **bugged! → 06° × 01°**.
- [x] S23A SynTek Autogun
  - Normal spread: 07° × 07° **→ 07° × 03°**.
  - Crouch spread: 07° × 07° **→ 04° × 01°**.


---

#### Documentation
- [x] Updated Swarmopedia entries to reflect the new crouch spread mechanics and accuracy adjustments.

---

#### Technical Notes
- Implemented `GetBulletSpread()` and `GetAngularBulletSpread()` overrides for the affected weapons.  
- Added crouch-specific spread reductions consistent with existing weapon implementations.

---

#### Fixes
- Corrected vertical flattening errors in spread cone definitions.  
- Adjusted angular spread parameters for consistency across all weapon types.

---

#### Testing / Verification
- [x] Verified crouch accuracy visually in-game for all listed weapons.
