### PR TITLE
dont find entities which are marked for deletion

### DIFF
--- a/src/game/server/entitylist.cpp
+++ b/src/game/server/entitylist.cpp
@@ -599,6 +599,9 @@ CBaseEntity *CGlobalEntityList::FindEntityByClassname( CBaseEntity *pStartEntity
 			continue;
 		}
 
+		if ( pEntity->IsMarkedForDeletion() )
+			continue;
+
 		if ( pEntity->ClassMatches(szName) )
 			return pEntity;
 	}
@@ -727,6 +730,9 @@ CBaseEntity *CGlobalEntityList::FindEntityByName( CBaseEntity *pStartEntity, con
 			continue;
 		}
 
+		if ( ent->IsMarkedForDeletion() )
+			continue;
+
 		if ( !ent->m_iName.Get() )
 			continue;
 
@@ -788,6 +794,9 @@ CBaseEntity *CGlobalEntityList::FindEntityByModel( CBaseEntity *pStartEntity, co
 			continue;
 		}
 
+		if ( ent->IsMarkedForDeletion() )
+			continue;
+
 		if ( !ent->edict() || !ent->GetModelName() )
 			continue;
 
@@ -817,6 +826,9 @@ CBaseEntity	*CGlobalEntityList::FindEntityByTarget( CBaseEntity *pStartEntity, c
 			DevWarning( "NULL entity in global entity list!\n" );
 			continue;
 		}
+
+		if ( ent->IsMarkedForDeletion() )
+			continue;
 
 		if ( !ent->m_target )
 			continue;
@@ -889,6 +901,9 @@ CBaseEntity *CGlobalEntityList::FindEntityInSphere( CBaseEntity *pStartEntity, c
 			DevWarning( "NULL entity in global entity list!\n" );
 			continue;
 		}
+
+		if ( ent->IsMarkedForDeletion() )
+			continue;
 
 		if ( !ent->edict() )
 			continue;


### PR DESCRIPTION
was leading to vscript crashes in a typical while find entity loop especially if ran every tick. entity would be marked for deletion and deemed invalid with IsValid function, but the find function would resurrect it in the same tick, then trying to use the resurrected handle shortly afterwards would crash the game. Also now doing Destroy in the typical while find loop is fine