### PR TITLE
Increase minigun low-ammo click sound threshold

### DIFF
--- a/src/game/shared/swarm/asw_weapon_minigun.h
+++ b/src/game/shared/swarm/asw_weapon_minigun.h
@@ -33,6 +33,7 @@ public:
 
 	virtual const float GetAutoAimAmount() { return 0.0f; }
 	virtual const float GetAutoAimRadiusScale() { return 1.0f; }
+	virtual int AmmoClickPoint() { return 8; } // displayed ammo is double of that
 	virtual const Vector& GetBulletSpread( void );
 	virtual void ItemPostFrame();
 	virtual void ItemBusyFrame();


### PR DESCRIPTION
- From default 6 to 8 (12 to 16) - increase by 33%. 25% would be better, but we work with int.
- Close #278