### PR TITLE
Add client convar for weapon auto-aim toggle

### DIFF
--- a/src/game/client/swarm/c_asw_weapon.cpp
+++ b/src/game/client/swarm/c_asw_weapon.cpp
@@ -126,6 +126,8 @@ ConVar rd_drop_magazine_spin( "rd_drop_magazine_spin", "1000", FCVAR_NONE, "Amou
 ConVar rd_drop_magazine_lifetime( "rd_drop_magazine_lifetime", "4", FCVAR_NONE, "Time before a dropped magazine fades" );
 ConVar rd_strange_device_model( "rd_strange_device_model", "0", FCVAR_NONE, "Should items with strange devices attached display them in the world?" );
 
+ConVar rd_autoaim_weapons("rd_autoaim_weapons", "1", FCVAR_NONE, "Enable auto-aim bonus for selected weapons (autogun, prifle)");
+
 extern ConVar asw_use_particle_tracers;
 extern ConVar muzzleflash_light;
 extern ConVar rd_show_others_laser_pointer;

--- a/src/game/client/swarm/c_asw_weapon.h
+++ b/src/game/client/swarm/c_asw_weapon.h
@@ -17,6 +17,8 @@ class C_BreakableProp;
 class CASW_EquipItem;
 class C_RD_Weapon_Accessory;
 
+extern ConVar rd_autoaim_weapons;
+
 extern ConVar rd_ground_shooting;
 
 class C_ASW_Weapon : public C_BaseCombatWeapon, public IASW_Client_Usable_Entity

--- a/src/game/shared/swarm/asw_weapon_autogun_shared.h
+++ b/src/game/shared/swarm/asw_weapon_autogun_shared.h
@@ -28,7 +28,11 @@ public:
 	//float	GetFireRate( void ) { return 0.1f; }
 
 	virtual const float GetAutoAimAmount() { return 0.36f; }	
+#ifdef CLIENT_DLL
+	virtual const float GetAutoAimRadiusScale() { return rd_autoaim_weapons.GetBool() ? 1.5f : 1.0f; }
+#else
 	virtual const float GetAutoAimRadiusScale() { return 1.5f; }
+#endif // CLIENT_DLL
 	virtual bool ShouldFlareAutoaim() { return true; }
 	virtual const Vector& GetBulletSpread( void );
 

--- a/src/game/shared/swarm/asw_weapon_prifle_shared.h
+++ b/src/game/shared/swarm/asw_weapon_prifle_shared.h
@@ -23,7 +23,11 @@ public:
 	void Precache();
 
 	virtual const float GetAutoAimAmount() { return 0.26f; }
+#ifdef CLIENT_DLL
+	virtual const float GetAutoAimRadiusScale() { return rd_autoaim_weapons.GetBool() ? 1.5f : 1.0f; }
+#else
 	virtual const float GetAutoAimRadiusScale() { return 1.5f; }
+#endif // CLIENT_DLL
 	virtual float GetFireRate();
 	virtual float GetWeaponBaseDamageOverride();
 	virtual int GetWeaponSkillId();


### PR DESCRIPTION
Allow disabling extra auto-aim support for autogun and prifle with `rd_autoaim_weapons`.