### PR TITLE
Bulldog prevent endless reload when holding attack before reloading

### DIFF
--- a/src/game/shared/swarm/asw_weapon_deagle_shared.cpp
+++ b/src/game/shared/swarm/asw_weapon_deagle_shared.cpp
@@ -70,7 +70,7 @@ void CASW_Weapon_DEagle::ItemPostFrame()
 {
 	CBasePlayer *pOwner = GetCommander();
 
-	if ( !m_bCanShoot && pOwner && !( pOwner->m_afButtonReleased & IN_ATTACK ) && ( pOwner->m_nButtons & IN_ATTACK ) )
+	if ( !m_bInReload && !m_bCanShoot && pOwner && !( pOwner->m_afButtonReleased & IN_ATTACK ) && ( pOwner->m_nButtons & IN_ATTACK ) )
 	{
 		// pretend we're still on cooldown so we don't run the weapon_fire event
 		m_flNextPrimaryAttack = MAX( gpGlobals->curtime + TICK_INTERVAL, m_flNextPrimaryAttack );


### PR DESCRIPTION
- Fix #1054