### PR TITLE
Gameplay & concommands: client-access fixes and weapon auto-aim toggle

### DIFF
--- a/src/game/client/swarm/c_asw_concommands.cpp
+++ b/src/game/client/swarm/c_asw_concommands.cpp
@@ -862,7 +862,7 @@ void rd_reset_level_and_promotion_f()
 
 	Msg( "All done, your level and promotion have been reset!\n" );
 }
-ConCommand rd_reset_level_and_promotion( "rd_reset_level_and_promotion", rd_reset_level_and_promotion_f, "Resets promotion (rank, level etc.)", FCVAR_NOT_CONNECTED );
+ConCommand rd_reset_level_and_promotion( "rd_reset_level_and_promotion", rd_reset_level_and_promotion_f, "Resets promotion (rank, level etc.)", FCVAR_CHEAT | FCVAR_NOT_CONNECTED );
 
 void asw_show_xp_f()
 {

--- a/src/game/client/swarm/c_asw_concommands.cpp
+++ b/src/game/client/swarm/c_asw_concommands.cpp
@@ -862,7 +862,7 @@ void rd_reset_level_and_promotion_f()
 
 	Msg( "All done, your level and promotion have been reset!\n" );
 }
-ConCommand rd_reset_level_and_promotion( "rd_reset_level_and_promotion", rd_reset_level_and_promotion_f, "Resets promotion (rank, level etc.)", FCVAR_DEVELOPMENTONLY );
+ConCommand rd_reset_level_and_promotion( "rd_reset_level_and_promotion", rd_reset_level_and_promotion_f, "Resets promotion (rank, level etc.)", FCVAR_NOT_CONNECTED );
 
 void asw_show_xp_f()
 {

--- a/src/game/client/swarm/c_asw_weapon.cpp
+++ b/src/game/client/swarm/c_asw_weapon.cpp
@@ -125,6 +125,7 @@ ConVar rd_drop_magazine_force_up( "rd_drop_magazine_force_up", "50", FCVAR_NONE,
 ConVar rd_drop_magazine_spin( "rd_drop_magazine_spin", "1000", FCVAR_NONE, "Amount of random angular velocity to apply to dropped magazine" );
 ConVar rd_drop_magazine_lifetime( "rd_drop_magazine_lifetime", "4", FCVAR_NONE, "Time before a dropped magazine fades" );
 ConVar rd_strange_device_model( "rd_strange_device_model", "0", FCVAR_NONE, "Should items with strange devices attached display them in the world?" );
+ConVar rd_weapon_autoaim( "rd_weapon_autoaim", "1", FCVAR_NONE,  "Enable or disable weapon auto-aim if available." );
 
 extern ConVar asw_use_particle_tracers;
 extern ConVar muzzleflash_light;

--- a/src/game/shared/swarm/asw_weapon_autogun_shared.h
+++ b/src/game/shared/swarm/asw_weapon_autogun_shared.h
@@ -27,8 +27,28 @@ public:
 
 	//float	GetFireRate( void ) { return 0.1f; }
 
-	virtual const float GetAutoAimAmount() { return 0.36f; }	
-	virtual const float GetAutoAimRadiusScale() { return 1.5f; }
+	#ifdef CLIENT_DLL
+		virtual const float GetAutoAimAmount()
+		{
+			extern ConVar rd_weapon_autoaim;
+			return rd_weapon_autoaim.GetBool() ? 0.36f : 0.0f;
+		}
+		virtual const float GetAutoAimRadiusScale()
+		{
+			extern ConVar rd_weapon_autoaim;
+			return rd_weapon_autoaim.GetBool() ? 1.5f : 0.0f;
+		}
+	#else
+		virtual const float GetAutoAimAmount()
+		{
+			return 0.26f;
+		}
+		virtual const float GetAutoAimRadiusScale()
+		{
+			return 1.5f;
+		}
+	#endif
+
 	virtual bool ShouldFlareAutoaim() { return true; }
 	virtual const Vector& GetBulletSpread( void );
 

--- a/src/game/shared/swarm/asw_weapon_autogun_shared.h
+++ b/src/game/shared/swarm/asw_weapon_autogun_shared.h
@@ -41,7 +41,7 @@ public:
 	#else
 		virtual const float GetAutoAimAmount()
 		{
-			return 0.26f;
+			return 0.36f;
 		}
 		virtual const float GetAutoAimRadiusScale()
 		{

--- a/src/game/shared/swarm/asw_weapon_prifle_shared.h
+++ b/src/game/shared/swarm/asw_weapon_prifle_shared.h
@@ -22,8 +22,27 @@ public:
 	virtual ~CASW_Weapon_PRifle();
 	void Precache();
 
-	virtual const float GetAutoAimAmount() { return 0.26f; }
-	virtual const float GetAutoAimRadiusScale() { return 1.5f; }
+	#ifdef CLIENT_DLL
+		virtual const float GetAutoAimAmount()
+		{
+			extern ConVar rd_weapon_autoaim;
+			return rd_weapon_autoaim.GetBool() ? 0.26f : 0.0f;
+		}
+		virtual const float GetAutoAimRadiusScale()
+		{
+			extern ConVar rd_weapon_autoaim;
+			return rd_weapon_autoaim.GetBool() ? 1.5f : 0.0f;
+		}
+	#else
+		virtual const float GetAutoAimAmount()
+		{
+			return 0.26f;
+		}
+		virtual const float GetAutoAimRadiusScale()
+		{
+			return 1.5f;
+		}
+	#endif
 	virtual float GetFireRate();
 	virtual float GetWeaponBaseDamageOverride();
 	virtual int GetWeaponSkillId();


### PR DESCRIPTION
This PR introduces two gameplay-related changes:

1. ConCommand accessibility adjustment
   - Makes rd_reset_level_and_promotion available to clients outside of development-only mode
   - Replaces FCVAR_DEVELOPMENTONLY with FCVAR_NOT_CONNECTED to restrict usage during active multiplayer sessions

2. Weapon auto-aim control system
   - Adds rd_weapon_autoaim ConVar
   - Enables runtime toggle for auto-aim behavior in Autogun and PRifle
   - Auto-aim is now gated on the CLIENT_DLL via ConVar state

No gameplay balance changes are intended beyond exposing existing mechanics to configurable control.