### PR TITLE
Features: Shaders: RDCharacter - enabled $flashlightnolambert and applied HVS to baseColor

### DIFF
--- a/src/materialsystem/stdshaders/character_dx9_helper.cpp
+++ b/src/materialsystem/stdshaders/character_dx9_helper.cpp
@@ -248,6 +248,8 @@ void DrawCharacter_DX9( CBaseVSShader *pShader, IMaterialVar **params, IShaderDy
 	CCharacter_DX9_Context *pContextData = reinterpret_cast< CCharacter_DX9_Context * > ( *pContextDataPtr );
 
 	bool bHasFlashlight = pShader->UsingFlashlight( params );
+	//bool bNoCull = IS_FLAG_SET( MATERIAL_VAR_NOCULL );
+	bool bFlashlightNoLambert = ( info.m_nFlashlightNoLambert != -1 ) && ( params[ info.m_nFlashlightNoLambert ]->GetIntValue() != 0 );
 	bool bIsDecal = IS_FLAG_SET( MATERIAL_VAR_DECAL );
 	bool bIsAlphaTested = IS_FLAG_SET( MATERIAL_VAR_ALPHATEST ) != 0;
 	BlendType_t nBlendType = pShader->EvaluateBlendRequirements( info.m_nBaseTexture, true );
@@ -844,7 +846,7 @@ void DrawCharacter_DX9( CBaseVSShader *pShader, IMaterialVar **params, IShaderDy
 				state.m_nDepthTweakConstant = PSREG_ENVMAP_TINT__SHADOW_TWEAKS; // NOTE: Reg 43 not available on < ps3.0!
 				state.m_nScreenScaleConstant = PSREG_FLASHLIGHT_SCREEN_SCALE;
 				state.m_nWorldToTextureConstant = PSREG_FLASHLIGHT_TO_WORLD_TEXTURE;
-				state.m_bFlashlightNoLambert = false;
+				state.m_bFlashlightNoLambert = bFlashlightNoLambert;
 				state.m_bSinglePassFlashlight = false;
 				pContextData->m_SemiStaticCmdsOut.SetPixelShaderFlashlightState( state );
 

--- a/src/materialsystem/stdshaders/character_ps20b.fxc
+++ b/src/materialsystem/stdshaders/character_ps20b.fxc
@@ -204,6 +204,13 @@ float4 main( PS_INPUT i ) : COLOR
 	
 	float4 baseColor = tex2Dsrgb( BaseTextureSampler, i.baseTexCoordDetailTexCoord.xy );
 
+#if HSV
+	float3 baseColorHSV = rgb2hsv(baseColor.rgb);
+	baseColorHSV.x = fmod(baseColorHSV.x + g_HsvParams.x, 1.0);
+	baseColorHSV.yz = clamp(baseColorHSV.yz * g_HsvParams.yz, 0.0, 1.0);
+	baseColor.xyz = lerp(baseColor.xyz, hsv2rgb(baseColorHSV), saturate(baseColor.a + g_fInverseBlendTintByBaseAlpha));
+#endif
+	
 	float flWrinkleAmount, flStretchAmount, flTextureAmount;
 	#if ( WRINKLEMAP )
 	{
@@ -378,13 +385,6 @@ float4 main( PS_INPUT i ) : COLOR
 
 	// Optionally use basealpha to blend in the diffuse modulation (saturated add of g_fInverseBlendTintByBaseAlpha turns this on/off)
 	diffuseLighting *= lerp( float3( 1.0f, 1.0f, 1.0f ), g_DiffuseModulation.rgb, saturate( baseColor.a + g_fInverseBlendTintByBaseAlpha ) );
-
-#if HSV
-	float3 albedoHSV = rgb2hsv(albedo.rgb);
-	albedoHSV.x = fmod(albedoHSV.x + g_HsvParams.x, 1.0);
-	albedoHSV.yz = clamp(albedoHSV.yz * g_HsvParams.yz, 0.0, 1.0);
-	albedo.xyz = lerp(albedo.xyz, hsv2rgb(albedoHSV), saturate(baseColor.a + g_fInverseBlendTintByBaseAlpha));
-#endif
 
 	float3 diffuseComponent = albedo * diffuseLighting;
 


### PR DESCRIPTION
### Shaders: RDCharacter - enabled $flashlightnolambert and applied HVS to baseColor

---

#### Description

- Added support for $flashlightnolambert, fixing non-Lambert flashlight behavior.
- Reordered shader flow to ensure HVS modifies baseColor at the start, directly affecting the base texture rather than post-processed color adjustments.

---

#### Testing / Verification

- [x] Shader successfully compiled and tested in-game.
- [x] HVS color modification and $flashlightnolambert behavior verified on RDCharacter models.