### PR TITLE
Extract shared out-of-ammo notification handling

### DIFF
--- a/src/game/client/swarm/c_asw_weapon.h
+++ b/src/game/client/swarm/c_asw_weapon.h
@@ -105,6 +105,7 @@ public:
 	virtual void WeaponSound( WeaponSound_t sound_type, float soundtime = 0.0f );
 	virtual bool HasAmmo();
 	virtual bool PrimaryAmmoLoaded( void );
+	virtual void NotifyIfNoneClip1Ammo( C_ASW_Marine *pMarine );
 	virtual float GetReloadTime();
 	virtual float GetReloadFailTime();
 	virtual bool Reload();

--- a/src/game/server/swarm/asw_weapon.h
+++ b/src/game/server/swarm/asw_weapon.h
@@ -61,6 +61,7 @@ public:
 	virtual float	GetFireRate( void );
 	virtual bool HasAmmo();
 	virtual bool PrimaryAmmoLoaded( void );
+	virtual void NotifyIfNoneClip1Ammo( CASW_Marine *pMarine );
 
 	virtual int LookupAttachment( const char *pAttachmentName );
 	virtual bool ShouldMarineMoveSlow();		// is the weapon in slow mode (when firing or reloading)

--- a/src/game/shared/swarm/asw_weapon_cryo_cannon_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_cryo_cannon_shared.cpp
@@ -263,13 +263,7 @@ void CASW_Weapon_Cryo_Cannon::PrimaryAttack()
 	{
 		iShots = MIN( iShots, m_iClip1 );
 		m_iClip1 -= iShots;
-
-#ifdef GAME_DLL
-		if ( m_iClip1 <= 0 && pMarine && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
-		{
-			pMarine->OnWeaponOutOfAmmo( true );
-		}
-#endif
+		NotifyIfNoneClip1Ammo( pMarine );
 	}
 	else
 	{

--- a/src/game/shared/swarm/asw_weapon_flamer_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_flamer_shared.cpp
@@ -287,25 +287,7 @@ void CASW_Weapon_Flamer::PrimaryAttack( void )
 
 		// decrement ammo
 		m_iClip1 -= 1;
-#ifdef GAME_DLL
-		if ( m_iClip1 <= 0 && pMarine->GetAmmoCount(m_iPrimaryAmmoType) <= 0 )
-		{
-			// check he doesn't have ammo in an ammo bay
-			CASW_Weapon_Ammo_Bag* pAmmoBag = NULL;
-			CASW_Weapon* pWeapon = pMarine->GetASWWeapon(0);
-			if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-				pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-
-			if (!pAmmoBag)
-			{
-				pWeapon = pMarine->GetASWWeapon(1);
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-			}
-			if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon(this) )
-				pMarine->OnWeaponOutOfAmmo(true);
-		}
-#endif
+		NotifyIfNoneClip1Ammo( pMarine );
 
 		/*
 		if (!m_iClip1 && pMarine->GetAmmoCount(m_iPrimaryAmmoType) <= 0)

--- a/src/game/shared/swarm/asw_weapon_flechette2_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_flechette2_shared.cpp
@@ -133,26 +133,7 @@ void CASW_Weapon_Flechette2::PrimaryAttack()
 		{
 			iShots = MIN( iShots, m_iClip1 );
 			m_iClip1 -= iShots;
-
-#ifdef GAME_DLL
-			if ( m_iClip1 <= 0 && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
-			{
-				// check he doesn't have ammo in an ammo bay
-				CASW_Weapon_Ammo_Bag *pAmmoBag = NULL;
-				CASW_Weapon *pWeapon = pMarine->GetASWWeapon( 0 );
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-
-				if ( !pAmmoBag )
-				{
-					pWeapon = pMarine->GetASWWeapon( 1 );
-					if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-						pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-				}
-				if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon( this ) )
-					pMarine->OnWeaponOutOfAmmo( true );
-			}
-#endif
+			NotifyIfNoneClip1Ammo( pMarine );
 		}
 		else
 		{

--- a/src/game/shared/swarm/asw_weapon_flechette_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_flechette_shared.cpp
@@ -130,26 +130,7 @@ void CASW_Weapon_Flechette::PrimaryAttack()
 		{
 			iShots = MIN( iShots, m_iClip1 );
 			m_iClip1 -= iShots;
-
-#ifdef GAME_DLL
-			if ( m_iClip1 <= 0 && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
-			{
-				// check he doesn't have ammo in an ammo bay
-				CASW_Weapon_Ammo_Bag *pAmmoBag = NULL;
-				CASW_Weapon *pWeapon = pMarine->GetASWWeapon( 0 );
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-
-				if ( !pAmmoBag )
-				{
-					pWeapon = pMarine->GetASWWeapon( 1 );
-					if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-						pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-				}
-				if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon( this ) )
-					pMarine->OnWeaponOutOfAmmo( true );
-			}
-#endif
+			NotifyIfNoneClip1Ammo( pMarine );
 		}
 		else
 		{

--- a/src/game/shared/swarm/asw_weapon_minigun.cpp
+++ b/src/game/shared/swarm/asw_weapon_minigun.cpp
@@ -229,26 +229,7 @@ void CASW_Weapon_Minigun::PrimaryAttack()
 		iEffectiveClip -= info.m_iShots;
 		m_iClip1 = ( iEffectiveClip + 1 ) / 2;
 		m_bHalfShot = ( iEffectiveClip & 1 ) != 0;
-
-#ifdef GAME_DLL
-		if ( m_iClip1 <= 0 && pMarine->GetAmmoCount(m_iPrimaryAmmoType) <= 0 )
-		{
-			// check he doesn't have ammo in an ammo bay
-			CASW_Weapon_Ammo_Bag* pAmmoBag = NULL;
-			CASW_Weapon* pWeapon = pMarine->GetASWWeapon(0);
-			if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-				pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-			
-			if (!pAmmoBag)
-			{
-				pWeapon = pMarine->GetASWWeapon(1);
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-			}
-			if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon(this) )
-				pMarine->OnWeaponOutOfAmmo(true);
-		}
-#endif
+		NotifyIfNoneClip1Ammo( pMarine );
 	}
 	else
 	{

--- a/src/game/shared/swarm/asw_weapon_mining_laser_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_mining_laser_shared.cpp
@@ -550,25 +550,8 @@ bool CASW_Weapon_Mining_Laser::Fire( const Vector &vecOrigSrc, const Vector &vec
 			// decrement ammo
 			m_iClip1 -= 1;
 			m_flAmmoUseTime = gpGlobals->curtime + 0.2;
+			NotifyIfNoneClip1Ammo( pMarine );
 #ifdef GAME_DLL
-			if ( m_iClip1 <= 0 && pMarine->GetAmmoCount(m_iPrimaryAmmoType) <= 0 )
-			{
-				// check he doesn't have ammo in an ammo bay
-				CASW_Weapon_Ammo_Bag* pAmmoBag = NULL;
-				CASW_Weapon* pWeapon = pMarine->GetASWWeapon(0);
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-
-				if (!pAmmoBag)
-				{
-					pWeapon = pMarine->GetASWWeapon(1);
-					if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-						pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-				}
-				if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon(this) )
-					pMarine->OnWeaponOutOfAmmo(true);
-			}
-
 			pMarine->OnWeaponFired(this, 1);
 #endif
 		}

--- a/src/game/shared/swarm/asw_weapon_pdw_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_pdw_shared.cpp
@@ -265,25 +265,7 @@ void CASW_Weapon_PDW::PrimaryAttack()
 			for ( int k = 0; k < info.m_iShots; k++ )
 			{
 				m_iClip1 -= 1;
-#ifdef GAME_DLL
-				if ( m_iClip1 <= 0 && pMarine && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
-				{
-					// check he doesn't have ammo in an ammo bay
-					CASW_Weapon_Ammo_Bag *pAmmoBag = NULL;
-					CASW_Weapon *pWeapon = pMarine->GetASWWeapon( 0 );
-					if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-						pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-
-					if ( !pAmmoBag )
-					{
-						pWeapon = pMarine->GetASWWeapon( 1 );
-						if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-							pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-					}
-					if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon( this ) )
-						pMarine->OnWeaponOutOfAmmo( true );
-				}
-#endif
+				NotifyIfNoneClip1Ammo( pMarine );
 			}
 		}
 		else

--- a/src/game/shared/swarm/asw_weapon_pistol_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_pistol_shared.cpp
@@ -169,25 +169,7 @@ void CASW_Weapon_Pistol::PrimaryAttack( void )
 		{
 			info.m_iShots = MIN( info.m_iShots, m_iClip1 );
 			m_iClip1 -= info.m_iShots;
-#ifdef GAME_DLL
-			if ( m_iClip1 <= 0 && pMarine->GetAmmoCount(m_iPrimaryAmmoType) <= 0 )
-			{
-				// check he doesn't have ammo in an ammo bay
-				CASW_Weapon_Ammo_Bag* pAmmoBag = NULL;
-				CASW_Weapon* pWeapon = pMarine->GetASWWeapon(0);
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-
-				if (!pAmmoBag)
-				{
-					pWeapon = pMarine->GetASWWeapon(1);
-					if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-						pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-				}
-				if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon(this) )
-					pMarine->OnWeaponOutOfAmmo(true);
-			}
-#endif
+			NotifyIfNoneClip1Ammo( pMarine );
 		}
 		else
 		{

--- a/src/game/shared/swarm/asw_weapon_plasma_thrower_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_plasma_thrower_shared.cpp
@@ -324,13 +324,7 @@ void CASW_Weapon_Plasma_Thrower::PrimaryAttack()
 	{
 		info.m_iShots = MIN( info.m_iShots, m_iClip1 );
 		m_iClip1 -= info.m_iShots;
-
-#ifdef GAME_DLL
-		if ( m_iClip1 <= 0 && pMarine && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
-		{
-			pMarine->OnWeaponOutOfAmmo( true );
-		}
-#endif
+		NotifyIfNoneClip1Ammo( pMarine );
 	}
 	else
 	{
@@ -491,12 +485,7 @@ void CASW_Weapon_Plasma_Thrower::SecondaryAttack()
 	}
 
 	m_iClip1 -= rd_plasma_thrower_airblast_ammo.GetInt();
-#ifdef GAME_DLL
-	if ( m_iClip1 <= 0 && pMarine && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
-	{
-		pMarine->OnWeaponOutOfAmmo( true );
-	}
-#endif
+	NotifyIfNoneClip1Ammo( pMarine );
 
 	SendWeaponAnim( GetSecondaryAttackActivity() );
 	if ( pMarine )

--- a/src/game/shared/swarm/asw_weapon_railgun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_railgun_shared.cpp
@@ -204,25 +204,7 @@ void CASW_Weapon_Railgun::PrimaryAttack()
 	{
 		info.m_iShots = MIN( info.m_iShots, m_iClip1 );
 		m_iClip1 -= info.m_iShots;
-#ifdef GAME_DLL
-			if ( m_iClip1 <= 0 && pMarine->GetAmmoCount(m_iPrimaryAmmoType) <= 0 )
-			{
-				// check he doesn't have ammo in an ammo bay
-				CASW_Weapon_Ammo_Bag* pAmmoBag = NULL;
-				CASW_Weapon* pWeapon = pMarine->GetASWWeapon(0);
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-
-				if (!pAmmoBag)
-				{
-					pWeapon = pMarine->GetASWWeapon(1);
-					if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-						pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-				}
-				if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon(this) )
-					pMarine->OnWeaponOutOfAmmo(true);
-			}
-#endif
+		NotifyIfNoneClip1Ammo( pMarine );
 	}
 	else
 	{

--- a/src/game/shared/swarm/asw_weapon_ricochet_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_ricochet_shared.cpp
@@ -163,26 +163,7 @@ void CASW_Weapon_Ricochet::PrimaryAttack()
 		{
 			info.m_iShots = MIN( info.m_iShots, m_iClip1 );
 			m_iClip1 -= info.m_iShots;
-
-#ifdef GAME_DLL
-			if ( m_iClip1 <= 0 && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
-			{
-				// check he doesn't have ammo in an ammo bay
-				CASW_Weapon_Ammo_Bag *pAmmoBag = NULL;
-				CASW_Weapon *pWeapon = pMarine->GetASWWeapon( 0 );
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-
-				if ( !pAmmoBag )
-				{
-					pWeapon = pMarine->GetASWWeapon( 1 );
-					if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-						pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-				}
-				if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon( this ) )
-					pMarine->OnWeaponOutOfAmmo( true );
-			}
-#endif
+			NotifyIfNoneClip1Ammo( pMarine );
 		}
 		else
 		{

--- a/src/game/shared/swarm/asw_weapon_rifle_burst_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_rifle_burst_shared.cpp
@@ -194,13 +194,7 @@ void CASW_Weapon_Rifle_Burst::DelayedAttack()
 	{
 		info.m_iShots = MIN( info.m_iShots, m_iClip1 );
 		m_iClip1 -= info.m_iShots;
-
-#ifdef GAME_DLL
-		if ( m_iClip1 <= 0 && pMarine && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
-		{
-			pMarine->OnWeaponOutOfAmmo( true );
-		}
-#endif
+		NotifyIfNoneClip1Ammo( pMarine );
 	}
 	else
 	{

--- a/src/game/shared/swarm/asw_weapon_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shared.cpp
@@ -662,22 +662,30 @@ bool CASW_Weapon::PrimaryAmmoLoaded( void )
 void CASW_Weapon::NotifyIfNoneClip1Ammo( CASW_Marine *pMarine )
 {
 #ifdef GAME_DLL
-	if ( m_iClip1 <= 0 && pMarine && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
+	if ( m_iClip1 <= 0 && pMarine && pMarine->GetAmmoCount(m_iPrimaryAmmoType) <= 0 )
 	{
-		// check he doesn't have ammo in an ammo bay
+		CASW_Weapon *pWeapon;
 		CASW_Weapon_Ammo_Bag *pAmmoBag = NULL;
-		CASW_Weapon *pWeapon = pMarine->GetASWWeapon( 0 );
+
+		pWeapon = pMarine->GetASWWeapon(0);
 		if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-			pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
+		{
+			pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
+		}
 
 		if ( !pAmmoBag )
 		{
-			pWeapon = pMarine->GetASWWeapon( 1 );
+			pWeapon = pMarine->GetASWWeapon(1);
 			if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-				pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
+			{
+				pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
+			}
 		}
-		if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon( this ) )
-			pMarine->OnWeaponOutOfAmmo( true );
+
+		if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon(this) )
+		{
+			pMarine->OnWeaponOutOfAmmo(true);
+		}
 	}
 #endif // GAME_DLL
 }

--- a/src/game/shared/swarm/asw_weapon_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shared.cpp
@@ -655,6 +655,32 @@ bool CASW_Weapon::PrimaryAmmoLoaded( void )
 	return (m_iClip1 > 0);
 }
 
+// if marine doesn't have ammo in an ammo bay
+// call pMarine->OnWeaponOutOfAmmo( true )
+//
+// `#ifdef GAME_DLL` in the body of this method
+void CASW_Weapon::NotifyIfNoneClip1Ammo( CASW_Marine *pMarine )
+{
+#ifdef GAME_DLL
+	if ( m_iClip1 <= 0 && pMarine && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
+	{
+		// check he doesn't have ammo in an ammo bay
+		CASW_Weapon_Ammo_Bag *pAmmoBag = NULL;
+		CASW_Weapon *pWeapon = pMarine->GetASWWeapon( 0 );
+		if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
+			pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
+
+		if ( !pAmmoBag )
+		{
+			pWeapon = pMarine->GetASWWeapon( 1 );
+			if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
+				pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
+		}
+		if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon( this ) )
+			pMarine->OnWeaponOutOfAmmo( true );
+	}
+#endif // GAME_DLL
+}
 
 void CASW_Weapon::PrimaryAttack( void )
 {

--- a/src/game/shared/swarm/asw_weapon_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shared.cpp
@@ -763,26 +763,7 @@ void CASW_Weapon::PrimaryAttack( void )
 	{
 		info.m_iShots = MIN( info.m_iShots, m_iClip1 );
 		m_iClip1 -= info.m_iShots;
-
-#ifdef GAME_DLL
-		if ( m_iClip1 <= 0 && pMarine && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
-		{
-			// check he doesn't have ammo in an ammo bay
-			CASW_Weapon_Ammo_Bag *pAmmoBag = NULL;
-			CASW_Weapon *pWeapon = pMarine->GetASWWeapon( 0 );
-			if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-				pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-
-			if ( !pAmmoBag )
-			{
-				pWeapon = pMarine->GetASWWeapon( 1 );
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-			}
-			if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon( this ) )
-				pMarine->OnWeaponOutOfAmmo( true );
-		}
-#endif
+		NotifyIfNoneClip1Ammo( pMarine );
 	}
 	else
 	{

--- a/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_shotgun_shared.cpp
@@ -276,25 +276,7 @@ void CASW_Weapon_Shotgun::PrimaryAttack( void )
 
 		// decrement ammo
 		m_iClip1 -= 1;
-#ifdef GAME_DLL
-		if ( m_iClip1 <= 0 && pMarine && pMarine->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
-		{
-			// check he doesn't have ammo in an ammo bay
-			CASW_Weapon_Ammo_Bag *pAmmoBag = NULL;
-			CASW_Weapon *pWeapon = pMarine->GetASWWeapon( 0 );
-			if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-				pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-
-			if ( !pAmmoBag )
-			{
-				pWeapon = pMarine->GetASWWeapon( 1 );
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast< CASW_Weapon_Ammo_Bag * >( pWeapon );
-			}
-			if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon( this ) )
-				pMarine->OnWeaponOutOfAmmo( true );
-		}
-#endif
+		NotifyIfNoneClip1Ammo( pMarine );
 	}
 
 	if ( m_iClip1 > 0 )		// only force the fire wait time if we have ammo for another shot

--- a/src/game/shared/swarm/asw_weapon_sniper_rifle.cpp
+++ b/src/game/shared/swarm/asw_weapon_sniper_rifle.cpp
@@ -168,25 +168,7 @@ void CASW_Weapon_Sniper_Rifle::PrimaryAttack( void )
 	{
 		info.m_iShots = MIN( info.m_iShots, m_iClip1 );
 		m_iClip1 -= info.m_iShots;
-#ifdef GAME_DLL
-		if ( m_iClip1 <= 0 && pMarine->GetAmmoCount(m_iPrimaryAmmoType) <= 0 )
-		{
-			// check he doesn't have ammo in an ammo bay
-			CASW_Weapon_Ammo_Bag* pAmmoBag = NULL;
-			CASW_Weapon* pWeapon = pMarine->GetASWWeapon(0);
-			if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-				pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-
-			if (!pAmmoBag)
-			{
-				pWeapon = pMarine->GetASWWeapon(1);
-				if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-					pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-			}
-			if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon(this) )
-				pMarine->OnWeaponOutOfAmmo(true);
-		}
-#endif
+		NotifyIfNoneClip1Ammo( pMarine );
 	}
 	else
 	{

--- a/src/game/shared/swarm/asw_weapon_tesla_gun_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_tesla_gun_shared.cpp
@@ -489,26 +489,7 @@ void CASW_Weapon_Tesla_Gun::Fire( const Vector &vecOrigSrc, const Vector &vecDir
 		SetFiringState( ASW_TG_FIRE_DISCHARGE );
 	}
 
-
-#ifdef GAME_DLL
-	if ( m_iClip1 <= 0 && pMarine->GetAmmoCount(m_iPrimaryAmmoType) <= 0 )
-	{
-		// check he doesn't have ammo in an ammo bay
-		CASW_Weapon_Ammo_Bag* pAmmoBag = NULL;
-		CASW_Weapon* pWeapon = pMarine->GetASWWeapon(0);
-		if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-			pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-
-		if (!pAmmoBag)
-		{
-			pWeapon = pMarine->GetASWWeapon(1);
-			if ( pWeapon && pWeapon->Classify() == CLASS_ASW_AMMO_BAG )
-				pAmmoBag = assert_cast<CASW_Weapon_Ammo_Bag*>(pWeapon);
-		}
-		if ( !pAmmoBag || !pAmmoBag->CanGiveAmmoToWeapon(this) )
-			pMarine->OnWeaponOutOfAmmo(true);
-	}
-#endif
+	NotifyIfNoneClip1Ammo( pMarine );
 
 	if ( tr.DidHit() )
 	{


### PR DESCRIPTION
This PR extracts the repeated out-of-ammo notification logic used across multiple weapons into a shared helper: `NotifyIfNoneClip1Ammo`.

## Changes

- Extract shared logic into `NotifyIfNoneClip1Ammo`
- Slightly refactor the extracted code for improved readability
- Replace all duplicated usages with the shared helper
- Replace similar code for beta weapons