### PR TITLE
Expose rd_reset_level_and_promotion as cheat command

### DIFF
--- a/src/game/client/swarm/c_asw_concommands.cpp
+++ b/src/game/client/swarm/c_asw_concommands.cpp
@@ -862,7 +862,7 @@ void rd_reset_level_and_promotion_f()
 
 	Msg( "All done, your level and promotion have been reset!\n" );
 }
-ConCommand rd_reset_level_and_promotion( "rd_reset_level_and_promotion", rd_reset_level_and_promotion_f, "Resets promotion (rank, level etc.)", FCVAR_DEVELOPMENTONLY );
+ConCommand rd_reset_level_and_promotion( "rd_reset_level_and_promotion", rd_reset_level_and_promotion_f, "Resets promotion (rank, level etc.)", FCVAR_CHEAT | FCVAR_NOT_CONNECTED );
 
 void asw_show_xp_f()
 {


### PR DESCRIPTION
Change ConVar flags from FCVAR_DEVELOPMENTONLY to FCVAR_CHEAT | FCVAR_NOT_CONNECTED to allow usage outside development builds while still restricting it to cheat mode and disallowing execution while connected.