### PR TITLE
Features: asw_door: add DelayBeforeClose input

### DIFF
--- a/reactivedrop/fgd/swarm.fgd
+++ b/reactivedrop/fgd/swarm.fgd
@@ -3210,7 +3210,7 @@
 	soundopenoverride(sound) : "Fully Open Sound" : : "Sound played when the door has finished opening."
 	soundcloseoverride(sound) : "Fully Closed Sound" : "ASW_Door.Door2StopClose" : "Sound played when the door has finished closing."
 	soundmoveoverride(sound) : "Moving Sound" : "ASW_Door.Door2Open" : "Sound played when the door starts to move."
-	returndelay(integer) : "Delay Before close (-1 stay open)" : 5 : "Amount of time, in seconds, after the door has opened before it closes. If the value is set to -1, the door never closes itself."
+	returndelay(integer) : "Delay Before Close (-1 stay open)" : 5 : "Amount of time, in seconds, after the door has opened before it closes.  If the value is set to -1, the door never closes itself."
 	dmg(integer) : "Damage Inflicted When Blocked" : 0 : "Amount of damage done to entities that block the movement of this door, per frame."
 	
 	//soundlockedoverride(sound) : "Locked Sound" : : "Sound played when the player tries to open the door, and fails because it's locked."
@@ -3304,6 +3304,7 @@
 	output OnDestroyed(void) : "Fired when the door is knocked down."
 
 	// Inputs
+	input DelayBeforeClose(float) : "Amount of time, in seconds, after the door has opened before it closes.  If the value is set to -1, the door never closes itself."
 	input Open(void) : "Open the door, if it is not fully open."
 	input OpenAwayFrom(string) : "Open the door away from the specified entity."
 	input Close(void) : "Close the door, if it is not fully closed."

--- a/src/game/server/BasePropDoor.h
+++ b/src/game/server/BasePropDoor.h
@@ -173,7 +173,7 @@ private:
 	void OnEndBlocked( void );
 
 	// Input handlers
-	void InputAutoReturnDelay(inputdata_t &inputdata);
+	void InputDelayBeforeClose(inputdata_t &inputdata);
 	void InputClose(inputdata_t &inputdata);
 	void InputLock(inputdata_t &inputdata);
 	void InputOpen(inputdata_t &inputdata);

--- a/src/game/server/BasePropDoor.h
+++ b/src/game/server/BasePropDoor.h
@@ -173,6 +173,7 @@ private:
 	void OnEndBlocked( void );
 
 	// Input handlers
+	void InputAutoReturnDelay(inputdata_t &inputdata);
 	void InputClose(inputdata_t &inputdata);
 	void InputLock(inputdata_t &inputdata);
 	void InputOpen(inputdata_t &inputdata);

--- a/src/game/server/props.cpp
+++ b/src/game/server/props.cpp
@@ -4008,7 +4008,7 @@ BEGIN_DATADESC(CBasePropDoor)
 	DEFINE_FIELD( m_bFirstBlocked, FIELD_BOOLEAN ),
 	//DEFINE_FIELD(m_hDoorList, FIELD_CLASSPTR),	// Reconstructed
 	
-	DEFINE_INPUTFUNC(FIELD_FLOAT, "DelayBeforeClose", InputAutoReturnDelay),
+	DEFINE_INPUTFUNC(FIELD_FLOAT, "DelayBeforeClose", InputDelayBeforeClose),
 	DEFINE_INPUTFUNC(FIELD_VOID, "Open", InputOpen),
 	DEFINE_INPUTFUNC(FIELD_STRING, "OpenAwayFrom", InputOpenAwayFrom),
 	DEFINE_INPUTFUNC(FIELD_VOID, "Close", InputClose),
@@ -4454,7 +4454,7 @@ void CBasePropDoor::OnUse( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TY
 //-----------------------------------------------------------------------------
 // Purpose: Sets the door auto-return(auto-close) delay.
 //-----------------------------------------------------------------------------
-void CBasePropDoor::InputAutoReturnDelay( inputdata_t& inputdata )
+void CBasePropDoor::InputDelayBeforeClose( inputdata_t& inputdata )
 {
 	m_flAutoReturnDelay = inputdata.value.Float();
 }

--- a/src/game/server/props.cpp
+++ b/src/game/server/props.cpp
@@ -4008,6 +4008,7 @@ BEGIN_DATADESC(CBasePropDoor)
 	DEFINE_FIELD( m_bFirstBlocked, FIELD_BOOLEAN ),
 	//DEFINE_FIELD(m_hDoorList, FIELD_CLASSPTR),	// Reconstructed
 	
+	DEFINE_INPUTFUNC(FIELD_FLOAT, "DelayBeforeClose", InputAutoReturnDelay),
 	DEFINE_INPUTFUNC(FIELD_VOID, "Open", InputOpen),
 	DEFINE_INPUTFUNC(FIELD_STRING, "OpenAwayFrom", InputOpenAwayFrom),
 	DEFINE_INPUTFUNC(FIELD_VOID, "Close", InputClose),
@@ -4449,6 +4450,15 @@ void CBasePropDoor::OnUse( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TY
 	}
 }
 
+
+//-----------------------------------------------------------------------------
+// Purpose: Sets the door auto-return(auto-close) delay.
+//-----------------------------------------------------------------------------
+void CBasePropDoor::InputAutoReturnDelay( inputdata_t& inputdata )
+{
+	m_flAutoReturnDelay = inputdata.value.Float();
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Closes the door if it is not already closed.
 //-----------------------------------------------------------------------------
@@ -4461,7 +4471,6 @@ void CBasePropDoor::InputClose(inputdata_t &inputdata)
 	}
 }
 
-
 //-----------------------------------------------------------------------------
 // Purpose: Input handler that locks the door.
 //-----------------------------------------------------------------------------
@@ -4470,7 +4479,6 @@ void CBasePropDoor::InputLock(inputdata_t &inputdata)
 	Lock();
 }
 
-
 //-----------------------------------------------------------------------------
 // Purpose: Opens the door if it is not already open.
 //-----------------------------------------------------------------------------
@@ -4478,7 +4486,6 @@ void CBasePropDoor::InputOpen(inputdata_t &inputdata)
 {
 	OpenIfUnlocked(inputdata.pActivator, NULL);
 }
-
 
 //-----------------------------------------------------------------------------
 // Purpose: Opens the door away from a specified entity if it is not already open.


### PR DESCRIPTION
Add a new input `DelayBeforeClose` to the `asw_door` entity.

This input specifies the number of seconds after a door has opened
before it automatically closes. Setting the value to `-1` disables
automatic closing. The input is implemented in `CBasePropDoor` in code
and available in Hammer for `asw_door` entities.

Checklist:
- [x] Code changes implemented
- [x] Tests / Verification