### PR TITLE
 Fix multi-byte character handling in chat

### DIFF
--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -466,6 +466,8 @@ CBaseHudChatInputLine::CBaseHudChatInputLine( CBaseHudChat *parent, char const *
 	m_pPrompt = new vgui::Label( this, "ChatInputPrompt", L"Enter text:" );
 	m_pInput = new CBaseHudChatEntry( this, "ChatInput", parent );	
 	m_pInput->SetMaximumCharCount( 127 );
+	// Send converts text to utf-8
+	m_pInput->m_iMaxByteCount = 127;
 }
 
 void CBaseHudChatInputLine::ApplySchemeSettings(vgui::IScheme *pScheme)
@@ -2518,4 +2520,60 @@ void CBaseHudChat::FireGameEvent( IGameEvent *event )
 		
 		ChatPrintf( player->entindex(), CHAT_FILTER_NONE, "(SourceTV) %s", event->GetString( "text" ) );
 	}
+}
+
+// Prevent player from inserting text over utf-8 byte limit
+void CBaseHudChatEntry::InsertChar(wchar_t ch)
+{
+	if ( m_iMaxByteCount == -1 )
+	{
+		BaseClass::InsertChar(ch);
+		return;
+	}
+
+	// single utf-16 char converted to utf-8 is 3 byte long in worst case
+	const int iBufLen = BaseClass::GetTextLength() * 3;
+
+	// Shortcut: fitting max byte count even in worst case
+	if ( iBufLen + 4 <= m_iMaxByteCount )
+	{
+		BaseClass::InsertChar(ch);
+		return;
+	}
+
+	// Count bytes of converted utf-8 str
+	m_szCharBuf.EnsureCapacity( iBufLen );
+	BaseClass::GetText( m_szCharBuf.Base(), m_szCharBuf.Count() );
+	const int iCurrentByteLen = Q_strlen( m_szCharBuf.Base() );
+
+	// Shortcut: average case
+	if ( iCurrentByteLen + 4 <= m_iMaxByteCount )
+	{
+		BaseClass::InsertChar(ch);
+		return;
+	}
+
+	// Edge case: check if current wchar_t will cause Send to truncate message
+	int iCharByteLen; // utf-8
+	if ( ch < 0x80 ) iCharByteLen = 1;
+	else if ( ch < 0x800 ) iCharByteLen = 2;
+	else if ( ch >= 0xD800 && ch <= 0xDBFF ) iCharByteLen = 4; // high surrogate, assume pair
+	else if ( ch >= 0xDC00 && ch <= 0xDFFF ) // low surrogate
+	{
+		// Check if previous wchar was a high surrogate
+		wchar_t wszHigh[2];
+		const int iLast = BaseClass::GetTextLength() - 1;
+		BaseClass::GetTextRange( wszHigh, iLast, 1 );
+		if ( wszHigh[0] >= 0xD800 && wszHigh[0] <= 0xDBFF ) { BaseClass::InsertChar(ch); return; }
+		else return; // it was not a hight surrogate, reject
+	}
+	else iCharByteLen = 3;
+
+	if ( iCurrentByteLen + iCharByteLen <= m_iMaxByteCount )
+	{
+		BaseClass::InsertChar(ch);
+		return;
+	}
+
+	return; // do not insert anything
 }

--- a/src/game/client/hud_basechat.h
+++ b/src/game/client/hud_basechat.h
@@ -324,6 +324,8 @@ class CBaseHudChatEntry : public vgui::TextEntry
 {
 	typedef vgui::TextEntry BaseClass;
 public:
+	int m_iMaxByteCount = -1; // utf-8 string length
+
 	CBaseHudChatEntry( vgui::Panel *parent, char const *panelName, CBaseHudChat *pChat )
 		: BaseClass( parent, panelName )
 	{
@@ -339,6 +341,8 @@ public:
 
 		SetPaintBorderEnabled( false );
 	}
+
+	virtual	void InsertChar(wchar_t ch);
 
 	virtual void OnKeyCodeTyped(vgui::KeyCode code)
 	{
@@ -371,6 +375,7 @@ public:
 
 private:
 	CBaseHudChat *m_pHudChat;
+	CUtlMemory<char> m_szCharBuf{ 0, 64 }; // tmp buffer
 };
 
 //-----------------------------------------------------------------------------

--- a/src/game/server/client.cpp
+++ b/src/game/server/client.cpp
@@ -73,7 +73,12 @@ char * CheckChatText( CBasePlayer *pPlayer, char *text )
 
 	// cut off after P_MAX_LEN chars
 	if ( length > P_MAX_LEN )
-		p[P_MAX_LEN] = 0;
+	{
+		// don't split utf-8 code point
+		size_t i = P_MAX_LEN;
+		while( i > 0 && ( static_cast<uint8_t>(p[i]) & 0b1100'0000 ) == 0b1000'0000 ) --i;
+		p[i] = '\0';
+	}
 
 	GameRules()->CheckChatText( pPlayer, p );
 


### PR DESCRIPTION


Related to #855

## Problems

1. Message validation may truncate input in the middle of a multi-byte utf-8 sequence, producing invalid text.
2. Chat input operates on utf-16 `wchar` characters, but message sending uses utf-8 `char`.
3. Chat input doesn’t represent what will be sent over, because non-Latin letters in most languages are typically multi-byte characters that take up only a single `wchar` and 2–3 `char`.

## Goals

- [x] Fix truncation in message validation 
- [x] Fix char limit calculation in chat box input
- [x] ~~Do not fix truncation splitting utf-8 graphemes~~

## Test strings

<details>

### Bytes


- numbers `123…` represent `110 + n` byte position (counting from 1)
- `|` represent string cutoff
- `x` represent utf-8 code point's byte
```
_128_chars______________________________________________________________________________________________________7|8__ok_12345678
```
```
ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ_____7|8____ok_12345678
```
```
ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ____6x|x___nok_123456ø
```
```
ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ___5xx|x___nok_12345Ⓐ
```

```
ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ__4xxx|_____ok_1234Ⓐ
```

### Chars

128 characters (`"Ⓐ"*41+"Ⓑ"*(126-41)+"78"`). 300+ bytes.

```
ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷⒷ78
```

</details>

## Examples

<details>

### Before

```
SuperCake: _128_chars______________________________________________________________________________________________________7|8__ok_1234567
SuperCake: ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ_____7|8____ok_1234567
SuperCake: ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ____6x|x___nok_123456�
SuperCake: ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ___5xx|x___nok_12345�
SuperCake: ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ__4xxx|_____ok_1234Ⓐ
SuperCake: ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒷ�溰p䷗ট溰p
```

### After

```
SuperCake: _128_chars______________________________________________________________________________________________________7|8__ok_1234567
SuperCake: ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ_____7|8____ok_1234567
SuperCake: ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ____6x|x___nok_123456
SuperCake: ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ___5xx|x___nok_12345
SuperCake: ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶ__4xxx|_____ok_1234Ⓐ
SuperCake: ⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒶⒷ7
```

</details>