### PR TITLE
Fix steam activation requestexperience crash upon new player join on previously active server

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -1,4 +1,4 @@
-//====== Copyright � 1996-2005, Valve Corporation, All rights reserved. =====//
+//====== Copyright © 1996-2005, Valve Corporation, All rights reserved. =====//
 //
 // Purpose: Client-side CBasePlayer.
 //

--- a/src/game/client/c_prop_vehicle.cpp
+++ b/src/game/client/c_prop_vehicle.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/client/c_sceneentity.cpp
+++ b/src/game/client/c_sceneentity.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/client/c_vehicle_choreo_generic.cpp
+++ b/src/game/client/c_vehicle_choreo_generic.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/client/cdll_bounded_cvars.cpp
+++ b/src/game/client/cdll_bounded_cvars.cpp
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/game/client/hud_base_account.cpp
+++ b/src/game/client/hud_base_account.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/client/hud_basetimer.cpp
+++ b/src/game/client/hud_basetimer.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: Draws a timer in the format "Minutes:Seconds"
 // Seconds are padded with zeros

--- a/src/game/client/hud_numericdisplay.cpp
+++ b/src/game/client/hud_numericdisplay.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/client/in_main.cpp
+++ b/src/game/client/in_main.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: builds an intended movement command to send to the server
 //

--- a/src/game/client/swarm/vgui/asw_hud_chat.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_chat.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose:  ASW version of hud_chat.cpp (exclude hud_chat.cpp from build)
 //

--- a/src/game/client/swarm/vgui/asw_scalable_text.cpp
+++ b/src/game/client/swarm/vgui/asw_scalable_text.cpp
@@ -1,4 +1,4 @@
-﻿#include "cbase.h"
+#include "cbase.h"
 #include <vgui_controls/Panel.h>
 #include "asw_scalable_text.h"
 #include <vgui/isurface.h>
@@ -112,3 +112,4 @@ float CASW_Scalable_Text::GetLetterWidth( wchar_t ch )
 		return 0.75f;
 	}
 }
+

--- a/src/game/server/ai_behavior.h
+++ b/src/game/server/ai_behavior.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose:
 //

--- a/src/game/server/ai_blended_movement.h
+++ b/src/game/server/ai_blended_movement.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose:
 //

--- a/src/game/server/ai_navigator.cpp
+++ b/src/game/server/ai_navigator.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose:
 //

--- a/src/game/server/basecombatweapon.cpp
+++ b/src/game/server/basecombatweapon.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/server/gamehandle.cpp
+++ b/src/game/server/gamehandle.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: returns the module handle of the game dll
 //			this is in its own file to protect it from tier0 PROTECTED_THINGS

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -111,6 +111,7 @@
 #include "missionchooser/iasw_mission_chooser_source.h"
 #include "matchmaking/swarm/imatchext_swarm.h"
 #include "asw_gamerules.h"
+#include "asw_player.h"
 #include "asw_util_shared.h"
 #include "iconsistency.h"
 #endif
