### PR TITLE
Prevent reload of heal and amp ammo of various healguns

### DIFF
--- a/src/game/shared/swarm/asw_weapon_heal_gun_shared.h
+++ b/src/game/shared/swarm/asw_weapon_heal_gun_shared.h
@@ -52,6 +52,7 @@ public:
 	virtual void	HealAttack() { PrimaryAttack(); }
 	virtual bool	HasMedicalAmmo() { return HasPrimaryAmmo(); }
 	virtual bool	SecondaryAttackUsesPrimaryAmmo() { return true; }
+	virtual bool	UsesClipsForAmmo1() const override { return false; }
 	virtual bool	Reload( void );
 	virtual bool	HasAmmo();
 	virtual void	WeaponIdle( void );

--- a/src/game/shared/swarm/asw_weapon_healamp_gun_shared.h
+++ b/src/game/shared/swarm/asw_weapon_healamp_gun_shared.h
@@ -24,7 +24,7 @@ public:
 
 	virtual Class_T		Classify( void ) { return (Class_T)CLASS_ASW_HEALAMP_GUN; }
 	virtual bool		SecondaryAttackUsesPrimaryAmmo() { return false; }
-	virtual bool		UsesClipsForAmmo2() { return false; }
+	virtual bool		UsesClipsForAmmo2() const override { return false; }
 
 #ifdef CLIENT_DLL
 	virtual void MouseOverEntity(C_BaseEntity *pEnt, Vector vecWorldCursor);

--- a/src/game/shared/swarm/asw_weapon_medrifle_shared.h
+++ b/src/game/shared/swarm/asw_weapon_medrifle_shared.h
@@ -39,6 +39,7 @@ public:
 	virtual void SecondaryAttack();
 	virtual void HealAttack() { SecondaryAttack(); }
 	virtual bool HasMedicalAmmo() { return HasSecondaryAmmo(); }
+	virtual bool UsesClipsForAmmo2() const override { return false; }
 	virtual void WeaponIdle( void );
 	virtual const Vector& GetBulletSpread( void );
 	virtual void ItemPostFrame();


### PR DESCRIPTION
Fix issue where healguns would reload (to 0) when ammo count exceeded defined clip ammo count.

Should prevent any future regressions similar to #590, #1062.