### PR TITLE
Improved auto close function

### DIFF
--- a/src/game/server/BasePropDoor.h
+++ b/src/game/server/BasePropDoor.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright Â© 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: A base class for model-based doors. The exact movement required to
 //			open or close the door is not dictated by this class, only that
@@ -154,7 +154,7 @@ private:
 
 	void DoorOpenMoveDone();
 	void DoorCloseMoveDone();
-	void DoorAutoCloseThink();
+	virtual void DoorAutoCloseThink();
 
 	void Lock();
 	void Unlock();

--- a/src/game/server/BasePropDoor.h
+++ b/src/game/server/BasePropDoor.h
@@ -154,6 +154,7 @@ private:
 
 	void DoorOpenMoveDone();
 	void DoorCloseMoveDone();
+	protected:
 	virtual void DoorAutoCloseThink();
 
 	void Lock();

--- a/src/game/server/swarm/asw_door.cpp
+++ b/src/game/server/swarm/asw_door.cpp
@@ -18,7 +18,7 @@
 #include "cvisibilitymonitor.h"
 #include "soundent.h"
 #include "asw_util_shared.h"
-#include "asw_gameresource.h"
+#include "asw_game_resource.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"

--- a/src/game/server/swarm/asw_door.cpp
+++ b/src/game/server/swarm/asw_door.cpp
@@ -479,7 +479,7 @@ void CASW_Door::DoorAutoCloseThink()
         {
             // In flWait seconds, DoorClose will fire, unless wait is -1, then door stays open
             SetMoveDoneTime(m_flAutoReturnDelay + 0.1);
-            SetMoveDone(&CBasePropDoor::DoorAutoCloseThink);
+            SetMoveDone(&CASW_Door::DoorAutoCloseThink);
         }
 
         return;

--- a/src/game/server/swarm/asw_door.cpp
+++ b/src/game/server/swarm/asw_door.cpp
@@ -441,7 +441,7 @@ void CASW_Door::OnDoorClosed( void )
 void CASW_Door::DoorAutoCloseThink()
 {
     
-    const float CLOSE_DIST = 350.0f;
+    const float CLOSE_DIST = 450.0f;
     bool bMarineNearby = false;
 
     if (ASWGameResource())

--- a/src/game/server/swarm/asw_door.cpp
+++ b/src/game/server/swarm/asw_door.cpp
@@ -18,6 +18,7 @@
 #include "cvisibilitymonitor.h"
 #include "soundent.h"
 #include "asw_util_shared.h"
+#include "asw_gameresource.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -436,6 +437,57 @@ void CASW_Door::OnDoorClosed( void )
 	}
 }
 
+// Purpose: Check if a marine is close to a door and if so prevent it from closing
+void CASW_Door::DoorAutoCloseThink()
+{
+    
+    const float CLOSE_DIST = 350.0f;
+    bool bMarineNearby = false;
+
+    if (ASWGameResource())
+    {
+        for (int i = 0; i < ASWGameResource()->GetMaxMarineResources(); i++)
+        {
+            CASW_Marine_Resource *pMR = ASWGameResource()->GetMarineResource(i);
+            CASW_Marine *pMarine = pMR ? pMR->GetMarineEntity() : NULL;
+            if (pMarine && pMarine->GetHealth() > 0)
+            {
+                float dist = (pMarine->GetAbsOrigin() - GetAbsOrigin()).Length();
+                if (dist < CLOSE_DIST)
+                {
+                    bMarineNearby = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (bMarineNearby)
+    {
+        // Don't auto-close if a marine is nearby. Try again soon.
+        SetNextThink(gpGlobals->curtime + 0.1);
+        return;
+    }
+    
+    if ( !DoorCanClose( true ) )
+    {
+        if (m_flAutoReturnDelay == -1)
+        {
+            SetNextThink( TICK_NEVER_THINK );
+        }
+        else
+        {
+            // In flWait seconds, DoorClose will fire, unless wait is -1, then door stays open
+            SetMoveDoneTime(m_flAutoReturnDelay + 0.1);
+            SetMoveDone(&CBasePropDoor::DoorAutoCloseThink);
+        }
+
+        return;
+    }
+
+    DoorClose();
+
+}
 
 //-----------------------------------------------------------------------------
 // Purpose: Returns whether the way is clear for the door to close.

--- a/src/game/server/swarm/asw_door.h
+++ b/src/game/server/swarm/asw_door.h
@@ -59,7 +59,7 @@ public:
 
 	void	GetNPCOpenData(CAI_BaseNPC *pNPC, opendata_t &opendata);
 
-	void	DoorClose( void );
+	
 	bool	DoorCanClose( bool bAutoClose );
 	void	DoorOpen( CBaseEntity *pOpenAwayFrom );
 

--- a/src/game/server/swarm/asw_door.h
+++ b/src/game/server/swarm/asw_door.h
@@ -155,7 +155,7 @@ public:
 private:
 
 	float m_fLastFullyWeldedSound;
-
+	void DoorAutoCloseThink();
 	void	SlideMove(const Vector &vecDestPosition, float flSpeed);
 	void	CalculateDoorVolume( Vector OpenPosition, Vector ClosedPosition, Vector *destMins, Vector *destMaxs );
 


### PR DESCRIPTION
Changes to  
asw_door.h
asw_door.cpp
BasePropDoor.h

moved autoclose from props.cpp to asw_door.cpp and improved it in the process to detect marines near doors and reschedule autoclosing if it attempts to autoclose when a marine is near a door

removed doorclose from asw_door.h when theres no door close function in asw_door.cpp