### PR TITLE
Fix marines unexpectedly aiming at targets above the camera

### DIFF
--- a/src/game/client/swarm/asw_input.cpp
+++ b/src/game/client/swarm/asw_input.cpp
@@ -55,6 +55,8 @@ ConVar joy_disable_movement_in_ui( "joy_disable_movement_in_ui", "1", FCVAR_NONE
 ConVar rd_input_controller_mode_mouse( "rd_input_controller_mode_mouse", "-1", FCVAR_NONE );
 ConVar rd_input_controller_mode_keyboard( "rd_input_controller_mode_keyboard", "-1", FCVAR_NONE );
 
+ConVar rd_aim_ignore_above_camera_z( "rd_aim_ignore_above_camera_z", "-60", FCVAR_NONE, "Targets above the camera by this Z distance are ignored in top-down mode" );
+
 extern kbutton_t in_attack;
 extern kbutton_t in_walk;
 extern int g_asw_iPlayerListOpen;
@@ -464,7 +466,7 @@ C_BaseEntity* HUDToWorld(float screenx, float screeny,
 		Vector vecAlienPos = pBestAlien->GetAimTargetRadiusPos( vecWeaponPos );
 
 		// Don't aim at stuff a bit below camera and higher
-		if ( vecAlienPos.z > vCameraLocation.z - 60.0f )
+		if ( vecAlienPos.z > vCameraLocation.z + rd_aim_ignore_above_camera_z.GetFloat() )
 		{
 			pBestAlien = NULL;
 		}
@@ -519,7 +521,8 @@ C_BaseEntity* HUDToWorld(float screenx, float screeny,
 				continue;
 
 			// Don't aim at stuff a bit below camera and higher
-			if ( pPlayer->GetASWControls() == ASWC_TOPDOWN && vecAlienPos.z > vCameraLocation.z - 60.0f )
+			if ( pPlayer->GetASWControls() == ASWC_TOPDOWN &&
+					vecAlienPos.z > vCameraLocation.z + rd_aim_ignore_above_camera_z.GetFloat() )
 				continue;
 
 			Vector vDirection = vecAlienPos - vecWeaponPos;

--- a/src/game/client/swarm/asw_input.cpp
+++ b/src/game/client/swarm/asw_input.cpp
@@ -457,6 +457,19 @@ C_BaseEntity* HUDToWorld(float screenx, float screeny,
 	if (asw_DebugAutoAim.GetBool())
 		ASW_StoreClearAll();
 
+	// Check bad aim angles
+	if ( pPlayer->GetASWControls() == ASWC_TOPDOWN &&
+			!ASWInput()->ControllerModeActiveMouse() && pBestAlien )
+	{
+		Vector vecAlienPos = pBestAlien->GetAimTargetRadiusPos( vecWeaponPos );
+
+		// Don't aim at stuff a bit below camera and higher
+		if ( vecAlienPos.z > vCameraLocation.z - 60.0f )
+		{
+			pBestAlien = NULL;
+		}
+	}
+
 	// if we have our cursor over a target (and not using the controller), make sure we have LOS to him before we continue
 	if ( !ASWInput()->ControllerModeActiveMouse() && pBestAlien )
 	{
@@ -503,6 +516,10 @@ C_BaseEntity* HUDToWorld(float screenx, float screeny,
 			// check he's in range
 			Vector vecAlienPos = pAimTarget->GetAimTargetRadiusPos(vecWeaponPos); //pEnt->WorldSpaceCenter();
 			if ( vecAlienPos.DistToSqr(vecWeaponPos) > ASW_MAX_AUTO_AIM_RANGE )
+				continue;
+
+			// Don't aim at stuff a bit below camera and higher
+			if ( pPlayer->GetASWControls() == ASWC_TOPDOWN && vecAlienPos.z > vCameraLocation.z - 60.0f )
 				continue;
 
 			Vector vDirection = vecAlienPos - vecWeaponPos;


### PR DESCRIPTION
- Closes #444

This PR fixes an issue where marine aim could suddenly launch upward, even when there appeared to be nothing under the cursor.

The `rd_limit_aim_top_offset` convar has been introduced to allow customization of the aiming limit behavior.

## Description

The targeting logic now filters potential aim targets by comparing their Z coordinate against the camera's Z position. An additional offset lowers the threshold slightly to avoid cases where:
- a target's hitbox clips through the camera
- a target occupies most of the screen space

The change does not affect aiming at the ground and first person challenge and should not interfere with targeting enemies that are normally visible to the player.

## Offset examples

- **-50** - removes most noticeable aim glitches while still allowing targets positioned high above the player (for example, enemies on the cargo elevator ceiling)
- **-70** - ignores drones that are extremely close to the camera and fill roughly half the screen
- **-2000** - effectively disables aim target selection
- **99999** - effectively disables this fix

## Good maps for testing

- `as_city17_05` Citadel (last map of City 17) on the elevator
- `rd-bonus14_cargrev` Reversed Cargo Elevator
- `dc1-omega_city` Omega City (first map of Dead City) first trigger

---

P.S. A better fix would probably involve results of `UTIL_TraceLine`.