### PR TITLE
Add extra buff time for damage amplifier ticks to prevent gaps

### DIFF
--- a/src/game/server/swarm/asw_buffgrenade_projectile.cpp
+++ b/src/game/server/swarm/asw_buffgrenade_projectile.cpp
@@ -90,7 +90,7 @@ void CASW_BuffGrenade_Projectile::StartAOE( CBaseEntity *pEntity )
 		return;
 	}
 
-	pMarine->AddDamageBuff( this, MIN( m_flTimeBurnOut - gpGlobals->curtime, GetDoAOEDelayTime() ), (Class_T) CLASS_ASW_BUFF_GRENADE, CASW_Marine::AsMarine( GetOwnerEntity() ) );
+	pMarine->AddDamageBuff( this, MIN( m_flTimeBurnOut - gpGlobals->curtime, GetDoAOEDelayTime() + 0.17f ), (Class_T) CLASS_ASW_BUFF_GRENADE, CASW_Marine::AsMarine( GetOwnerEntity() ) );
 	//NDebugOverlay::Box( pMarine->GetAbsOrigin(), Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), 0, 0, 255, 200, 0.5 );
 
 	EHANDLE hMarine = pMarine;
@@ -110,7 +110,7 @@ void CASW_BuffGrenade_Projectile::DoAOE( CBaseEntity *pEntity )
 		return;
 	}
 
-	pMarine->AddDamageBuff( this, MIN( m_flTimeBurnOut - gpGlobals->curtime, GetDoAOEDelayTime() * 1.1f ), ( Class_T )CLASS_ASW_BUFF_GRENADE, CASW_Marine::AsMarine( GetOwnerEntity() ) );
+	pMarine->AddDamageBuff( this, MIN( m_flTimeBurnOut - gpGlobals->curtime, GetDoAOEDelayTime() + 0.17f ), ( Class_T )CLASS_ASW_BUFF_GRENADE, CASW_Marine::AsMarine( GetOwnerEntity() ) );
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
- Fix #790

I haven't tested smaller values, but `0.17` seems to be magical enough for preventing gaps.
*My idea was 0.1 think + 0.05 cl_cmdrate=20 + 0.02 extra magic.*