### PR TITLE
Update to script: Last Stand key press change

### DIFF
--- a/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
+++ b/reactivedrop/content/infection/scripts/vscripts/challenge_asw_infection_base.nut
@@ -215,7 +215,7 @@ function Update()
 			if (hMarine && hMarine in g_teamHuman && !(hMarine in g_lastHuman))
 			{
 				local nButtons = NetProps.GetPropInt( hPlayer, "m_nButtons" );
-				if (nButtons & 16384)
+				if (nButtons & 278528)
 				{
 					UseLastStand(hMarine);
 				}


### PR DESCRIPTION
Activation of Last Stand mode now requires the crouch key to be pressed in addition to the melee key.
This is to allow players to continue making use of any strategies that may require the use of the melee key outside of Last Stand mode while Last Stand mode is available.