### PR TITLE
Revert "Prevent reload of heal and amp ammo of various healguns"

### DIFF
--- a/src/game/shared/swarm/asw_weapon_heal_gun_shared.h
+++ b/src/game/shared/swarm/asw_weapon_heal_gun_shared.h
@@ -52,7 +52,6 @@ public:
 	virtual void	HealAttack() { PrimaryAttack(); }
 	virtual bool	HasMedicalAmmo() { return HasPrimaryAmmo(); }
 	virtual bool	SecondaryAttackUsesPrimaryAmmo() { return true; }
-	virtual bool	UsesClipsForAmmo1() const override { return false; }
 	virtual bool	Reload( void );
 	virtual bool	HasAmmo();
 	virtual void	WeaponIdle( void );

--- a/src/game/shared/swarm/asw_weapon_healamp_gun_shared.h
+++ b/src/game/shared/swarm/asw_weapon_healamp_gun_shared.h
@@ -24,7 +24,7 @@ public:
 
 	virtual Class_T		Classify( void ) { return (Class_T)CLASS_ASW_HEALAMP_GUN; }
 	virtual bool		SecondaryAttackUsesPrimaryAmmo() { return false; }
-	virtual bool		UsesClipsForAmmo2() const override { return false; }
+	virtual bool		UsesClipsForAmmo2() { return false; }
 
 #ifdef CLIENT_DLL
 	virtual void MouseOverEntity(C_BaseEntity *pEnt, Vector vecWorldCursor);

--- a/src/game/shared/swarm/asw_weapon_medrifle_shared.h
+++ b/src/game/shared/swarm/asw_weapon_medrifle_shared.h
@@ -39,7 +39,6 @@ public:
 	virtual void SecondaryAttack();
 	virtual void HealAttack() { SecondaryAttack(); }
 	virtual bool HasMedicalAmmo() { return HasSecondaryAmmo(); }
-	virtual bool UsesClipsForAmmo2() const override { return false; }
 	virtual void WeaponIdle( void );
 	virtual const Vector& GetBulletSpread( void );
 	virtual void ItemPostFrame();


### PR DESCRIPTION
Reverts ReactiveDrop/reactivedrop_public_src#1063

Ok, this need to be reverted because apparently it breaks `CBaseCombatWeapon::GiveDefaultAmmo` and makes map healguns spawn without heal ammo :exploding_head:

And healamp gun's original `UsesClipsForAmmo2` does not do anything because it does not match signature of parents.

https://github.com/ReactiveDrop/reactivedrop_public_src/blob/3a3d5fe495fe68af3dd90ea31a5d3981b356f792/src/game/shared/basecombatweapon_shared.cpp#L125-L146