### PR TITLE
Fix #1027 Movement is slow and clunky on gravel textures

### DIFF
--- a/reactivedrop/scripts/surfaceproperties.txt
+++ b/reactivedrop/scripts/surfaceproperties.txt
@@ -562,7 +562,8 @@
 "gravel"
 {
 	"base"		"rock"
-	"friction"	"0.4"
+// asrd no sliding, feels horrible
+// "friction"	"0.4"
 	"stepleft"	"Gravel.StepLeft"
 	"stepright""Gravel.StepRight"
 }


### PR DESCRIPTION
- Fix #1027 

Materials that use a value `$surfaceprop gravel` make the marine movement slow and clunky, which feels bad especially when player plays on a server and has 70+ ping.

This happens because **gravel** surface is set to have `"friction"	"0.4"` instead of standard `0.8` in `reactivedrop/scripts/surfaceproperties.txt`

As I remember this was an issue in `rd-area9800PP2` map ending but was fixed at some point.

Now this is an issue in maps that use `blend_grass_gravel_01_lowdensity.vmt` and similar materials. Specifically the **Dark Carnival** campaign on workshop and the upcoming **Swamp Fever** campaign workshop port.

`blend_grass_gravel_01_lowdensity.vmt`, and similar materials, are shipped with RD so we can either change them to not use `$surfaceprop gravel` or we can change gravel to have standard friction `0.8`. I'm suggesting the 2nd option.

Note: see the comment of original Alien Swarm developers in `surfaceproperties.txt` 😺:
```
// asw no sliding, feels horrible
//	"friction"	"0.35"
```