@@ -617,6 +618,7 @@ EXPOSE_SINGLE_INTERFACE_GLOBALVAR(CServerGameDLL, IServerGameDLL, INTERFACEVERSI
 // before Steam is fully activated for the new session. Track activation so code can safely
 // skip Steam calls until the engine signals readiness.
 static bool g_bRDSteamAPIActivated = false;
+static float g_flNextDeferredSteamStatsRequestTime = 0.0f;
 
 bool RD_IsSteamAPIActivated()
 {
@@ -1278,6 +1280,9 @@ void CServerGameDLL::GameServerSteamAPIActivated( void )
 	// the Steam API pointers used to be initialized here, but that happens automatically now.
 	// Crash fix/hardening: mark Steam as activated so code can safely call Steam APIs.
 	g_bRDSteamAPIActivated = true;
+
+	// If any players tried to request XP before Steam activation (restart/join window), retry now.
+	g_flNextDeferredSteamStatsRequestTime = 0.0f;
 }
 
 //-----------------------------------------------------------------------------
@@ -1292,6 +1297,28 @@ void CServerGameDLL::GameFrame( bool simulating )
 	// Don't run frames until fully restored
 	if ( g_InRestore )
 		return;
+
+	// Crash fix/hardening: if we deferred any Steam stats requests because Steam wasn't activated
+	// yet (e.g. lobby soft-close -> restart), retry them once Steam is ready.
+	if ( g_bRDSteamAPIActivated && gpGlobals && gpGlobals->curtime >= g_flNextDeferredSteamStatsRequestTime )
+	{
+		g_flNextDeferredSteamStatsRequestTime = gpGlobals->curtime + 1.0f;
+		for ( int i = 1; i <= gpGlobals->maxClients; i++ )
+		{
+			CASW_Player *pPlayer = ToASW_Player( UTIL_PlayerByIndex( i ) );
+			if ( !pPlayer )
+				continue;
+
+			if ( pPlayer->m_bDeferredSteamStatsRequest && !pPlayer->m_bPendingSteamStats )
+			{
+				pPlayer->RequestExperience();
+				if ( pPlayer->m_bPendingSteamStats )
+				{
+					pPlayer->m_bDeferredSteamStatsRequest = false;
+				}
+			}
+		}
+	}
 
 #ifndef NO_STEAM
 	// All the calls to us from the engine prior to gameframe (like LevelInit & ServerActivate)

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -1300,6 +1300,7 @@ void CServerGameDLL::GameFrame( bool simulating )
 
 	// Crash fix/hardening: if we deferred any Steam stats requests because Steam wasn't activated
 	// yet (e.g. lobby soft-close -> restart), retry them once Steam is ready.
+	static const float k_flDeferredSteamStatsRequestTimeout = 30.0f;
 	if ( g_bRDSteamAPIActivated && gpGlobals && gpGlobals->curtime >= g_flNextDeferredSteamStatsRequestTime )
 	{
 		g_flNextDeferredSteamStatsRequestTime = gpGlobals->curtime + 1.0f;
@@ -1311,10 +1312,23 @@ void CServerGameDLL::GameFrame( bool simulating )
 
 			if ( pPlayer->m_bDeferredSteamStatsRequest && !pPlayer->m_bPendingSteamStats )
 			{
+				if ( pPlayer->m_flDeferredSteamStatsRequestStart < 0.0f )
+				{
+					pPlayer->m_flDeferredSteamStatsRequestStart = gpGlobals->curtime;
+				}
+
+				if ( ( gpGlobals->curtime - pPlayer->m_flDeferredSteamStatsRequestStart ) > k_flDeferredSteamStatsRequestTimeout )
+				{
+					pPlayer->m_bDeferredSteamStatsRequest = false;
+					pPlayer->m_flDeferredSteamStatsRequestStart = -1.0f;
+					continue;
+				}
+
 				pPlayer->RequestExperience();
 				if ( pPlayer->m_bPendingSteamStats )
 				{
 					pPlayer->m_bDeferredSteamStatsRequest = false;
+					pPlayer->m_flDeferredSteamStatsRequestStart = -1.0f;
 				}
 			}
 		}

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -613,6 +613,15 @@ static bool InitGameSystems( CreateInterfaceFn appSystemFactory )
 
 CServerGameDLL g_ServerGameDLL;
 EXPOSE_SINGLE_INTERFACE_GLOBALVAR(CServerGameDLL, IServerGameDLL, INTERFACEVERSION_SERVERGAMEDLL, g_ServerGameDLL);
+// Crash fix/hardening: the engine can call into game code during lobby soft-close -> restart
+// before Steam is fully activated for the new session. Track activation so code can safely
+// skip Steam calls until the engine signals readiness.
+static bool g_bRDSteamAPIActivated = false;
+
+bool RD_IsSteamAPIActivated()
+{
+	return g_bRDSteamAPIActivated;
+}
 
 bool CServerGameDLL::DLLInit( CreateInterfaceFn appSystemFactory, 
 		CreateInterfaceFn physicsFactory, CreateInterfaceFn fileSystemFactory, 
@@ -1064,6 +1073,7 @@ bool CServerGameDLL::SupportsSaveRestore()
 bool CServerGameDLL::LevelInit( const char *pMapName, char const *pMapEntities, char const *pOldLevel, char const *pLandmarkName, bool loadGame, bool background )
 {
 	VPROF("CServerGameDLL::LevelInit");
+	g_bRDSteamAPIActivated = false;
 	ResetWindspeed();
 	UpdateChapterRestrictions( pMapName );
 
@@ -1266,6 +1276,8 @@ void CServerGameDLL::ServerActivate( edict_t *pEdictList, int edictCount, int cl
 void CServerGameDLL::GameServerSteamAPIActivated( void )
 {
 	// the Steam API pointers used to be initialized here, but that happens automatically now.
+	// Crash fix/hardening: mark Steam as activated so code can safely call Steam APIs.
+	g_bRDSteamAPIActivated = true;
 }
 
 //-----------------------------------------------------------------------------
@@ -1518,6 +1530,7 @@ void CServerGameDLL::LevelShutdown( void )
 	MDLCACHE_CRITICAL_SECTION();
 	IGameSystem::LevelShutdownPreEntityAllSystems();
 
+	g_bRDSteamAPIActivated = false;
 	// YWB:
 	// This entity pointer is going away now and is corrupting memory on level transitions/restarts
 	CSoundEnt::ShutdownSoundEnt();

--- a/src/game/server/gameinterface.h
+++ b/src/game/server/gameinterface.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright ï¿½ 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: Expose things from GameInterface.cpp. Mostly the engine interfaces.
 //
@@ -210,6 +210,11 @@ public:
 };
 
 bool IsEngineThreaded();
+
+// Crash fix support: during lobby soft-close -> restart, the engine can call into game code
+// (including PlayerSpawn) before Steam is fully activated for the new session.
+// This helper lets server-side code skip Steam calls until GameServerSteamAPIActivated fires.
+bool RD_IsSteamAPIActivated();
 
 class CServerGameTags : public IServerGameTags
 {

--- a/src/game/server/gameinterface.h
+++ b/src/game/server/gameinterface.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: Expose things from GameInterface.cpp. Mostly the engine interfaces.
 //

--- a/src/game/server/mapentities.cpp
+++ b/src/game/server/mapentities.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: Controls the loading, parsing and creation of the entities from the BSP.
 //

--- a/src/game/server/nav_area.cpp
+++ b/src/game/server/nav_area.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/server/nav_edit.cpp
+++ b/src/game/server/nav_edit.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/server/nav_entities.cpp
+++ b/src/game/server/nav_entities.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/server/nav_generate.cpp
+++ b/src/game/server/nav_generate.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/server/nav_mesh.cpp
+++ b/src/game/server/nav_mesh.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/server/ndebugoverlay.cpp
+++ b/src/game/server/ndebugoverlay.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose:		Namespace for functions dealing with Debug Overlays
 //

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: Functions dealing with the player.
 //

--- a/src/game/server/swarm/asw_player.cpp
+++ b/src/game/server/swarm/asw_player.cpp
@@ -408,6 +408,7 @@ CASW_Player::CASW_Player()
 	m_bPendingSteamStats = false;
 	m_flPendingSteamStatsStart = 0.0f;
 	m_bDeferredSteamStatsRequest = false;
+	m_flDeferredSteamStatsRequestStart = -1.0f;
 
 	m_bWelcomed = false;
 

--- a/src/game/server/swarm/asw_player.cpp
+++ b/src/game/server/swarm/asw_player.cpp
@@ -407,6 +407,7 @@ CASW_Player::CASW_Player()
 
 	m_bPendingSteamStats = false;
 	m_flPendingSteamStatsStart = 0.0f;
+	m_bDeferredSteamStatsRequest = false;
 
 	m_bWelcomed = false;
 

--- a/src/game/server/swarm/asw_player.h
+++ b/src/game/server/swarm/asw_player.h
@@ -278,6 +278,7 @@ public:
 	bool m_bHasAwardedXP;
 	bool m_bPendingSteamStats;
 	float m_flPendingSteamStatsStart;
+	bool m_bDeferredSteamStatsRequest;
 	bool m_bSentPromotedMessage;
 
 	// static inventory (medals)

--- a/src/game/server/swarm/asw_player.h
+++ b/src/game/server/swarm/asw_player.h
@@ -279,6 +279,7 @@ public:
 	bool m_bPendingSteamStats;
 	float m_flPendingSteamStatsStart;
 	bool m_bDeferredSteamStatsRequest;
+	float m_flDeferredSteamStatsRequestStart;
 	bool m_bSentPromotedMessage;
 
 	// static inventory (medals)

--- a/src/game/shared/basecombatweapon_shared.cpp
+++ b/src/game/shared/basecombatweapon_shared.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: Implements shared baseplayer class functionality
 //

--- a/src/game/shared/gamestringpool.cpp
+++ b/src/game/shared/gamestringpool.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose:
 //

--- a/src/game/shared/swarm/asw_gamerules.h
+++ b/src/game/shared/swarm/asw_gamerules.h
@@ -1,4 +1,4 @@
-//====== Copyright ?1996-2003, Valve Corporation, All rights reserved. =======
+//====== Copyright © 1996-2003, Valve Corporation, All rights reserved. =======
 //
 // Purpose: Game rules for Alien Swarm
 //

--- a/src/game/shared/swarm/asw_player_experience.cpp
+++ b/src/game/shared/swarm/asw_player_experience.cpp
@@ -467,6 +467,12 @@ void CASW_Player::RequestExperience()
 #else
 	if ( engine->IsDedicatedServer() )
 	{
+		// Crash fix/hardening: during lobby soft-close -> restart, PlayerSpawn can run before
+		// Steam is activated for the new session. Avoid calling RequestUserStats until the
+		// engine signals Steam readiness (GameServerSteamAPIActivated).
+		if ( !RD_IsSteamAPIActivated() )
+			return;
+
 		Assert( SteamGameServerStats() );
 		if ( SteamGameServerStats() )
 		{

--- a/src/game/shared/swarm/asw_player_experience.cpp
+++ b/src/game/shared/swarm/asw_player_experience.cpp
@@ -471,7 +471,11 @@ void CASW_Player::RequestExperience()
 		// Steam is activated for the new session. Avoid calling RequestUserStats until the
 		// engine signals Steam readiness (GameServerSteamAPIActivated).
 		if ( !RD_IsSteamAPIActivated() )
+		{
+			// Defer rather than skip: once Steam is activated, game code will retry this request.
+			m_bDeferredSteamStatsRequest = true;
 			return;
+		}
 
 		Assert( SteamGameServerStats() );
 		if ( SteamGameServerStats() )

--- a/src/game/shared/util_shared.cpp
+++ b/src/game/shared/util_shared.cpp
@@ -1,4 +1,4 @@
-//===== Copyright ?1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/game/shared/util_shared.h
+++ b/src/game/shared/util_shared.h
@@ -1,4 +1,4 @@
-//========= Copyright ?1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: Shared util code between client and server.
 //

--- a/src/public/SoundEmitterSystem/isoundemittersystembase.h
+++ b/src/public/SoundEmitterSystem/isoundemittersystembase.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/public/bitvec.h
+++ b/src/public/bitvec.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/public/dispcoll_common.h
+++ b/src/public/dispcoll_common.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/public/icvar.h
+++ b/src/public/icvar.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/public/materialsystem/imaterial.h
+++ b/src/public/materialsystem/imaterial.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/public/materialsystem/imaterialsystem.h
+++ b/src/public/materialsystem/imaterialsystem.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/public/materialsystem/materialsystem_config.h
+++ b/src/public/materialsystem/materialsystem_config.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/public/networkvar.h
+++ b/src/public/networkvar.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/public/shaderlib/cshader.h
+++ b/src/public/shaderlib/cshader.h
@@ -184,7 +184,7 @@ inline bool CShader_IsFlag2Set( IMaterialVar **params, MaterialVarFlags2_t _flag
 	// which in turn tries to ask the compiler to instantiate an object like so:
 	// 		static CShaderParam COLOR( (ShaderMaterialVars_t)COLOR, SHADER_PARAM_TYPE_COLOR, "{255 255 255}", "unused", SHADER_PARAM_NOT_EDITABLE )
 	// and GCC thinks that the reference to COLOR in the arg list is actually a reference to the object we're in the middle of making.
-	// and you get --> error: invalid cast from type ‘Cloak_DX90::CShaderParam’ to type ‘ShaderMaterialVars_t’
+	// and you get --> error: invalid cast from type 'Cloak_DX90::CShaderParam' to type 'ShaderMaterialVars_t'
 	// Resolved: add the "::" so compiler knows that reference is to the enum, not to the name of the object being made.
 	
 	

--- a/src/public/stdstring.h
+++ b/src/public/stdstring.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose:
 //

--- a/src/public/steam/isteamclient.h
+++ b/src/public/steam/isteamclient.h
@@ -1,4 +1,4 @@
-﻿//====== Copyright Valve Corporation, All rights reserved. ====================
+//====== Copyright Valve Corporation, All rights reserved. ====================
 //
 // Internal low-level access to Steamworks interfaces.
 //
@@ -177,3 +177,4 @@ inline ISteamClient *SteamGameServerClient() { return SteamClient(); }
 #endif
 
 #endif // ISTEAMCLIENT_H
+

--- a/src/public/steam/isteamparentalsettings.h
+++ b/src/public/steam/isteamparentalsettings.h
@@ -1,4 +1,4 @@
-//====== Copyright � 2013-, Valve Corporation, All rights reserved. =======
+//====== Copyright © 2013-, Valve Corporation, All rights reserved. =======
 //
 // Purpose: Interface to Steam parental settings (Family View)
 //

--- a/src/public/steam/isteamremotestorage.h
+++ b/src/public/steam/isteamremotestorage.h
@@ -1,4 +1,4 @@
-//====== Copyright � 1996-2008, Valve Corporation, All rights reserved. =======
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
 //
 // Purpose: public interface to user remote file storage in Steam
 //

--- a/src/public/steam/isteamscreenshots.h
+++ b/src/public/steam/isteamscreenshots.h
@@ -1,4 +1,4 @@
-//====== Copyright � 1996-2008, Valve Corporation, All rights reserved. =======
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
 //
 // Purpose: public interface to user remote file storage in Steam
 //

--- a/src/public/steam/isteamuserstats.h
+++ b/src/public/steam/isteamuserstats.h
@@ -1,4 +1,4 @@
-//====== Copyright � 1996-2009, Valve Corporation, All rights reserved. =======
+//====== Copyright © 1996-2009, Valve Corporation, All rights reserved. =======
 //
 // Purpose: interface to stats, achievements, and leaderboards 
 //

--- a/src/public/steam/isteamutils.h
+++ b/src/public/steam/isteamutils.h
@@ -1,4 +1,4 @@
-//====== Copyright � 1996-2008, Valve Corporation, All rights reserved. =======
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
 //
 // Purpose: interface to utility functions in Steam
 //

--- a/src/public/steam/matchmakingtypes.h
+++ b/src/public/steam/matchmakingtypes.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2008, Valve LLC, All rights reserved. ============
+//========= Copyright © 1996-2008, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/src/public/steam/steamclientpublic.h
+++ b/src/public/steam/steamclientpublic.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2008, Valve LLC, All rights reserved. ============
+//========= Copyright © 1996-2008, Valve LLC, All rights reserved. ============
 //
 // Declare common types used by the Steamworks SDK.
 //

--- a/src/public/steam/steamuniverse.h
+++ b/src/public/steam/steamuniverse.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2008, Valve LLC, All rights reserved. ============
+//========= Copyright © 1996-2008, Valve LLC, All rights reserved. ============
 //
 // Purpose:
 //

--- a/src/public/tier0/memoverride.cpp
+++ b/src/public/tier0/memoverride.cpp
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: Insert this file into all projects using the memory system
 // It will cause that project to use the shader memory allocator

--- a/src/public/tier1/KeyValues.h
+++ b/src/public/tier1/KeyValues.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/public/tier1/UtlSortVector.h
+++ b/src/public/tier1/UtlSortVector.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // $Header: $
 // $NoKeywords: $

--- a/src/public/tier1/interface.h
+++ b/src/public/tier1/interface.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/public/tier1/refcount.h
+++ b/src/public/tier1/refcount.h
@@ -1,4 +1,4 @@
-//========== Copyright � 2005, Valve Corporation, All rights reserved. ========
+//========== Copyright © 2005, Valve Corporation, All rights reserved. ========
 //
 // Purpose: Tools for correctly implementing & handling reference counted
 //			objects

--- a/src/public/tier1/smartptr.h
+++ b/src/public/tier1/smartptr.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/public/tier1/tier1.h
+++ b/src/public/tier1/tier1.h
@@ -1,4 +1,4 @@
-//===== Copyright � 2005-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 2005-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: A higher level link library for general use in the game and tools.
 //

--- a/src/public/tier1/utlblockmemory.h
+++ b/src/public/tier1/utlblockmemory.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/public/tier1/utlenvelope.h
+++ b/src/public/tier1/utlenvelope.h
@@ -1,4 +1,4 @@
-//========== Copyright � 2005, Valve Corporation, All rights reserved. ========
+//========== Copyright © 2005, Valve Corporation, All rights reserved. ========
 //
 // Purpose: A class to wrap data for transport over a boundary like a thread
 //			or window.

--- a/src/public/tier1/utlfixedmemory.h
+++ b/src/public/tier1/utlfixedmemory.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/public/tier1/utlintrusivelist.h
+++ b/src/public/tier1/utlintrusivelist.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2006, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2006, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: Intrusive linked list templates, both for singly and doubly linked lists
 //

--- a/src/public/tier1/utllinkedlist.h
+++ b/src/public/tier1/utllinkedlist.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: Linked list container class 
 //

--- a/src/public/tier1/utlrbtree.h
+++ b/src/public/tier1/utlrbtree.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/public/tier2/renderutils.h
+++ b/src/public/tier2/renderutils.h
@@ -1,4 +1,4 @@
-//===== Copyright � 2005-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 2005-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: A set of utilities to render standard shapes
 //

--- a/src/public/tier2/tier2.h
+++ b/src/public/tier2/tier2.h
@@ -1,4 +1,4 @@
-//===== Copyright � 2005-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 2005-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: A higher level link library for general use in the game and tools.
 //

--- a/src/public/tier3/tier3.h
+++ b/src/public/tier3/tier3.h
@@ -1,4 +1,4 @@
-//===== Copyright � 2005-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 2005-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: A higher level link library for general use in the game and tools.
 //

--- a/src/public/vgui/Dar.h
+++ b/src/public/vgui/Dar.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: Holds the enumerated list of default cursors
 //

--- a/src/public/vgui_controls/EditablePanel.h
+++ b/src/public/vgui_controls/EditablePanel.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/src/public/vgui_controls/consoledialog.h
+++ b/src/public/vgui_controls/consoledialog.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //

--- a/src/public/vstdlib/jobthread.h
+++ b/src/public/vstdlib/jobthread.h
@@ -1,4 +1,4 @@
-//========== Copyright � 2005, Valve Corporation, All rights reserved. ========
+//========== Copyright © 2005, Valve Corporation, All rights reserved. ========
 //
 // Purpose:	A utility for a discrete job-oriented worker thread.
 //

--- a/src/public/vtf/vtf.h
+++ b/src/public/vtf/vtf.h
@@ -1,4 +1,4 @@
-//===== Copyright � 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //


### PR DESCRIPTION
This old bug still plagued my classic Alien Swarm server, so i ported the fix on ASRD if you guys are interested.

(Brief bug description: Dedicated server launches, players connect, everything is smooth, players disconnect, server idles on lobby, a new player joins, server crashes upon player stats fetching).

You need to test it first, but I believe it will work without any issues.

Cheers and have fun!