### PR TITLE
Misc refactors to appease the compiler

### DIFF
--- a/src/game/client/c_baseanimating.cpp
+++ b/src/game/client/c_baseanimating.cpp
@@ -1204,43 +1204,43 @@ void C_BaseAnimating::ParseModelEffects( KeyValues *modelKeyValues )
 		for ( KeyValues *pSingleEffect = pkvAllParticleEffects->GetFirstSubKey(); pSingleEffect; pSingleEffect = pSingleEffect->GetNextKey() )
 		{
 			const char *pszParticleEffect = pSingleEffect->GetString( "name", "" );
-			const char *pszAttachment = pSingleEffect->GetString( "attachment_point", "" );
-			const char *pszAttachType = pSingleEffect->GetString( "attachment_type", "" );
-			const char *pszAttachOffset = pSingleEffect->GetString( "attachment_offset", "" );
+			const char *pszPEAttachment = pSingleEffect->GetString( "attachment_point", "" );
+			const char *pszPEAttachType = pSingleEffect->GetString( "attachment_type", "" );
+			const char *pszPEAttachOffset = pSingleEffect->GetString( "attachment_offset", "" );
 
 			// Convert attach type
-			int iAttachType = GetAttachTypeFromString( pszAttachType );
-			if ( iAttachType == -1 )
+			int iPEAttachType = GetAttachTypeFromString( pszPEAttachType );
+			if ( iPEAttachType == -1 )
 			{
-				Warning("Invalid attach type specified for particle effect in model '%s' keyvalues section. Trying to spawn effect '%s' with attach type of '%s'\n", GetModelName(), pszParticleEffect, pszAttachType );
+				Warning("Invalid attach type specified for particle effect in model '%s' keyvalues section. Trying to spawn effect '%s' with attach type of '%s'\n", GetModelName(), pszParticleEffect, pszPEAttachType );
 				return;
 			}
 
 			// Convert attachment point
-			int iAttachment = atoi(pszAttachment);
+			int iAttachment = atoi(pszPEAttachment);
 			// See if we can find any attachment points matching the name
-			if ( pszAttachment[0] != '0' && iAttachment == 0 )
+			if ( pszPEAttachment[0] != '0' && iAttachment == 0 )
 			{
-				iAttachment = LookupAttachment( pszAttachment );
+				iAttachment = LookupAttachment( pszPEAttachment );
 				if ( iAttachment == -1 )
 				{
-					Warning("Failed to find attachment point specified for particle effect in model '%s' keyvalues section. Trying to spawn effect '%s' on attachment named '%s'\n", GetModelName(), pszParticleEffect, pszAttachment );
+					Warning("Failed to find attachment point specified for particle effect in model '%s' keyvalues section. Trying to spawn effect '%s' on attachment named '%s'\n", GetModelName(), pszParticleEffect, pszPEAttachment );
 					return;
 				}
 			}
 
-			Vector vecOffset = vec3_origin;
+			Vector vecOffsetPE = vec3_origin;
 
-			if ( pszAttachOffset )
+			if ( pszPEAttachOffset )
 			{
 				float flVec[3];
-				UTIL_StringToVector( flVec, pszAttachOffset );
-				vecOffset = Vector( flVec[0], flVec[1], flVec[2] );
+				UTIL_StringToVector( flVec, pszPEAttachOffset );
+				vecOffsetPE = Vector( flVec[0], flVec[1], flVec[2] );
 			}
 
 			CUtlReference<CNewParticleEffect> hModelEffect;
 			// Spawn the particle effectw
-			hModelEffect = ParticleProp()->Create( pszParticleEffect, (ParticleAttachment_t)iAttachType, iAttachment, vecOffset );
+			hModelEffect = ParticleProp()->Create( pszParticleEffect, (ParticleAttachment_t)iPEAttachType, iAttachment, vecOffsetPE );
 
 			KeyValues *pkvAllControlPoints = pSingleEffect->FindKey("ControlPoints");
 			if ( pkvAllControlPoints )
@@ -1249,37 +1249,37 @@ void C_BaseAnimating::ParseModelEffects( KeyValues *modelKeyValues )
 				for ( KeyValues *pSingleCP = pkvAllControlPoints->GetFirstSubKey(); pSingleCP; pSingleCP = pSingleCP->GetNextKey() )
 				{
 					const char *pszControlPoint = pSingleCP->GetString( "cp_number", "" );
-					const char *pszAttachment = pSingleCP->GetString( "attachment_point", "" );
-					const char *pszAttachType = pSingleCP->GetString( "attachment_type", "" );
-					const char *pszAttachOffset = pSingleCP->GetString( "attachment_offset", "" );
+					const char *pszCPAttachment = pSingleCP->GetString( "attachment_point", "" );
+					const char *pszCPAttachType = pSingleCP->GetString( "attachment_type", "" );
+					const char *pszCPAttachOffset = pSingleCP->GetString( "attachment_offset", "" );
 
 					// Convert control point
 					int iControlPoint = atoi(pszControlPoint);
 
 					// Convert attach type
-					int iAttachType = GetAttachTypeFromString( pszAttachType );
-					if ( iAttachType == -1 )
+					int iCPAttachType = GetAttachTypeFromString( pszCPAttachType );
+					if ( iCPAttachType == -1 )
 					{
-						Warning("Invalid attach type specified for particle effect in model '%s' keyvalues section. Trying to spawn effect '%s' with attach type of '%s'\n", GetModelName(), pszParticleEffect, pszAttachType );
+						Warning("Invalid attach type specified for particle effect in model '%s' keyvalues section. Trying to spawn effect '%s' with attach type of '%s'\n", GetModelName(), pszParticleEffect, pszCPAttachType );
 						return;
 					}
 
-					Vector vecOffset = vec3_origin;
+					Vector vecOffsetCP = vec3_origin;
 
-					if ( pszAttachOffset )
+					if ( pszCPAttachOffset )
 					{
 						float flVec[3];
-						UTIL_StringToVector( flVec, pszAttachOffset );
-						vecOffset = Vector( flVec[0], flVec[1], flVec[2] );
+						UTIL_StringToVector( flVec, pszCPAttachOffset );
+						vecOffsetCP = Vector( flVec[0], flVec[1], flVec[2] );
 					}
 
 					// Add the control point if we already have the effect
 					if ( hModelEffect )
 					{
-						if ( iAttachType == PATTACH_WORLDORIGIN )
-							ParticleProp()->AddControlPoint( hModelEffect, iControlPoint, NULL, (ParticleAttachment_t)iAttachType, NULL, vecOffset );
+						if ( iCPAttachType == PATTACH_WORLDORIGIN )
+							ParticleProp()->AddControlPoint( hModelEffect, iControlPoint, NULL, (ParticleAttachment_t)iCPAttachType, NULL, vecOffsetCP );
 						else
-							ParticleProp()->AddControlPoint( hModelEffect, iControlPoint, this, (ParticleAttachment_t)iAttachType, pszAttachment, vecOffset );
+							ParticleProp()->AddControlPoint( hModelEffect, iControlPoint, this, (ParticleAttachment_t)iCPAttachType, pszCPAttachment, vecOffsetCP );
 					}
 
 				}
@@ -3403,9 +3403,9 @@ void C_BaseAnimating::DoInternalDrawModel( ClientModelRenderInfo_t *pInfo, DrawM
 				if ( VPhysicsGetObject() )
 				{
 					static color32 debugColorPhys = {255,0,0,0};
-					matrix3x4_t matrix;
-					VPhysicsGetObject()->GetPositionMatrix( &matrix );
-					engine->DebugDrawPhysCollide( pCollide->solids[0], NULL, matrix, debugColorPhys );
+					matrix3x4_t matrix2;
+					VPhysicsGetObject()->GetPositionMatrix( &matrix2 );
+					engine->DebugDrawPhysCollide( pCollide->solids[0], NULL, matrix2, debugColorPhys );
 				}
 			}
 		}

--- a/src/game/client/c_baseflex.cpp
+++ b/src/game/client/c_baseflex.cpp
@@ -478,8 +478,7 @@ public:
 		Q_FixSlashes( szFilename );
 
 		// See if it's already loaded
-		int i;
-		for ( i = 0; i < m_FileList.Count(); i++ )
+		for ( int i = 0; i < m_FileList.Count(); i++ )
 		{
 			CFlexSceneFile *file = m_FileList[ i ];
 			if ( file && !V_stricmp( file->filename, szFilename ) )

--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -457,8 +457,7 @@ void C_BasePlayer::Spawn( void )
 	ClearFlags();
 	AddFlag( FL_CLIENT );
 
-	int effects = GetEffects() & EF_NOSHADOW;
-	SetEffects( effects );
+	SetEffects( GetEffects() & EF_NOSHADOW );
 
 	m_iFOV	= 0;	// init field of view.
 
@@ -1526,17 +1525,17 @@ void C_BasePlayer::CalcChaseCamView(Vector& eyeOrigin, QAngle& eyeAngles, float&
 
 void C_BasePlayer::CalcRoamingView(Vector& eyeOrigin, QAngle& eyeAngles, float& fov)
 {
-	C_BaseEntity *target = GetObserverTarget();
-	
-	if ( !target ) 
+	C_BaseEntity *observerTarget = GetObserverTarget();
+
+	if ( !observerTarget )
 	{
-		target = this;
+		observerTarget = this;
 	}
 
 	m_flObserverChaseDistance = 0.0;
 
-	eyeOrigin = target->EyePosition();
-	eyeAngles = target->EyeAngles();
+	eyeOrigin = observerTarget->EyePosition();
+	eyeAngles = observerTarget->EyeAngles();
 
 	if ( spec_track.GetInt() > 0 )
 	{

--- a/src/game/client/c_basetempentity.cpp
+++ b/src/game/client/c_basetempentity.cpp
@@ -92,11 +92,11 @@ void C_BaseTempEntity::Precache( void )
 //-----------------------------------------------------------------------------
 void C_BaseTempEntity::PrecacheTempEnts( void )
 {
-	C_BaseTempEntity *te = GetList();
-	while ( te )
+	C_BaseTempEntity *tempEntity = GetList();
+	while ( tempEntity )
 	{
-		te->Precache();
-		te = te->GetNext();
+		tempEntity->Precache();
+		tempEntity = tempEntity->GetNext();
 	}
 }
 
@@ -106,12 +106,12 @@ void C_BaseTempEntity::PrecacheTempEnts( void )
 void C_BaseTempEntity::ClearDynamicTempEnts( void )
 {
 	C_BaseTempEntity *next;
-	C_BaseTempEntity *te = s_pDynamicEntities;
-	while ( te )
+	C_BaseTempEntity *tempEntity = s_pDynamicEntities;
+	while ( tempEntity )
 	{
-		next = te->GetNextDynamic();
-		delete te;
-		te = next;
+		next = tempEntity->GetNextDynamic();
+		delete tempEntity;
+		tempEntity = next;
 	}
 
 	s_pDynamicEntities = NULL;
@@ -123,20 +123,20 @@ void C_BaseTempEntity::ClearDynamicTempEnts( void )
 void C_BaseTempEntity::CheckDynamicTempEnts( void )
 {
 	C_BaseTempEntity *next, *newlist = NULL;
-	C_BaseTempEntity *te = s_pDynamicEntities;
-	while ( te )
+	C_BaseTempEntity *tempEntity = s_pDynamicEntities;
+	while ( tempEntity )
 	{
-		next = te->GetNextDynamic();
-		if ( te->ShouldDestroy() )
+		next = tempEntity->GetNextDynamic();
+		if ( tempEntity->ShouldDestroy() )
 		{
-			delete te;
+			delete tempEntity;
 		}
 		else
 		{
-			te->m_pNextDynamic = newlist;
-			newlist = te;
+			tempEntity->m_pNextDynamic = newlist;
+			newlist = tempEntity;
 		}
-		te = next;
+		tempEntity = next;
 	}
 
 	s_pDynamicEntities = newlist;

--- a/src/game/client/c_env_projectedtexture.cpp
+++ b/src/game/client/c_env_projectedtexture.cpp
@@ -312,9 +312,8 @@ void C_EnvProjectedTexture::UpdateLight( void )
 
 			NDebugOverlay::Box( vec3_origin, mins, maxs, 0, 255, 0, 100, 0.0f );
 #endif
-			
-			bool bVisible = IsBBoxVisible( mins, maxs );
-			if (!bVisible)
+
+			if ( !IsBBoxVisible( mins, maxs ) )
 			{
 				// Spotlight's extents aren't in view
 				if ( m_LightHandle != CLIENTSHADOW_INVALID_HANDLE )

--- a/src/game/client/c_particle_smokegrenade.cpp
+++ b/src/game/client/c_particle_smokegrenade.cpp
@@ -909,12 +909,12 @@ void C_ParticleSmokeGrenade::CleanupToolRecordingState( KeyValues *msg )
 
 		int nId = AllocateToolParticleEffectId();
 
-		KeyValues *msg = new KeyValues( "OldParticleSystem_Create" );
-		msg->SetString( "name", "C_ParticleSmokeGrenade" );
-		msg->SetInt( "id", nId );
-		msg->SetFloat( "time", gpGlobals->curtime );
+		KeyValues *kvMsg = new KeyValues( "OldParticleSystem_Create" );
+		kvMsg->SetString( "name", "C_ParticleSmokeGrenade" );
+		kvMsg->SetInt( "id", nId );
+		kvMsg->SetFloat( "time", gpGlobals->curtime );
 
-		KeyValues *pEmitter = msg->FindKey( "DmeSpriteEmitter", true );
+		KeyValues *pEmitter = kvMsg->FindKey( "DmeSpriteEmitter", true );
 		pEmitter->SetInt( "count", NUM_PARTICLES_PER_DIMENSION * NUM_PARTICLES_PER_DIMENSION * NUM_PARTICLES_PER_DIMENSION );
 		pEmitter->SetFloat( "duration", 0 );
 		pEmitter->SetString( "material", "particle/particle_smokegrenade1" );
@@ -991,8 +991,8 @@ void C_ParticleSmokeGrenade::CleanupToolRecordingState( KeyValues *msg )
 		pSmokeGrenadeUpdater->SetFloat( "radiusExpandTime", SMOKESPHERE_EXPAND_TIME );
 		pSmokeGrenadeUpdater->SetFloat( "cutoffFraction", 0.7f );
 
-		ToolFramework_PostToolMessage( HTOOLHANDLE_INVALID, msg );
-		msg->deleteThis();
+		ToolFramework_PostToolMessage( HTOOLHANDLE_INVALID, kvMsg );
+		kvMsg->deleteThis();
 	}
 }
 

--- a/src/game/client/c_rope.cpp
+++ b/src/game/client/c_rope.cpp
@@ -234,9 +234,9 @@ void CRopeManager::AddToRenderCache( C_RopeKeyframe *pRope )
 	// If we didn't find one, then allocate the mofo.
 	if ( iRenderCache == nRenderCacheCount )
 	{
-		int iRenderCache = m_aRenderCache.AddToTail();
-		m_aRenderCache[iRenderCache].m_pSolidMaterial = pRope->GetSolidMaterial();
-		m_aRenderCache[iRenderCache].m_nCacheCount = 0;
+		int tail = m_aRenderCache.AddToTail();
+		m_aRenderCache[tail].m_pSolidMaterial = pRope->GetSolidMaterial();
+		m_aRenderCache[tail].m_nCacheCount = 0;
 	}
 
 	if ( m_aRenderCache[iRenderCache].m_nCacheCount >= MAX_ROPE_RENDERCACHE )
@@ -1506,6 +1506,7 @@ struct catmull_t
 };
 
 // bake out the terms of the catmull rom spline
+#pragma warning(suppress : 4459) // declaration of 'p4' hides global declaration
 void Catmull_Rom_Spline_Matrix( const Vector &p1, const Vector &p2, const Vector &p3, const Vector &p4, catmull_t &output )
 {
 	output.t3 = 0.5f * ((-1*p1) + (3*p2) + (-3*p3) + p4);	// 0.5 t^3 * [ (-1*p1) + ( 3*p2) + (-3*p3) + p4 ]
@@ -1618,10 +1619,10 @@ bool C_RopeKeyframe::CalculateEndPointAttachment( C_BaseEntity *pEnt, int iAttac
 			if ( !pModel )
 				return false;
 
-			int iAttachment = pModel->LookupAttachment( "buff_attach" );
+			int iBuffAttachment = pModel->LookupAttachment( "buff_attach" );
 			if ( pAngles )
-				return pModel->GetAttachment( iAttachment, vPos, *pAngles );
-			return pModel->GetAttachment( iAttachment, vPos );
+				return pModel->GetAttachment( iBuffAttachment, vPos, *pAngles );
+			return pModel->GetAttachment( iBuffAttachment, vPos );
 		}
 	}
 

--- a/src/game/client/c_sceneentity.cpp
+++ b/src/game/client/c_sceneentity.cpp
@@ -1145,11 +1145,11 @@ void C_SceneEntity::PrefetchAnimBlocks( CChoreoScene *pScene )
 							{
 								// Now look up the animblock
 								mstudioseqdesc_t &seqdesc = pStudioHdr->pSeqdesc( iSequence );
-								for ( int i = 0 ; i < seqdesc.groupsize[ 0 ] ; ++i )
+								for ( int j = 0 ; j < seqdesc.groupsize[ 0 ] ; ++j )
 								{
-									for ( int j = 0; j < seqdesc.groupsize[ 1 ]; ++j )
+									for ( int k = 0; k < seqdesc.groupsize[ 1 ]; ++k )
 									{
-										int iAnimation = seqdesc.anim( i, j );
+										int iAnimation = seqdesc.anim( j, k );
 										int iBaseAnimation = pStudioHdr->iRelativeAnim( iSequence, iAnimation );
 										mstudioanimdesc_t &animdesc = pStudioHdr->pAnimdesc( iBaseAnimation );
 
@@ -1168,14 +1168,14 @@ void C_SceneEntity::PrefetchAnimBlocks( CChoreoScene *pScene )
 											++nResident;
 											if ( nSpew > 1 )
 											{
-												Msg( "%s:%s[%i:%i] was resident\n", pStudioHdr->pszName(), animdesc.pszName(), i, j );
+												Msg( "%s:%s[%i:%i] was resident\n", pStudioHdr->pszName(), animdesc.pszName(), j, k );
 											}
 										}
 										else
 										{
 											if ( nSpew != 0 )
 											{
-												Msg( "%s:%s[%i:%i] async load\n", pStudioHdr->pszName(), animdesc.pszName(), i, j );
+												Msg( "%s:%s[%i:%i] async load\n", pStudioHdr->pszName(), animdesc.pszName(), j, k );
 											}
 										}
 									}

--- a/src/game/client/c_smoke_trail.cpp
+++ b/src/game/client/c_smoke_trail.cpp
@@ -396,12 +396,12 @@ void C_SmokeTrail::CleanupToolRecordingState( KeyValues *msg )
 	{
 		int nId = m_pSmokeEmitter->AllocateToolParticleEffectId();
 
-		KeyValues *msg = new KeyValues( "OldParticleSystem_Create" );
-		msg->SetString( "name", "C_SmokeTrail" );
-		msg->SetInt( "id", nId );
-		msg->SetFloat( "time", gpGlobals->curtime );
+		KeyValues *kvMsg = new KeyValues( "OldParticleSystem_Create" );
+		kvMsg->SetString( "name", "C_SmokeTrail" );
+		kvMsg->SetInt( "id", nId );
+		kvMsg->SetFloat( "time", gpGlobals->curtime );
 
-		KeyValues *pRandomEmitter = msg->FindKey( "DmeRandomEmitter", true );
+		KeyValues *pRandomEmitter = kvMsg->FindKey( "DmeRandomEmitter", true );
 		pRandomEmitter->SetInt( "count", m_SpawnRate );	// particles per second, when duration is < 0
 		pRandomEmitter->SetFloat( "duration", -1 );
 		pRandomEmitter->SetInt( "active", bEmitterActive );
@@ -486,18 +486,18 @@ void C_SmokeTrail::CleanupToolRecordingState( KeyValues *msg )
 		pEmitter2->SetString( "material", "particle/particle_noisesphere" );
 		pEmitterParent2->AddSubKey( pEmitter2 );
 
-		ToolFramework_PostToolMessage( HTOOLHANDLE_INVALID, msg );
-		msg->deleteThis();
+		ToolFramework_PostToolMessage( HTOOLHANDLE_INVALID, kvMsg );
+		kvMsg->deleteThis();
 	}
 	else 
 	{
-		KeyValues *msg = new KeyValues( "OldParticleSystem_ActivateEmitter" );
-		msg->SetInt( "id", m_pSmokeEmitter->GetToolParticleEffectId() );
-		msg->SetInt( "emitter", 0 );
-		msg->SetInt( "active", bEmitterActive );
-		msg->SetFloat( "time", gpGlobals->curtime );
-		ToolFramework_PostToolMessage( HTOOLHANDLE_INVALID, msg );
-		msg->deleteThis();
+		KeyValues *kvMsg = new KeyValues( "OldParticleSystem_ActivateEmitter" );
+		kvMsg->SetInt( "id", m_pSmokeEmitter->GetToolParticleEffectId() );
+		kvMsg->SetInt( "emitter", 0 );
+		kvMsg->SetInt( "active", bEmitterActive );
+		kvMsg->SetFloat( "time", gpGlobals->curtime );
+		ToolFramework_PostToolMessage( HTOOLHANDLE_INVALID, kvMsg );
+		kvMsg->deleteThis();
 	}
 }
 
@@ -770,8 +770,8 @@ void C_RocketTrail::Update( float fTimeDelta )
 	
 	if ( m_bDamaged )
 	{
-		SimpleParticle	*pParticle;
-		Vector			offset;
+		SimpleParticle	*pFlameParticle;
+		Vector			randomOffset;
 		Vector			offsetColor;
 
 		CSmartPtr<CEmberEffect>	pEmitter = CEmberEffect::Create("C_RocketTrail::damaged");
@@ -783,36 +783,36 @@ void C_RocketTrail::Update( float fTimeDelta )
 		// Flames from the rocket
 		for ( i = 0; i < 8; i++ )
 		{
-			offset = RandomVector( -8, 8 ) + GetAbsOrigin();
+			randomOffset = RandomVector( -8, 8 ) + GetAbsOrigin();
 
-			pParticle = (SimpleParticle *) pEmitter->AddParticle( sizeof( SimpleParticle ), flameMaterial, offset );
+			pFlameParticle = (SimpleParticle *) pEmitter->AddParticle( sizeof( SimpleParticle ), flameMaterial, randomOffset );
 
-			if ( pParticle != NULL )
+			if ( pFlameParticle != NULL )
 			{
-				pParticle->m_flLifetime		= 0.0f;
-				pParticle->m_flDieTime		= 0.25f;
+				pFlameParticle->m_flLifetime	= 0.0f;
+				pFlameParticle->m_flDieTime		= 0.25f;
 
-				pParticle->m_vecVelocity.Random( -1.0f, 1.0f );
-				pParticle->m_vecVelocity *= random->RandomFloat( 32, 128 );
-				
+				pFlameParticle->m_vecVelocity.Random( -1.0f, 1.0f );
+				pFlameParticle->m_vecVelocity *= random->RandomFloat( 32, 128 );
+
 				offsetColor = m_StartColor * random->RandomFloat( 0.75f, 1.25f );
 
 				offsetColor[0] = clamp( offsetColor[0], 0.0f, 1.0f );
 				offsetColor[1] = clamp( offsetColor[1], 0.0f, 1.0f );
 				offsetColor[2] = clamp( offsetColor[2], 0.0f, 1.0f );
 
-				pParticle->m_uchColor[0]	= offsetColor[0]*255.0f;
-				pParticle->m_uchColor[1]	= offsetColor[1]*255.0f;
-				pParticle->m_uchColor[2]	= offsetColor[2]*255.0f;
-				
-				pParticle->m_uchStartSize	= 8.0f;
-				pParticle->m_uchEndSize		= 32.0f;
-				
-				pParticle->m_uchStartAlpha	= 255;
-				pParticle->m_uchEndAlpha	= 0;
-				
-				pParticle->m_flRoll			= random->RandomInt( 0, 360 );
-				pParticle->m_flRollDelta	= random->RandomFloat( -8.0f, 8.0f );
+				pFlameParticle->m_uchColor[0]	= offsetColor[0]*255.0f;
+				pFlameParticle->m_uchColor[1]	= offsetColor[1]*255.0f;
+				pFlameParticle->m_uchColor[2]	= offsetColor[2]*255.0f;
+
+				pFlameParticle->m_uchStartSize	= 8.0f;
+				pFlameParticle->m_uchEndSize	= 32.0f;
+
+				pFlameParticle->m_uchStartAlpha	= 255;
+				pFlameParticle->m_uchEndAlpha	= 0;
+
+				pFlameParticle->m_flRoll		= random->RandomInt( 0, 360 );
+				pFlameParticle->m_flRollDelta	= random->RandomFloat( -8.0f, 8.0f );
 			}
 		}
 	}
@@ -1490,8 +1490,6 @@ void C_FireTrail::Update( float fTimeDelta )
 
 	CSmartPtr<CSimpleEmitter> pSimple = CSimpleEmitter::Create( "FireTrail" );
 	pSimple->SetSortOrigin( GetAbsOrigin() );
-	
-	Vector			offset;
 
 #define	STARTSIZE			8
 #define	ENDSIZE				16
@@ -1880,12 +1878,12 @@ void C_DustTrail::CleanupToolRecordingState( KeyValues *msg )
 	{
 		int nId = m_pDustEmitter->AllocateToolParticleEffectId();
 
-		KeyValues *msg = new KeyValues( "OldParticleSystem_Create" );
-		msg->SetString( "name", "C_DustTrail" );
-		msg->SetInt( "id", nId );
-		msg->SetFloat( "time", gpGlobals->curtime );
+		KeyValues *kvMsg = new KeyValues( "OldParticleSystem_Create" );
+		kvMsg->SetString( "name", "C_DustTrail" );
+		kvMsg->SetInt( "id", nId );
+		kvMsg->SetFloat( "time", gpGlobals->curtime );
 
-		KeyValues *pEmitter = msg->FindKey( "DmeSpriteEmitter", true );
+		KeyValues *pEmitter = kvMsg->FindKey( "DmeSpriteEmitter", true );
 		pEmitter->SetString( "material", "particle/smokesprites_0001" );
 		pEmitter->SetInt( "count", m_SpawnRate );	// particles per second, when duration is < 0
 		pEmitter->SetFloat( "duration", -1 ); // FIXME
@@ -1958,17 +1956,17 @@ void C_DustTrail::CleanupToolRecordingState( KeyValues *msg )
 		pUpdaters->FindKey( "DmeColorUpdater", true );
 		pUpdaters->FindKey( "DmeSizeUpdater", true );
 
-		ToolFramework_PostToolMessage( HTOOLHANDLE_INVALID, msg );
-		msg->deleteThis();
+		ToolFramework_PostToolMessage( HTOOLHANDLE_INVALID, kvMsg );
+		kvMsg->deleteThis();
 	}
 	else 
 	{
-		KeyValues *msg = new KeyValues( "OldParticleSystem_ActivateEmitter" );
-		msg->SetInt( "id", m_pDustEmitter->GetToolParticleEffectId() );
-		msg->SetInt( "emitter", 0 );
-		msg->SetInt( "active", bEmitterActive );
-		msg->SetFloat( "time", gpGlobals->curtime );
-		ToolFramework_PostToolMessage( HTOOLHANDLE_INVALID, msg );
-		msg->deleteThis();
+		KeyValues *kvMsg = new KeyValues( "OldParticleSystem_ActivateEmitter" );
+		kvMsg->SetInt( "id", m_pDustEmitter->GetToolParticleEffectId() );
+		kvMsg->SetInt( "emitter", 0 );
+		kvMsg->SetInt( "active", bEmitterActive );
+		kvMsg->SetFloat( "time", gpGlobals->curtime );
+		ToolFramework_PostToolMessage( HTOOLHANDLE_INVALID, kvMsg );
+		kvMsg->deleteThis();
 	}
 }

--- a/src/game/client/c_smokestack.cpp
+++ b/src/game/client/c_smokestack.cpp
@@ -459,8 +459,7 @@ void C_SmokeStack::SimulateParticles( CParticleSimulateIterator *pIterator )
 		}
 		else
 		{
-			// Transform.						   
-			Vector tPos;
+			// Transform.
 			if( m_bTwist )
 			{
 				Vector vTwist(

--- a/src/game/client/c_te_bloodstream.cpp
+++ b/src/game/client/c_te_bloodstream.cpp
@@ -173,18 +173,18 @@ void TE_BloodStream( IRecipientFilter& filter, float delay,
 			// 'chunkier' appearance.
 			for (count2 = 0; count2 < 2; count2++)
 			{
-				StandardParticle_t *p = pRen->AddParticle();
-				if(p)
+				StandardParticle_t *p2 = pRen->AddParticle();
+				if(p2)
 				{
-					pRen->SetParticleLifetime(p, 3);
-					p->SetColor(random->RandomFloat(0.7, 1.0), g, b);
-					p->SetAlpha(a);
-					p->m_Pos.Init(
+					pRen->SetParticleLifetime(p2, 3);
+					p2->SetColor(random->RandomFloat(0.7, 1.0), g, b);
+					p2->SetAlpha(a);
+					p2->m_Pos.Init(
 						(*org)[0] + random->RandomFloat(-1,1),
 						(*org)[1] + random->RandomFloat(-1,1),
 						(*org)[2] + random->RandomFloat(-1,1));
 					
-					pRen->SetParticleType(p, pt_vox_slowgrav);
+					pRen->SetParticleType(p2, pt_vox_slowgrav);
 					
 					VectorCopy (dir, dirCopy);
 					
@@ -192,7 +192,7 @@ void TE_BloodStream( IRecipientFilter& filter, float delay,
 					
 					VectorScale (dirCopy, num, dirCopy);// randomize a bit
 					
-					p->m_Velocity = dirCopy * speedCopy;
+					p2->m_Velocity = dirCopy * speedCopy;
 				}
 			}
 		}

--- a/src/game/client/c_te_legacytempents.cpp
+++ b/src/game/client/c_te_legacytempents.cpp
@@ -2797,7 +2797,6 @@ void CTempEnts::MuzzleFlash_Shotgun_NPC( ClientEntityHandle_t hEntity, int attac
 	QAngle	angles;
 
 	Vector	forward;
-	int		i;
 
 	// Setup the origin.
 	Vector	origin;
@@ -2864,7 +2863,7 @@ void CTempEnts::MuzzleFlash_Shotgun_NPC( ClientEntityHandle_t hEntity, int attac
 
 	int	numEmbers = random->RandomInt( 4, 8 );
 
-	for ( i = 0; i < numEmbers; i++ )
+	for ( int i = 0; i < numEmbers; i++ )
 	{
 		pTrailParticle = (TrailParticle *) pTrails->AddParticle( sizeof( TrailParticle ), g_Mat_SMG_Muzzleflash[0], origin );
 			

--- a/src/game/client/clientleafsystem.cpp
+++ b/src/game/client/clientleafsystem.cpp
@@ -752,8 +752,7 @@ void CClientLeafSystem::CreateRenderableHandle( IClientRenderable* pRenderable, 
 
 	if ( nModelType == RENDERABLE_MODEL_UNKNOWN_TYPE )
 	{
-		int nType = modelinfo->GetModelType( pRenderable->GetModel() );
-		switch( nType )
+		switch( modelinfo->GetModelType( pRenderable->GetModel() ) )
 		{
 		default: nModelType = RENDERABLE_MODEL_ENTITY; break;
 		case mod_brush: nModelType = RENDERABLE_MODEL_BRUSH; break;
@@ -1701,24 +1700,24 @@ void CClientLeafSystem::CollateViewModelRenderables( CViewModelRenderablesList *
 		// That's why we need to test RENDER_GROUP_OPAQUE_ENTITY - it may have changed in ComputeFXBlend()
 		if ( !bIsTransparent )
 		{
-			int i = opaqueList.AddToTail();
-			CViewModelRenderablesList::CEntry *pEntry = &opaqueList[i];
+			int tail = opaqueList.AddToTail();
+			CViewModelRenderablesList::CEntry *pEntry = &opaqueList[tail];
 			pEntry->m_pRenderable = renderable.m_pRenderable;
 			pEntry->m_InstanceData.m_nAlpha = 255;
 		}
 		else
 		{
-			int i = translucentList.AddToTail();
-			CViewModelRenderablesList::CEntry *pEntry = &translucentList[i];
+			int tail = translucentList.AddToTail();
+			CViewModelRenderablesList::CEntry *pEntry = &translucentList[tail];
 			pEntry->m_pRenderable = renderable.m_pRenderable;
 			pEntry->m_InstanceData.m_nAlpha = nAlpha;
 
 			if ( renderable.m_nTranslucencyType == RENDERABLE_IS_TWO_PASS )
 			{
-				int i = opaqueList.AddToTail();
-				CViewModelRenderablesList::CEntry *pEntry = &opaqueList[i];
-				pEntry->m_pRenderable = renderable.m_pRenderable;
-				pEntry->m_InstanceData.m_nAlpha = 255;
+				int tail2 = opaqueList.AddToTail();
+				CViewModelRenderablesList::CEntry *pEntry2 = &opaqueList[tail2];
+				pEntry2->m_pRenderable = renderable.m_pRenderable;
+				pEntry2->m_InstanceData.m_nAlpha = 255;
 			}
 		}
 	}

--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -1451,7 +1451,6 @@ CClientShadowMgr::CClientShadowMgr() :
 //-----------------------------------------------------------------------------
 CON_COMMAND_F( r_shadowdir, "Set shadow direction", FCVAR_CHEAT )
 {
-	Vector dir;
 	if ( args.ArgC() == 1 )
 	{
 		Vector dir = s_ClientShadowMgr.GetShadowDirection();
@@ -1461,6 +1460,7 @@ CON_COMMAND_F( r_shadowdir, "Set shadow direction", FCVAR_CHEAT )
 
 	if ( args.ArgC() == 4 )
 	{
+		Vector dir;
 		dir.x = atof( args[1] );
 		dir.y = atof( args[2] );
 		dir.z = atof( args[3] );
@@ -1470,8 +1470,6 @@ CON_COMMAND_F( r_shadowdir, "Set shadow direction", FCVAR_CHEAT )
 
 CON_COMMAND_F( r_shadowangles, "Set shadow angles", FCVAR_CHEAT )
 {
-	Vector dir;
-	QAngle angles;
 	if (args.ArgC() == 1)
 	{
 		Vector dir = s_ClientShadowMgr.GetShadowDirection();
@@ -1483,6 +1481,8 @@ CON_COMMAND_F( r_shadowangles, "Set shadow angles", FCVAR_CHEAT )
 
 	if (args.ArgC() == 4)
 	{
+		Vector dir;
+		QAngle angles;
 		angles.x = atof( args[1] );
 		angles.y = atof( args[2] );
 		angles.z = atof( args[3] );
@@ -4336,9 +4336,9 @@ void CClientShadowMgr::UpdateDirtyShadows()
 
 	// Transparent shadows must remain dirty, since they were not re-projected
 	int nCount = m_TransparentShadows.Count();
-	for ( int i = 0; i < nCount; ++i )
+	for ( int j = 0; j < nCount; ++j )
 	{
-		m_DirtyShadows.Insert( m_TransparentShadows[i] );
+		m_DirtyShadows.Insert( m_TransparentShadows[j] );
 	}
 	m_TransparentShadows.RemoveAll();
 }
@@ -4403,9 +4403,9 @@ void CClientShadowMgr::UpdateDirtyShadowsHalfRate()
 
 	// Transparent shadows must remain dirty, since they were not re-projected
 	int nCount = m_TransparentShadows.Count();
-	for ( int i = 0; i < nCount; ++i )
+	for ( int j = 0; j < nCount; ++j )
 	{
-		m_DirtyShadows.Insert( m_TransparentShadows[i] );
+		m_DirtyShadows.Insert( m_TransparentShadows[j] );
 	}
 	m_TransparentShadows.RemoveAll();
 }
@@ -6460,7 +6460,8 @@ void CClientShadowMgr::DrawDeferredShadows( const CViewSetup &view, int leafCoun
 	}
 
 	// draw deferred blobby shadow volumes
-	if ( s_VisibleShadowList.GetVisibleBlobbyShadowCount() > 0 )
+	const int nNumBlobbyShadows = s_VisibleShadowList.GetVisibleBlobbyShadowCount();
+	if ( nNumBlobbyShadows > 0 )
 	{
 		pRenderContext->Bind( m_RenderDeferredSimpleShadowMat );
 		pTextureVar = m_RenderDeferredSimpleShadowMat->FindVar( "$depthtexture", NULL, false );
@@ -6469,10 +6470,9 @@ void CClientShadowMgr::DrawDeferredShadows( const CViewSetup &view, int leafCoun
 			pTextureVar->SetTextureValue( GetFullFrameDepthTexture() );
 		}
 
-		int nNumShadows = s_VisibleShadowList.GetVisibleBlobbyShadowCount();
 		meshBuilder.Begin( pMesh, MATERIAL_TRIANGLES, nMaxShadowsPerBatch * ARRAYSIZE( pShadowBoundVerts ) / 4, nMaxShadowsPerBatch * ARRAYSIZE( pShadowBoundIndices ) );
 
-		for ( int i = 0; i < nNumShadows; ++i )
+		for ( int i = 0; i < nNumBlobbyShadows; ++i )
 		{
 			const VisibleShadowInfo_t& vsi = s_VisibleShadowList.GetVisibleBlobbyShadow( i );
 			ClientShadow_t& shadow = m_Shadows[vsi.m_hShadow];

--- a/src/game/client/detailobjectsystem.cpp
+++ b/src/game/client/detailobjectsystem.cpp
@@ -2922,12 +2922,12 @@ void CDetailObjectSystem::BuildRenderingData( DetailRenderableList_t &list, cons
 
 			// FIXME: Should we return a center + radius so culling can happen?
 			// right now, detail objects are not even frustum culled
-			int d = list.AddToTail();
-			DetailRenderableInfo_t &info = list[d];
-			info.m_pRenderable = &model;
-			info.m_InstanceData.m_nAlpha = nAlpha;
-			info.m_nRenderGroup = ( ( nAlpha != 255 ) || model.IsTranslucent() ) ? RENDER_GROUP_TRANSLUCENT : RENDER_GROUP_OPAQUE;
-			info.m_nLeafIndex = nListLeafIndex;
+			const int d = list.AddToTail();
+			DetailRenderableInfo_t &infoNew = list[d];
+			infoNew.m_pRenderable = &model;
+			infoNew.m_InstanceData.m_nAlpha = nAlpha;
+			infoNew.m_nRenderGroup = ( ( nAlpha != 255 ) || model.IsTranslucent() ) ? RENDER_GROUP_TRANSLUCENT : RENDER_GROUP_OPAQUE;
+			infoNew.m_nLeafIndex = nListLeafIndex;
 
 			// FIXME: Inherently not threadsafe, not to mention not easily SIMDable
 			// move this to happen in DrawModel()

--- a/src/game/client/fx.cpp
+++ b/src/game/client/fx.cpp
@@ -510,9 +510,9 @@ CSmartPtr<CSimpleEmitter> FX_Smoke( const Vector &origin, const Vector &velocity
 		pParticle->m_flLifetime = 0.0f;
 		pParticle->m_flDieTime = flDietime;
 		pParticle->m_vecVelocity = velocity;
-		for( int i = 0; i < 3; ++i )
+		for( int j = 0; j < 3; ++j )
 		{
-			pParticle->m_uchColor[i] = pColor[i];
+			pParticle->m_uchColor[j] = pColor[j];
 		}
 		pParticle->m_uchStartAlpha	= iAlpha;
 		pParticle->m_uchEndAlpha	= 0;
@@ -663,10 +663,10 @@ public:
 
 			// Randomize the color a little
 			int color[3][2];
-			for( int i = 0; i < 3; ++i )
+			for( int j = 0; j < 3; ++j )
 			{
-				color[i][0] = MAX( 0, m_SpurtColor[i] - 64 );
-				color[i][1] = MIN( 255, m_SpurtColor[i] + 64 );
+				color[j][0] = MAX( 0, m_SpurtColor[j] - 64 );
+				color[j][1] = MIN( 255, m_SpurtColor[j] + 64 );
 			}
 			pParticle->m_uchColor[0] = random->RandomInt( color[0][0], color[0][1] );
 			pParticle->m_uchColor[1] = random->RandomInt( color[1][0], color[1][1] );

--- a/src/game/client/game_controls/MapOverview.cpp
+++ b/src/game/client/game_controls/MapOverview.cpp
@@ -575,15 +575,15 @@ void CMapOverview::DrawMapPlayerTrails()
 		
 		player->trail[0] = WorldToMap ( player->position );
 
-		for ( int i=0; i<(MAX_TRAIL_LENGTH-1); i++)
+		for ( int j=0; j<(MAX_TRAIL_LENGTH-1); j++)
 		{
-			if ( player->trail[i+1].x == 0 && player->trail[i+1].y == 0 )
+			if ( player->trail[j+1].x == 0 && player->trail[j+1].y == 0 )
 				break;
 
-			Vector2D pos1 = MapToPanel( player->trail[i] );
-			Vector2D pos2 = MapToPanel( player->trail[i+1] );
+			Vector2D pos1 = MapToPanel( player->trail[j] );
+			Vector2D pos2 = MapToPanel( player->trail[j+1] );
 
-			int intensity = 255 - float(255.0f * i) / MAX_TRAIL_LENGTH;
+			int intensity = 255 - float(255.0f * j) / MAX_TRAIL_LENGTH;
 
 			Vector2D dist = pos1 - pos2;
 			

--- a/src/game/client/game_controls/SpectatorGUI.cpp
+++ b/src/game/client/game_controls/SpectatorGUI.cpp
@@ -226,10 +226,10 @@ void CSpectatorMenu::FireGameEvent( IGameEvent * event )
 
 		const char *selectedPlayerName = gr->GetPlayerName( playernum );
 		const char *currentPlayerName = "";
-		KeyValues *kv = m_pPlayerList->GetActiveItemUserData();
-		if ( kv )
+		KeyValues *kvActive = m_pPlayerList->GetActiveItemUserData();
+		if ( kvActive )
 		{
-			currentPlayerName = kv->GetString( "player" );
+			currentPlayerName = kvActive->GetString( "player" );
 		}
 		if ( !FStrEq( currentPlayerName, selectedPlayerName ) )
 		{

--- a/src/game/client/glow_overlay.cpp
+++ b/src/game/client/glow_overlay.cpp
@@ -440,34 +440,34 @@ void CGlowOverlay::Draw( bool bCacheFullSceneState )
 			pRenderContext->Bind( pWireframeMaterial );
 			
 			// Draw the sprite.
-			IMesh *pMesh = pRenderContext->GetDynamicMesh( false, 0, 0, pWireframeMaterial );
+			IMesh *pMeshWf = pRenderContext->GetDynamicMesh( false, 0, 0, pWireframeMaterial );
 			
-			CMeshBuilder builder;
-			builder.Begin( pMesh, MATERIAL_QUADS, 1 );
+			CMeshBuilder builderWf;
+			builderWf.Begin( pMeshWf, MATERIAL_QUADS, 1 );
 			
-			Vector vPt;
+			Vector vPtWf;
 			
-			vPt = vBasePt - vRight + vUp;
-			builder.Position3fv( vPt.Base() );
-			builder.Color3f( 1.0f, 0.0f, 0.0f );
-			builder.AdvanceVertex();
+			vPtWf = vBasePt - vRight + vUp;
+			builderWf.Position3fv( vPtWf.Base() );
+			builderWf.Color3f( 1.0f, 0.0f, 0.0f );
+			builderWf.AdvanceVertex();
 			
-			vPt = vBasePt + vRight + vUp;
-			builder.Position3fv( vPt.Base() );
-			builder.Color3f( 1.0f, 0.0f, 0.0f );
-			builder.AdvanceVertex();
+			vPtWf = vBasePt + vRight + vUp;
+			builderWf.Position3fv( vPtWf.Base() );
+			builderWf.Color3f( 1.0f, 0.0f, 0.0f );
+			builderWf.AdvanceVertex();
 			
-			vPt = vBasePt + vRight - vUp;
-			builder.Position3fv( vPt.Base() );
-			builder.Color3f( 1.0f, 0.0f, 0.0f );
-			builder.AdvanceVertex();
+			vPtWf = vBasePt + vRight - vUp;
+			builderWf.Position3fv( vPtWf.Base() );
+			builderWf.Color3f( 1.0f, 0.0f, 0.0f );
+			builderWf.AdvanceVertex();
 			
-			vPt = vBasePt - vRight - vUp;
-			builder.Position3fv( vPt.Base() );
-			builder.Color3f( 1.0f, 0.0f, 0.0f );
-			builder.AdvanceVertex();
+			vPtWf = vBasePt - vRight - vUp;
+			builderWf.Position3fv( vPtWf.Base() );
+			builderWf.Color3f( 1.0f, 0.0f, 0.0f );
+			builderWf.AdvanceVertex();
 			
-			builder.End( false, true );
+			builderWf.End( false, true );
 		}
 	}
 }

--- a/src/game/client/hl2/c_strider.cpp
+++ b/src/game/client/hl2/c_strider.cpp
@@ -130,8 +130,8 @@ public:
 
 			for ( int i = 0; i < NUM_STRIDER_IK_TARGETS; i++ )
 			{
-				CIKTarget &target = m_pIk->m_target[i];
-				target.SetPos( m_vecIKTarget[i] );
+				CIKTarget &targetI = m_pIk->m_target[i];
+				targetI.SetPos( m_vecIKTarget[i] );
 #if 0
 				debugoverlay->AddBoxOverlay( m_vecIKTarget[i], Vector( -2, -2, -2 ), Vector( 2, 2, 2), QAngle( 0, 0, 0 ), (int)255*m_pIk->m_target[i].est.latched, 0, 0, 0, 0 );
 #endif

--- a/src/game/client/hud.cpp
+++ b/src/game/client/hud.cpp
@@ -875,11 +875,11 @@ bool CHud::LockRenderGroup( int iGroupIndex, CHudElement *pLocker /* = NULL */ )
 	if ( !DoesRenderGroupExist(iGroupIndex) )
 		return false;
 
-	int i = m_RenderGroups.Find( iGroupIndex );
+	int idx = m_RenderGroups.Find( iGroupIndex );
 
-	Assert( m_RenderGroups.IsValidIndex(i) );
+	Assert( m_RenderGroups.IsValidIndex(idx) );
 
-	CHudRenderGroup *group = m_RenderGroups.Element(i);
+	CHudRenderGroup *group = m_RenderGroups.Element(idx);
 
 	Assert( group );
 
@@ -924,11 +924,11 @@ bool CHud::UnlockRenderGroup( int iGroupIndex, CHudElement *pLocker /* = NULL */
 	if ( !DoesRenderGroupExist(iGroupIndex) )
 		return false;
 
-	int i = m_RenderGroups.Find( iGroupIndex );
+	int idx = m_RenderGroups.Find( iGroupIndex );
 
-	Assert( m_RenderGroups.IsValidIndex(i) );
+	Assert( m_RenderGroups.IsValidIndex(idx) );
 
-	CHudRenderGroup *group = m_RenderGroups.Element(i);
+	CHudRenderGroup *group = m_RenderGroups.Element(idx);
 
 	if ( group )
 	{

--- a/src/game/client/hud_closecaption.cpp
+++ b/src/game/client/hud_closecaption.cpp
@@ -2549,14 +2549,14 @@ void CHudCloseCaption::ProcessSentenceCaptionStream( const char *tokenstream )
 		}
 		else
 		{
-			CaptionRepeat &entry = m_CloseCaptionRepeats[ idx ];
-			if ( gpGlobals->curtime < ( entry.m_flLastEmitTime + entry.m_flInterval ) )
+			CaptionRepeat &repeatEntry = m_CloseCaptionRepeats[ idx ];
+			if ( gpGlobals->curtime < ( repeatEntry.m_flLastEmitTime + repeatEntry.m_flInterval ) )
 			{
 				return;
 			}
 
-			entry.m_flLastEmitTime = gpGlobals->curtime;
-			entry.m_nLastEmitTick = gpGlobals->tickcount;
+			repeatEntry.m_flLastEmitTime = gpGlobals->curtime;
+			repeatEntry.m_nLastEmitTick = gpGlobals->tickcount;
 		}
 	}
 
@@ -2600,26 +2600,26 @@ void CHudCloseCaption::_ProcessCaption( const wchar_t *caption, unsigned int has
 	}
 	else
 	{
-		CaptionRepeat &entry = m_CloseCaptionRepeats[ idx ];
+		CaptionRepeat &repeatEntry = m_CloseCaptionRepeats[ idx ];
 
 		// Interval of 0.0 means just don't double emit on same tick #
-		if ( entry.m_flInterval <= 0.0f )
+		if ( repeatEntry.m_flInterval <= 0.0f )
 		{
-			if ( gpGlobals->tickcount <= entry.m_nLastEmitTick )
+			if ( gpGlobals->tickcount <= repeatEntry.m_nLastEmitTick )
 			{
 				return;
 			}
 		}
 		else if ( hasnorepeat )
 		{
-			if ( gpGlobals->curtime < ( entry.m_flLastEmitTime + entry.m_flInterval ) )
+			if ( gpGlobals->curtime < ( repeatEntry.m_flLastEmitTime + repeatEntry.m_flInterval ) )
 			{
 				return;
 			}
 		}
 
-		entry.m_flLastEmitTime = gpGlobals->curtime;
-		entry.m_nLastEmitTick = gpGlobals->tickcount;
+		repeatEntry.m_flLastEmitTime = gpGlobals->curtime;
+		repeatEntry.m_nLastEmitTick = gpGlobals->tickcount;
 	}
 
 	Process( caption, duration, fromplayer, direct );
@@ -2883,7 +2883,9 @@ void OnCaptionLanguageChanged( IConVar *pConVar, const char *pOldString, float f
 	char uilanguage[ 64 ];
 	engine->GetUILanguage( uilanguage, sizeof( uilanguage ) );
 
+#ifndef INFESTED_DLL
 	CHudCloseCaption *hudCloseCaption = GET_FULLSCREEN_HUDELEMENT( CHudCloseCaption );
+#endif
 
 	// If it's not the default, load the language on top of the user's default language
 	if ( Q_strlen( var.GetString() ) > 0 && Q_stricmp( var.GetString(), uilanguage ) )

--- a/src/game/client/hud_lcd.cpp
+++ b/src/game/client/hud_lcd.cpp
@@ -1072,8 +1072,10 @@ void CLCD::DumpPlayer()
 
 	Msg( "(localplayer)\n\n" );
 
-	CDescribeData helper( (const byte *)player );
-	helper.DumpDescription( player->GetPredDescMap() );
+	{
+		CDescribeData helper( (const byte *)player );
+		helper.DumpDescription( player->GetPredDescMap() );
+	}
 
 	Msg( "(localteam)\n\n" );
 

--- a/src/game/client/in_joystick.cpp
+++ b/src/game/client/in_joystick.cpp
@@ -350,7 +350,7 @@ ConVar joy_virtual_peg("joy_virtual_peg", "0");
 static float ResponseCurveLookDefault( int nSlot, float x, int axis, float otherAxis, float dist, float frametime )
 {
 	envelope_t &envelope = controlEnvelope[ MAX( nSlot, 0 ) ];
-	float input = x;
+	float x_input = x;
 
 	bool bStickIsPhysicallyPegged = ( dist >= joy_pegged.GetFloat() );
 
@@ -418,11 +418,11 @@ static float ResponseCurveLookDefault( int nSlot, float x, int axis, float other
 		x = joy_lowmap.GetFloat() * factor;
 	}
 
-	x *= AutoAimDampening( input, axis, dist );
+	x *= AutoAimDampening( x_input, axis, dist );
 
 	if( axis == YAW && x > 0.0f && joy_display_input.GetBool() )
 	{
-		Msg("In:%f Out:%f Frametime:%f\n", input, x, frametime );
+		Msg("In:%f Out:%f Frametime:%f\n", x_input, x, frametime );
 	}
 
 	if( negative )
@@ -438,7 +438,7 @@ static float ResponseCurveLookAccelerated( int nSlot, float x, int axis, float o
 {
 	envelope_t &envelope = controlEnvelope[ MAX( nSlot, 0 ) ];
 
-	float input = x;
+	float x_input = x;
 
 	float flJoyDist = ( sqrt(x*x + otherAxis * otherAxis) );
 	bool bIsPegged = ( flJoyDist>= joy_pegged.GetFloat() );
@@ -487,11 +487,11 @@ static float ResponseCurveLookAccelerated( int nSlot, float x, int axis, float o
 		x = joy_lowmap.GetFloat() + (delta * envelope.envelopeScale[axis]);
 	}
 
-	x *= AutoAimDampening( input, axis, dist );
+	x *= AutoAimDampening( x_input, axis, dist );
 
-	if( axis == YAW && input != 0.0f && joy_display_input.GetBool() )
+	if( axis == YAW && x_input != 0.0f && joy_display_input.GetBool() )
 	{
-		Msg("In:%f Out:%f Frametime:%f\n", input, x, frametime );
+		Msg("In:%f Out:%f Frametime:%f\n", x_input, x, frametime );
 	}
 
 	if( negative )
@@ -927,7 +927,7 @@ void CInput::JoyStickTurn( CUserCmd *cmd, float &yaw, float &pitch, float framet
 	float   aspeed = lookFrametime * GetHud().GetFOVSensitivityAdjust();
 
 	// apply turn control
-	float angle = 0.f;
+	float angle_yaw = 0.f;
 
 	if ( user.m_flSpinFrameTime )
 	{
@@ -943,25 +943,25 @@ void CInput::JoyStickTurn( CUserCmd *cmd, float &yaw, float &pitch, float framet
 		{
 			user.m_flSpinFrameTime -= delta;
 		}
-		angle = user.m_flSpinRate * delta;
+		angle_yaw = user.m_flSpinRate * delta;
 	}
 	else if ( bVariableFrametime || frametime != gpGlobals->frametime )
 	{
 		if ( bAbsoluteYaw )
 		{
 			float fAxisValue = ResponseCurveLook( nSlot, joy_response_look.GetInt(), yaw, YAW, pitch, dist, lookFrametime );
-			angle = fAxisValue * s_joy_yawsensitivity.GetFloat( nSlot ) * aspeed * cl_yawspeed.GetFloat();
+			angle_yaw = fAxisValue * s_joy_yawsensitivity.GetFloat( nSlot ) * aspeed * cl_yawspeed.GetFloat();
 		}
 		else
 		{
-			angle = yaw * s_joy_yawsensitivity.GetFloat( nSlot ) * aspeed * 180.0;
+			angle_yaw = yaw * s_joy_yawsensitivity.GetFloat( nSlot ) * aspeed * 180.0;
 		}
 	}
 
-	if ( angle )
+	if ( angle_yaw )
 	{
 		// track angular direction
-		user.m_flLastYawAngle = angle;
+		user.m_flLastYawAngle = angle_yaw;
 	}
 
 	C_BasePlayer *pLocalPlayer = C_BasePlayer::GetLocalPlayer( nSlot );
@@ -981,27 +981,27 @@ void CInput::JoyStickTurn( CUserCmd *cmd, float &yaw, float &pitch, float framet
 		}
 	}
 
-	viewangles[YAW] += angle;
-	cmd->mousedx = angle;
+	viewangles[YAW] += angle_yaw;
+	cmd->mousedx = angle_yaw;
 
 	// apply look control
 	if ( in_jlook.GetPerUser( nSlot ).state & 1 )
 	{
-		float angle = 0;
+		float angle_pitch = 0;
 		if ( bVariableFrametime || frametime != gpGlobals->frametime )
 		{
 			if ( bAbsolutePitch )
 			{
 				float fAxisValue = ResponseCurveLook( nSlot, joy_response_look.GetInt(), pitch, PITCH, yaw, dist, lookFrametime );
-				angle = fAxisValue * s_joy_pitchsensitivity.GetFloat( nSlot ) * aspeed * cl_pitchspeed.GetFloat();
+				angle_pitch = fAxisValue * s_joy_pitchsensitivity.GetFloat( nSlot ) * aspeed * cl_pitchspeed.GetFloat();
 			}
 			else
 			{
-				angle = pitch * s_joy_pitchsensitivity.GetFloat( nSlot ) * aspeed * 180.0;
+				angle_pitch = pitch * s_joy_pitchsensitivity.GetFloat( nSlot ) * aspeed * 180.0;
 			}
 		}
-		viewangles[PITCH] += angle;
-		cmd->mousedy = angle;
+		viewangles[PITCH] += angle_pitch;
+		cmd->mousedy = angle_pitch;
 		view->StopPitchDrift();
 		if ( pitch == 0.f && lookspring.GetFloat() == 0.f )
 		{

--- a/src/game/client/particlemgr.cpp
+++ b/src/game/client/particlemgr.cpp
@@ -270,8 +270,8 @@ inline void CParticleEffectBinding::StartDrawMaterialParticles(
 	// Setup the ParticleDraw and bind the material.
 	if( bWireframe )
 	{
-		IMaterial *pMaterial = m_pParticleMgr->m_pMaterialSystem->FindMaterial( "debug/debugparticlewireframe", TEXTURE_GROUP_OTHER );
-		pRenderContext->Bind( pMaterial, NULL );
+		IMaterial *pMaterialWf = m_pParticleMgr->m_pMaterialSystem->FindMaterial( "debug/debugparticlewireframe", TEXTURE_GROUP_OTHER );
+		pRenderContext->Bind( pMaterialWf, NULL );
 	}
 	else
 	{

--- a/src/game/client/swarm/c_asw_aoegrenade_projectile.cpp
+++ b/src/game/client/swarm/c_asw_aoegrenade_projectile.cpp
@@ -195,9 +195,9 @@ void C_ASW_AOEGrenade_Projectile::UpdateTargetAOEEffects( void )
 	}
 
 	// Now add any new targets
-	for ( int i = 0; i < m_hAOETargets.Count(); i++ )
+	for ( int t = 0; t < m_hAOETargets.Count(); t++ )
 	{
-		C_BaseEntity *pTarget = m_hAOETargets[i].Get();
+		C_BaseEntity *pTarget = m_hAOETargets[t].Get();
 
 		// Loops through the aoe targets, and make sure we have an effect for each of them
 		if ( pTarget )

--- a/src/game/client/swarm/c_asw_generic_emitter.cpp
+++ b/src/game/client/swarm/c_asw_generic_emitter.cpp
@@ -988,8 +988,8 @@ void CASWGenericEmitter::SetDieTime(float fTime)
 // load our emitter settings from a particular template
 void CASWGenericEmitter::UseTemplate(const char* templatename, bool bReset, bool bLoadFromCache)
 {	
-	char buf[MAX_PATH];
-	Q_snprintf(buf, sizeof(buf), "resource/particletemplates/%s.ptm", templatename);
+	char pathBuf[MAX_PATH];
+	Q_snprintf(pathBuf, sizeof(pathBuf), "resource/particletemplates/%s.ptm", templatename);
 
 	KeyValues* kv = NULL;
 	if (bLoadFromCache)	
@@ -1000,10 +1000,10 @@ void CASWGenericEmitter::UseTemplate(const char* templatename, bool bReset, bool
 		kv = new KeyValues("UncachedParticleEmitter");
 		if (kv)
 		{
-			if (!kv->LoadFromFile(filesystem, buf, "GAME"))
+			if (!kv->LoadFromFile(filesystem, pathBuf, "GAME"))
 			{
 				kv->deleteThis();
-				DevMsg(1, "C_ASW_Emitter::UseTemplate: couldn't load file: %s\n", buf);
+				DevMsg(1, "C_ASW_Emitter::UseTemplate: couldn't load file: %s\n", pathBuf);
 				return;
 			}
 		}
@@ -1014,7 +1014,7 @@ void CASWGenericEmitter::UseTemplate(const char* templatename, bool bReset, bool
 	// couldn't find the template
 	if ( !kv )
 	{
-		DevMsg( 1, "Couldn't load emitter template from cache. %s\n", buf );
+		DevMsg( 1, "Couldn't load emitter template from cache. %s\n", pathBuf );
 		return;
 	}
 

--- a/src/game/client/swarm/vgui/asw_vgui_hack_wire_tile.cpp
+++ b/src/game/client/swarm/vgui/asw_vgui_hack_wire_tile.cpp
@@ -451,9 +451,6 @@ void CASW_VGUI_Hack_Wire_Tile::Paint()
 {
 	BaseClass::Paint();
 
-	int x,y,w,t;
-	GetBounds(x,y,w,t);
-
 	if (!m_hHack.Get())
 		return;
 

--- a/src/game/client/swarm/vgui/asw_vgui_info_message.cpp
+++ b/src/game/client/swarm/vgui/asw_vgui_info_message.cpp
@@ -74,9 +74,9 @@ CASW_VGUI_Info_Message::CASW_VGUI_Info_Message( vgui::Panel *pParent, const char
 	{
 		m_pLogButton = new ImageButton( this, "LogButton", "#asw_message_log" );
 		m_pLogButton->AddActionSignalTarget( this );
-		KeyValues *msg = new KeyValues( "Command" );
-		msg->SetString( "command", "MessageLog" );
-		m_pLogButton->SetCommand( msg );
+		KeyValues *kvMsg = new KeyValues( "Command" );
+		kvMsg->SetString( "command", "MessageLog" );
+		m_pLogButton->SetCommand( kvMsg );
 	}
 	else
 	{
@@ -218,15 +218,15 @@ void CASW_VGUI_Info_Message::PerformLayout()
 		{
 			int linew = GetWide()- (ScreenWidth() * TEXT_BORDER_X * 2);
 			m_pLine[i]->SetWide(linew);
-			int w, h;
-			m_pLine[i]->GetTextImage()->GetContentSize(w, h);
-			m_pLine[i]->SetTall(h);
-			//Msg("setting line %d to %d %d\n", i, linew,  h);			
+			int text_w, text_h;
+			m_pLine[i]->GetTextImage()->GetContentSize(text_w, text_h);
+			m_pLine[i]->SetTall(text_h);
+			//Msg("setting line %d to %d %d\n", i, linew,  text_h);			
 			int posx = ScreenWidth() * TEXT_BORDER_X;
 			int posy = panel_y;
 			//Msg(" and pos %d %d\n", posx, posy);
 			m_pLine[i]->SetPos(posx, posy);
-			panel_y += h + ScreenHeight() * 0.015f;
+			panel_y += text_h + ScreenHeight() * 0.015f;
 		}
 	}
 
@@ -287,12 +287,13 @@ void CASW_VGUI_Info_Message::ApplySchemeSettings(vgui::IScheme *pScheme)
 		m_pLine[i]->SetFgColor(Color(255,255,255,255));
 	}
 
+	Color white(255,255,255,255);
+	Color blue(19,20,40, 255);
+
 	m_pOkayButton->SetAlpha(255);
 	m_pOkayButton->SetPaintBackgroundEnabled(true);
 	m_pOkayButton->SetContentAlignment(vgui::Label::a_center);
 	m_pOkayButton->SetBorders("TitleButtonBorder", "TitleButtonBorder");
-	Color white(255,255,255,255);
-	Color blue(19,20,40, 255);
 	m_pOkayButton->SetColors(white, white, white, white, blue);
 	m_pOkayButton->SetPaintBackgroundType(2);
 
@@ -302,8 +303,6 @@ void CASW_VGUI_Info_Message::ApplySchemeSettings(vgui::IScheme *pScheme)
 		m_pLogButton->SetPaintBackgroundEnabled(true);
 		m_pLogButton->SetContentAlignment(vgui::Label::a_center);
 		m_pLogButton->SetBorders("TitleButtonBorder", "TitleButtonBorder");
-		Color white(255,255,255,255);
-		Color blue(19,20,40, 255);
 		m_pLogButton->SetColors(white, white, white, white, blue);
 		m_pLogButton->SetPaintBackgroundType(2);
 	}

--- a/src/game/client/swarm/vgui/campaignpanel.cpp
+++ b/src/game/client/swarm/vgui/campaignpanel.cpp
@@ -700,7 +700,7 @@ void CampaignPanel::SetStage( int i )
 	int bracketx, brackety, bracketw, brackett;
 	float fFadeTime = 0.1f;
 	float fMediumFadeTime = 0.5f;
-	float fBracketTime = 0.4f;
+	const float fBracketTime = 0.4f;
 	float fInitialMapLabelDelay = 2.5f;
 	float fMapLabelInterval = 0.05f;
 	GetMapBounds( iMapX, iMapY, iMapW, iMapT );
@@ -726,13 +726,13 @@ void CampaignPanel::SetStage( int i )
 			vgui::GetAnimationController()->RunAnimationCommand( m_pGalaxyEdges, "alpha", 128, 0, fMediumFadeTime, vgui::AnimationController::INTERPOLATOR_LINEAR );
 
 			// fade in all the galactic map labels
-			for ( int i = 0; i < ASW_NUM_CAMPAIGN_LABELS; i++ )
+			for ( int j = 0; j < ASW_NUM_CAMPAIGN_LABELS; j++ )
 			{
-				float fLabelDelay = fInitialMapLabelDelay + ( i * fMapLabelInterval );
-				vgui::GetAnimationController()->RunAnimationCommand( m_pMapLabels[i], "alpha", 255, fLabelDelay, fMediumFadeTime, vgui::AnimationController::INTERPOLATOR_LINEAR );
+				float fLabelDelay = fInitialMapLabelDelay + ( j * fMapLabelInterval );
+				vgui::GetAnimationController()->RunAnimationCommand( m_pMapLabels[j], "alpha", 255, fLabelDelay, fMediumFadeTime, vgui::AnimationController::INTERPOLATOR_LINEAR );
 
-				m_pMapLabels[i]->SizeToContents();
-				m_pMapLabels[i]->SetSize( m_pMapLabels[i]->GetWide() + 6, m_pMapLabels[i]->GetTall() + 2 );
+				m_pMapLabels[j]->SizeToContents();
+				m_pMapLabels[j]->SetSize( m_pMapLabels[j]->GetWide() + 6, m_pMapLabels[j]->GetTall() + 2 );
 			}
 			// update right side messages
 			vgui::GetAnimationController()->RunAnimationCommand( m_pMissionDetails, "alpha", 255, 0, 0.3f, vgui::AnimationController::INTERPOLATOR_LINEAR );
@@ -777,7 +777,6 @@ void CampaignPanel::SetStage( int i )
 	{
 		//Msg("CMP_BRACKETING_CONSTELLATION\n");
 		vgui::GetAnimationController()->RunAnimationCommand( m_pBracket, "alpha", 255, 0, fFadeTime, vgui::AnimationController::INTERPOLATOR_LINEAR );
-		float fBracketTime = 0.4f;
 		GetConstellationBracket( bracketx, brackety, bracketw, brackett );
 		vgui::GetAnimationController()->RunAnimationCommand( m_pBracket, "xpos", bracketx, 0, fBracketTime, vgui::AnimationController::INTERPOLATOR_LINEAR );
 		vgui::GetAnimationController()->RunAnimationCommand( m_pBracket, "ypos", brackety, 0, fBracketTime, vgui::AnimationController::INTERPOLATOR_LINEAR );

--- a/src/game/client/swarm/vgui/missioncompletepanel.cpp
+++ b/src/game/client/swarm/vgui/missioncompletepanel.cpp
@@ -649,8 +649,8 @@ void MissionCompletePanel::OnCommand( const char *command )
 	{
 		if ( m_bSuccess && m_bLastMission && !m_bCreditsSeen )
 		{
-			C_ASW_Player *pPlayer = C_ASW_Player::GetLocalASWPlayer();
-			if ( pPlayer )
+			// C_ASW_Player *pPlayer = C_ASW_Player::GetLocalASWPlayer();
+			// if ( pPlayer )
 			{
 				m_pStatsPanel->m_pDebrief->m_pPara[0]->SetVisible( false );
 				m_pStatsPanel->m_pDebrief->m_pPara[1]->SetVisible( false );

--- a/src/game/client/swarm/vgui/missioncompletestatsline.cpp
+++ b/src/game/client/swarm/vgui/missioncompletestatsline.cpp
@@ -229,7 +229,7 @@ void MissionCompleteStatsLine::InitFrom(C_ASW_Debrief_Stats *pDebriefStats)
 	int iHighestDamage = pDebriefStats->GetHighestDamageTaken();
 	int iHighestShotsFired = pDebriefStats->GetHighestShotsFired();
 
-	float fDelay = 1.0f;	// roughly how many seconds we want it to take for the bars to fill
+	const float fDelay = 1.0f;	// roughly how many seconds we want it to take for the bars to fill
 	float fKillRate = float(iHighestKills) / fDelay;
 	float fAccRate = fHighestAccuracy / fDelay;
 	float fFFRate = float(iHighestFF) / fDelay;
@@ -310,7 +310,6 @@ void MissionCompleteStatsLine::InitFrom(C_ASW_Debrief_Stats *pDebriefStats)
 		m_pBarIcons[6]->SetVisible(true);
 
 		int iHighestSkillPointsAwarded = pDebriefStats->GetHighestSkillPointsAwarded();
-		float fDelay = 1.0f;	// roughly how many seconds we want it to take for the bars to fill
 		float fSkillPointsRate = float(iHighestSkillPointsAwarded) / fDelay;
 		m_pStats[6]->Init(0, pDebriefStats->GetSkillPointsAwarded(m_iMarineIndex), fSkillPointsRate, true, false);
 		m_pStats[6]->AddMinMax( 0, iHighestSkillPointsAwarded );
@@ -347,11 +346,11 @@ void MissionCompleteStatsLine::ShowStats()
 	m_pMedalArea->StartShowingMedals(gpGlobals->curtime + fProp * 0.9f + 5.0f);
 }
 
-void MissionCompleteStatsLine::SetMarineIndex(int i)
+void MissionCompleteStatsLine::SetMarineIndex( int idx )
 {
-	if (m_iMarineIndex != i)
+	if ( m_iMarineIndex != idx )
 	{
-		m_iMarineIndex = i;
+		m_iMarineIndex = idx;
 
 		UpdateLabels();
 

--- a/src/game/client/swarm/vgui/missioncompletestatsline.h
+++ b/src/game/client/swarm/vgui/missioncompletestatsline.h
@@ -31,7 +31,7 @@ public:
 	virtual void PerformLayout();
 	void ApplySchemeSettings( vgui::IScheme *scheme );
 	void UpdateLabels();
-	void SetMarineIndex(int i);
+	void SetMarineIndex( int idx );
 	void InitFrom(C_ASW_Debrief_Stats* pStats);
 	void ShowStats();
 

--- a/src/game/client/swarm/vgui/nb_lobby_row.cpp
+++ b/src/game/client/swarm/vgui/nb_lobby_row.cpp
@@ -207,10 +207,10 @@ void CNB_Lobby_Row::UpdateDetails()
 	lightblue.b = 192;
 	lightblue.a = 255;
 
-	BaseModHybridButton *pButton = m_pNameDropdown->GetButton();
-	if ( pButton )
+	BaseModHybridButton *phButton = m_pNameDropdown->GetButton();
+	if ( phButton )
 	{
-		pButton->SetText( Briefing()->GetMarineOrPlayerName( m_nLobbySlot ) );
+		phButton->SetText( Briefing()->GetMarineOrPlayerName( m_nLobbySlot ) );
 	}
 	m_pNameDropdown->SetVisible( true );
 

--- a/src/game/client/swarm/vgui/nb_select_marine_entry.cpp
+++ b/src/game/client/swarm/vgui/nb_select_marine_entry.cpp
@@ -106,8 +106,8 @@ void CNB_Select_Marine_Entry::OnThink()
 		}
 		else
 		{
-			CASW_Marine_Profile *pProfile = Briefing()->GetMarineProfile( m_nPreferredLobbySlot );
-			if ( !pProfile || pProfile->m_ProfileIndex != m_nProfileIndex )
+			CASW_Marine_Profile *pProfilePref = Briefing()->GetMarineProfile( m_nPreferredLobbySlot );
+			if ( !pProfilePref || pProfilePref->m_ProfileIndex != m_nProfileIndex )
 			{
 				bEnabled = false;
 			}

--- a/src/game/client/vgui_netgraphpanel.cpp
+++ b/src/game/client/vgui_netgraphpanel.cpp
@@ -866,9 +866,9 @@ void CNetGraphPanel::DrawTextFields( int graphvalue, int x, int y, int w, netban
 	// Draw legend
 	if ( graphvalue >= 3 && graphvalue < 5 )
 	{
-		int textTall = g_pMatSystemSurface->GetFontTall( m_hFontSmall );
+		int smallTextTall = g_pMatSystemSurface->GetFontTall( m_hFontSmall );
 
-		y = saveY - textTall - 5;
+		y = saveY - smallTextTall - 5;
 		int cw, ch;
 		g_pMatSystemSurface->GetTextSize( m_hFontSmall, L"otherplayersWWW", cw, ch );
 		if ( x - cw < 0 )
@@ -881,27 +881,27 @@ void CNetGraphPanel::DrawTextFields( int graphvalue, int x, int y, int w, netban
 		}
 
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 0, 0, 255, 255, "localplayer" );
-		y -= textTall;
+		y -= smallTextTall;
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 0, 255, 0, 255, "otherplayers" );
-		y -= textTall;
+		y -= smallTextTall;
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 255, 0, 0, 255, "entities" );
-		y -= textTall;
+		y -= smallTextTall;
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 255, 255, 0, 255, "sounds" );
-		y -= textTall;
+		y -= smallTextTall;
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 0, 255, 255, 255, "events" );
-		y -= textTall;
+		y -= smallTextTall;
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 255, 0, 255, 255, "tempents" );
-		y -= textTall;
+		y -= smallTextTall;
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 128, 128, 0, 255, "usermessages" );
-		y -= textTall;
+		y -= smallTextTall;
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 0, 128, 128, 255, "entmessages" );
-		y -= textTall;
+		y -= smallTextTall;
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 128, 0, 0, 255, "stringcmds" );
-		y -= textTall;
+		y -= smallTextTall;
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 0, 128, 0, 255, "stringtables" );
-		y -= textTall;
+		y -= smallTextTall;
 		g_pMatSystemSurface->DrawColoredText( m_hFontSmall, x, y, 0, 0, 128, 255, "voice" );
-		y -= textTall;
+		y -= smallTextTall;
 	}
 }
 

--- a/src/game/client/viewpostprocess.cpp
+++ b/src/game/client/viewpostprocess.cpp
@@ -326,9 +326,8 @@ void CTonemapSystem::IssueAndReceiveBucketQueries()
 	int nQueriesIssuedThisFrame = 0;
 	m_nCurrentQueryFrame++;
 
-	int nNumHistogramBuckets = NUM_HISTOGRAM_BUCKETS;
-	if ( mat_tonemap_algorithm.GetInt() == 1 )
-		nNumHistogramBuckets = NUM_HISTOGRAM_BUCKETS_NEW;
+	const int nNumHistogramBuckets =  mat_tonemap_algorithm.GetInt() == 1 ?
+		NUM_HISTOGRAM_BUCKETS_NEW : NUM_HISTOGRAM_BUCKETS;
 
 	for ( int i = 0; i < nNumHistogramBuckets; i++ )
 	{
@@ -362,10 +361,6 @@ void CTonemapSystem::IssueAndReceiveBucketQueries()
 	// Now, issue queries for the oldest finished queries we have
 	while ( nQueriesIssuedThisFrame < MAX_QUERIES_PER_FRAME )
 	{
-		int nNumHistogramBuckets = NUM_HISTOGRAM_BUCKETS;
-		if ( mat_tonemap_algorithm.GetInt() == 1 )
-			nNumHistogramBuckets = NUM_HISTOGRAM_BUCKETS_NEW;
-
 		int nOldestSoFar = -1;
 		for ( int i = 0; i < nNumHistogramBuckets; i++ )
 		{
@@ -1913,9 +1908,9 @@ void DoEnginePostProcessing( int x, int y, int w, int h, bool bFlashlightIsOn, b
 			partialViewportPostDestRect.height	-= 0.50f*fullViewportPostDestRect.height;
 
 			// This math interprets texel coords as being at corner pixel centers (*not* at corner vertices):
-			Vector2D uvScale(	1.0f - ( (w / 2) / (float)(w - 1) ),
+			Vector2D uvScale2(	1.0f - ( (w / 2) / (float)(w - 1) ),
 								1.0f - ( (h / 2) / (float)(h - 1) ) );
-			CenterScaleQuadUVs( partialViewportPostSrcCorners, uvScale );
+			CenterScaleQuadUVs( partialViewportPostSrcCorners, uvScale2 );
 		}
 
 		// Temporary hack... Color correction was crashing on the first frame 

--- a/src/game/client/viewrender.cpp
+++ b/src/game/client/viewrender.cpp
@@ -1848,11 +1848,7 @@ static void GetSkyboxFogColor( float *pColor, bool ignoreOverride, bool ignoreHD
 	{
 
 		fogparams_t *pFogParams = NULL;
-		C_BasePlayer *pbp = C_BasePlayer::GetLocalPlayer();
-		if (pbp)
-		{
-			pFogParams = pbp->GetFogParams();
-		}
+		pFogParams = pbp->GetFogParams();
 
 		if (GetFogEnable(pFogParams))
 		{

--- a/src/game/server/EventLog.cpp
+++ b/src/game/server/EventLog.cpp
@@ -193,12 +193,7 @@ bool CEventLog::PrintPlayerEvent( IGameEvent *event )
 
 		CBasePlayer *pAttacker = UTIL_PlayerByUserId( attackerid );
 		CTeam *team = pPlayer->GetTeam();
-		CTeam *attackerTeam = NULL;
-		
-		if ( pAttacker )
-		{
-			attackerTeam = pAttacker->GetTeam();
-		}
+
 		if ( pPlayer == pAttacker && pPlayer )  
 		{  
 

--- a/src/game/server/ai_baseactor.cpp
+++ b/src/game/server/ai_baseactor.cpp
@@ -294,14 +294,14 @@ bool CAI_BaseActor::StartSceneEvent( CSceneEventInfo *info, CChoreoScene *scene,
 			}	
 			else if (stricmp( event->GetParameters(), "AI_IGNORECOLLISION") == 0)
 			{
-				CBaseEntity *pTarget = FindNamedEntity( event->GetParameters2( ) );
+				CBaseEntity *pTarget2 = FindNamedEntity( event->GetParameters2( ) );
 
-				if (pTarget)
+				if (pTarget2)
 				{
 					info->m_nType = SCENE_AI_IGNORECOLLISION;
-					info->m_hTarget = pTarget;
+					info->m_hTarget = pTarget2;
 					float remaining = event->GetEndTime() - scene->GetTime();
-					NPCPhysics_CreateSolver( this, pTarget, true, remaining );
+					NPCPhysics_CreateSolver( this, pTarget2, true, remaining );
 					info->m_flNext = gpGlobals->curtime + remaining;
 					return true;
 				}

--- a/src/game/server/ai_basenpc.cpp
+++ b/src/game/server/ai_basenpc.cpp
@@ -12158,9 +12158,9 @@ bool CAI_BaseNPC::CineCleanup()
 				}
 				else if ( drop == 0 ) // Hanging in air?
 				{
-					Vector origin = GetLocalOrigin();
-					origin.z = new_origin.z;
-					SetLocalOrigin( origin );
+					Vector hanging_origin = GetLocalOrigin();
+					hanging_origin.z = new_origin.z;
+					SetLocalOrigin( hanging_origin );
 					SetGroundEntity( NULL );
 				}
 			}

--- a/src/game/server/ai_basenpc_schedule.cpp
+++ b/src/game/server/ai_basenpc_schedule.cpp
@@ -2146,8 +2146,8 @@ void CAI_BaseNPC::StartTask( const Task_t *pTask )
 
 					if ( GetTacticalServices()->FindLateralCover( pEntity->EyePosition(), 0, &coverPos ) )
 					{
-						AI_NavGoal_t goal( coverPos, ACT_RUN );
-						GetNavigator()->SetGoal( goal, AIN_CLEAR_PREVIOUS_STATE );
+						AI_NavGoal_t lateralCoverGoal( coverPos, ACT_RUN );
+						GetNavigator()->SetGoal( lateralCoverGoal, AIN_CLEAR_PREVIOUS_STATE );
 						
  						//FIXME: What exactly is this doing internally?
 						m_flMoveWaitFinished = gpGlobals->curtime + pTask->flTaskData;
@@ -2166,7 +2166,8 @@ void CAI_BaseNPC::StartTask( const Task_t *pTask )
 													AIN_HULL_TOLERANCE,
 													AIN_DEF_FLAGS,
 													m_hStoredPathTarget );
-							
+
+							// TODO: is this a bug? why goal and not coverGoal?
 							foundPath = GetNavigator()->SetGoal( goal );
 
 							m_flMoveWaitFinished = gpGlobals->curtime + pTask->flTaskData;

--- a/src/game/server/ai_navigator.cpp
+++ b/src/game/server/ai_navigator.cpp
@@ -4262,8 +4262,8 @@ void CAI_Navigator::DrawDebugRouteOverlay(void)
 
 		if (waypoint->GetNext()) 
 		{
-			Vector RGB = GetRouteColor(waypoint->GetNext()->NavType(), waypoint->GetNext()->Flags());
-			NDebugOverlay::Line(waypoint->GetPos(), waypoint->GetNext()->GetPos(),RGB[0],RGB[1],RGB[2], true,0);
+			Vector RGBnext = GetRouteColor(waypoint->GetNext()->NavType(), waypoint->GetNext()->Flags());
+			NDebugOverlay::Line(waypoint->GetPos(), waypoint->GetNext()->GetPos(),RGBnext[0],RGBnext[1],RGBnext[2], true,0);
 		}
 		waypoint = waypoint->GetNext();
 	}

--- a/src/game/server/ai_pathfinder.cpp
+++ b/src/game/server/ai_pathfinder.cpp
@@ -929,13 +929,13 @@ AI_Waypoint_t *CAI_Pathfinder::BuildSimpleRoute( Navigation_t navType, const Vec
 //-----------------------------------------------------------------------------
 // Builds a complex route (triangulation, making way)
 //-----------------------------------------------------------------------------
-AI_Waypoint_t *CAI_Pathfinder::BuildComplexRoute( Navigation_t navType, const Vector &vStart, 
+AI_Waypoint_t *CAI_Pathfinder::BuildComplexRoute( const Navigation_t navType, const Vector &vStart,
 	const Vector &vEnd, const CBaseEntity *pTarget, int endFlags, int nodeID, 
 	int buildFlags, float flYaw, float goalTolerance, float maxLocalNavDistance )
 {
 	AI_PROFILE_SCOPE( CAI_Pathfinder_BuildComplexRoute );
 	
-	float flTotalDist = ComputePathDistance( navType, vStart, vEnd );
+	const float flTotalDist = ComputePathDistance( navType, vStart, vEnd );
 	if ( flTotalDist < 0.0625 )
 	{
 		return new AI_Waypoint_t( vEnd, flYaw, navType, endFlags, nodeID );
@@ -980,7 +980,7 @@ AI_Waypoint_t *CAI_Pathfinder::BuildComplexRoute( Navigation_t navType, const Ve
 		{
 			if ( !UseStrongOptimizations() || ( GetOuter()->GetState() == NPC_STATE_SCRIPT || GetOuter()->IsCurSchedule( SCHED_SCENE_GENERIC, false ) ) )
 			{
-				float flTotalDist = ComputePathDistance( navType, vStart, vEnd );
+				// float flTotalDist = ComputePathDistance( navType, vStart, vEnd ); // already calculated above
 
 				AI_Waypoint_t *triangRoute = BuildTriangulationRoute(vStart, vEnd, pTarget, 
 					endFlags, nodeID, flYaw, flTotalDist - moveTrace.flDistObstructed, navType);

--- a/src/game/server/ai_pathfinder.h
+++ b/src/game/server/ai_pathfinder.h
@@ -134,7 +134,7 @@ private:
 		const CBaseEntity *pTarget, int endFlags, int nodeID, int nodeTargetType, float flYaw);
 
 	// Builds a complex route (triangulation, making way)
-	AI_Waypoint_t	*BuildComplexRoute( Navigation_t navType, const Vector &vStart, 
+	AI_Waypoint_t	*BuildComplexRoute( const Navigation_t navType, const Vector &vStart,
 		const Vector &vEnd, const CBaseEntity *pTarget, int endFlags, int nodeID, 
 		int buildFlags, float flYaw, float goalTolerance, float maxLocalNavDistance );
 

--- a/src/game/server/ai_schedule.cpp
+++ b/src/game/server/ai_schedule.cpp
@@ -287,8 +287,8 @@ bool CAI_SchedulesManager::LoadSchedulesFromBuffer( const char *prefix, char *pS
 				pfile = engine->ParseFile(pfile, token, sizeof( token ) );
 
 				// Convert generic ID to sub-class specific enum
-				int taskID = CAI_BaseNPC::GetTaskID(token);
-				tempTask[taskNum].flTaskData = (pIdSpace) ? pIdSpace->TaskGlobalToLocal(taskID) : AI_RemapFromGlobal( taskID );
+				int taskID2 = CAI_BaseNPC::GetTaskID(token);
+				tempTask[taskNum].flTaskData = (pIdSpace) ? pIdSpace->TaskGlobalToLocal(taskID2) : AI_RemapFromGlobal( taskID2 );
 
 				if (tempTask[taskNum].flTaskData == -1)
 				{

--- a/src/game/server/ai_scriptconditions.cpp
+++ b/src/game/server/ai_scriptconditions.cpp
@@ -537,14 +537,14 @@ void CAI_ScriptConditions::EvaluationThink()
 			m_hTarget.Get()
 		};
 
-		for ( int i = 0; i < nEvaluators; ++i )
+		for ( int j = 0; j < nEvaluators; ++j )
 		{
-			if ( !(this->*gm_Evaluators[i].pfnEvaluator)( args ) )
+			if ( !(this->*gm_Evaluators[j].pfnEvaluator)( args ) )
 			{
 				pConditionElement->GetTimer()->Reset();
 				result = false;
 
-				ScrCondDbgMsg( ( "%s failed on: %s\n", GetDebugName(), gm_Evaluators[ i ].pszName ) );
+				ScrCondDbgMsg( ( "%s failed on: %s\n", GetDebugName(), gm_Evaluators[ j ].pszName ) );
 
 				break;
 			}

--- a/src/game/server/ambientgeneric.cpp
+++ b/src/game/server/ambientgeneric.cpp
@@ -185,8 +185,8 @@ void CAmbientGeneric::ComputeMaxAudibleDistance( )
 
 	// Sadly, there's no direct way of getting at this. 
 	// We have to do an interative computation.
-	float flGain = enginesound->GetDistGainFromSoundLevel( m_iSoundLevel, m_radius );
-	if ( flGain <= MIN_AUDIBLE_VOLUME )
+	const float flGainMRadius = enginesound->GetDistGainFromSoundLevel( m_iSoundLevel, m_radius );
+	if ( flGainMRadius <= MIN_AUDIBLE_VOLUME )
 	{
 		m_flMaxRadius = m_radius;
 		return;
@@ -197,8 +197,8 @@ void CAmbientGeneric::ComputeMaxAudibleDistance( )
 	while ( true )
 	{
 		// First, find a min + max range surrounding the desired distance gain
-		float flGain = enginesound->GetDistGainFromSoundLevel( m_iSoundLevel, flMaxRadius );
-		if ( flGain <= MIN_AUDIBLE_VOLUME )
+		const float flGainMaxRadius = enginesound->GetDistGainFromSoundLevel( m_iSoundLevel, flMaxRadius );
+		if ( flGainMaxRadius <= MIN_AUDIBLE_VOLUME )
 			break;
 
 		// Always audible.
@@ -216,9 +216,9 @@ void CAmbientGeneric::ComputeMaxAudibleDistance( )
 	int nInterations = 4;
 	while ( --nInterations >= 0 )
 	{
-		float flTestRadius = (flMinRadius + flMaxRadius) * 0.5f;
-		float flGain = enginesound->GetDistGainFromSoundLevel( m_iSoundLevel, flTestRadius );
-		if ( flGain <= MIN_AUDIBLE_VOLUME )
+		const float flTestRadius = (flMinRadius + flMaxRadius) * 0.5f;
+		const float flGainTestRadius = enginesound->GetDistGainFromSoundLevel( m_iSoundLevel, flTestRadius );
+		if ( flGainTestRadius <= MIN_AUDIBLE_VOLUME )
 		{
 			flMaxRadius = flTestRadius;
 		}

--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -3037,17 +3037,17 @@ void CBaseEntity::VPhysicsUpdatePusher( IPhysicsObject *pPhysics )
 	if ( !PhysIsFinalTick() )
 		return;
 
-	Vector origin;
-	QAngle angles;
+	Vector shadowOrigin;
+	QAngle shadowAngles;
 
 	// physics updated the shadow, so check to see if I got blocked
 	// NOTE: SOLID_BSP cannont compute consistent collisions wrt vphysics, so 
 	// don't allow vphysics to block.  Assume game physics has handled it.
-	if ( GetSolid() != SOLID_BSP && pPhysics->GetShadowPosition( &origin, &angles ) )
+	if ( GetSolid() != SOLID_BSP && pPhysics->GetShadowPosition( &shadowOrigin, &shadowAngles ) )
 	{
 		CUtlVector<CBaseEntity *> list;
 		GetAllInHierarchy( this, list );
-		//NDebugOverlay::BoxAngles( origin, CollisionProp()->OBBMins(), CollisionProp()->OBBMaxs(), angles, 255,0,0,0, gpGlobals->frametime);
+		//NDebugOverlay::BoxAngles( shadowOrigin, CollisionProp()->OBBMins(), CollisionProp()->OBBMaxs(), shadowAngles, 255,0,0,0, gpGlobals->frametime);
 
 		physicspushlist_t *pList = NULL;
 		if ( HasDataObjectType(PHYSICSPUSHLIST) )

--- a/src/game/server/baseflex.cpp
+++ b/src/game/server/baseflex.cpp
@@ -576,8 +576,7 @@ bool CBaseFlex::HandleStartGestureSceneEvent( CSceneEventInfo *info, CChoreoScen
 		char szEndLoop[CEventAbsoluteTag::MAX_EVENTTAG_LENGTH] = { "end" };
 
 		// check in the tag indexes
-		KeyValues *pkvFaceposer;
-		for ( pkvFaceposer = pkvAllFaceposer->GetFirstSubKey(); pkvFaceposer; pkvFaceposer = pkvFaceposer->GetNextKey() )
+		for ( KeyValues *pkvFaceposer = pkvAllFaceposer->GetFirstSubKey(); pkvFaceposer; pkvFaceposer = pkvFaceposer->GetNextKey() )
 		{
 			if (!stricmp( pkvFaceposer->GetName(), "startloop" ))
 			{
@@ -619,8 +618,7 @@ bool CBaseFlex::HandleStartGestureSceneEvent( CSceneEventInfo *info, CChoreoScen
 			mstudioanimdesc_t &animdesc = pstudiohdr->pAnimdesc( pstudiohdr->iRelativeAnim( info->m_nSequence, seqdesc.anim(0,0) ) );
 
 			// check in the tag indexes
-			KeyValues *pkvFaceposer;
-			for ( pkvFaceposer = pkvAllFaceposer->GetFirstSubKey(); pkvFaceposer; pkvFaceposer = pkvFaceposer->GetNextKey() )
+			for ( KeyValues *pkvFaceposer = pkvAllFaceposer->GetFirstSubKey(); pkvFaceposer; pkvFaceposer = pkvFaceposer->GetNextKey() )
 			{
 				if (!stricmp( pkvFaceposer->GetName(), "tags" ))
 				{
@@ -633,14 +631,14 @@ bool CBaseFlex::HandleStartGestureSceneEvent( CSceneEventInfo *info, CChoreoScen
 						{
 							float percentage = (float)pkvTags->GetInt() / maxFrame;
 
-							CEventAbsoluteTag *ptag = event->FindAbsoluteTag( CChoreoEvent::ORIGINAL, pkvTags->GetName() );
-							if (ptag)
+							CEventAbsoluteTag *ptagOriginal = event->FindAbsoluteTag( CChoreoEvent::ORIGINAL, pkvTags->GetName() );
+							if (ptagOriginal)
 							{
-								if (fabs(ptag->GetPercentage() - percentage) > 0.05)
+								if (fabs(ptagOriginal->GetPercentage() - percentage) > 0.05)
 								{
-									DevWarning("%s repositioned tag: %s : %.3f -> %.3f (%s:%s:%s)\n", scene->GetFilename(), pkvTags->GetName(), ptag->GetPercentage(), percentage, scene->GetFilename(), actor->GetName(), event->GetParameters() );
+									DevWarning("%s repositioned tag: %s : %.3f -> %.3f (%s:%s:%s)\n", scene->GetFilename(), pkvTags->GetName(), ptagOriginal->GetPercentage(), percentage, scene->GetFilename(), actor->GetName(), event->GetParameters() );
 									// reposition tag
-									ptag->SetPercentage( percentage );
+									ptagOriginal->SetPercentage( percentage );
 								}
 							}
 						}
@@ -1062,8 +1060,7 @@ public:
 		Q_FixSlashes( szFilename );
 
 		// See if it's already loaded
-		int i;
-		for ( i = 0; i < m_FileList.Count(); i++ )
+		for ( int i = 0; i < m_FileList.Count(); i++ )
 		{
 			CFlexSceneFile *file = m_FileList[ i ];
 			if ( file && !V_stricmp( file->filename, szFilename ) )

--- a/src/game/server/basetempentity.cpp
+++ b/src/game/server/basetempentity.cpp
@@ -106,11 +106,11 @@ void CBaseTempEntity::Test( const Vector& current_origin, const QAngle& current_
 //-----------------------------------------------------------------------------
 void CBaseTempEntity::PrecacheTempEnts( void )
 {
-	CBaseTempEntity *te = GetList();
-	while ( te )
+	CBaseTempEntity *tempEntity = GetList();
+	while ( tempEntity )
 	{
-		te->Precache();
-		te = te->GetNext();
+		tempEntity->Precache();
+		tempEntity = tempEntity->GetNext();
 	}
 }
 

--- a/src/game/server/baseviewmodel.cpp
+++ b/src/game/server/baseviewmodel.cpp
@@ -80,8 +80,8 @@ int CBaseViewModel::ShouldTransmit( const CCheckTransmitInfo *pInfo )
 	}
 
 	// check if recipient (or one of his splitscreen parasites) is spectating the owner of this viewmodel
-	CBasePlayer *pPlayer = ToBasePlayer( CBaseEntity::Instance( pInfo->m_pClientEnt ) );
-	if ( pPlayer)
+	CBasePlayer *pPClient = ToBasePlayer( CBaseEntity::Instance( pInfo->m_pClientEnt ) );
+	if ( pPClient)
 	{
 		// Bug 28591:  In splitscreen, when the second slot is the one in spectator mode, it wouldn't
 		//  get the viewmodel for the spectatee.
@@ -93,8 +93,8 @@ int CBaseViewModel::ShouldTransmit( const CCheckTransmitInfo *pInfo )
 		// This container was the source of most of the allocation cost in CS:GO so using a CUtlVectorFixed to avoid
 		// allocations is important.
 		CUtlVectorFixedGrowable< CBasePlayer *, MAX_SPLITSCREEN_CLIENTS > checkList;
-		checkList.AddToTail( pPlayer );
-		CUtlVector< CHandle< CBasePlayer > > &vecParasites = pPlayer->GetSplitScreenPlayers();
+		checkList.AddToTail( pPClient );
+		CUtlVector< CHandle< CBasePlayer > > &vecParasites = pPClient->GetSplitScreenPlayers();
 		for ( int i = 0; i < vecParasites.Count(); ++i )
 		{
 			checkList.AddToTail( vecParasites[ i ] );

--- a/src/game/server/buttons.cpp
+++ b/src/game/server/buttons.cpp
@@ -1316,18 +1316,18 @@ void CMomentaryRotButton::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, US
 			// Must be first!
 			g_EventQueue.AddEvent( this, "_DisableUpdateTarget", 0, this, this );
 
-			variant_t value;
-			value.SetFloat( flDist );
-			g_EventQueue.AddEvent( this, "SetPosition", value, 0.01, this, this );
+			variant_t position;
+			position.SetFloat( flDist );
+			g_EventQueue.AddEvent( this, "SetPosition", position, 0.01, this, this );
 
-			value.SetFloat( 0.0 );
-			g_EventQueue.AddEvent( this, "SetPosition", value, 0.1, this, this );
+			position.SetFloat( 0.0 );
+			g_EventQueue.AddEvent( this, "SetPosition", position, 0.1, this, this );
 
-			value.SetFloat( 0.5 * flDist );
-			g_EventQueue.AddEvent( this, "SetPosition", value, 0.2, this, this );
+			position.SetFloat( 0.5 * flDist );
+			g_EventQueue.AddEvent( this, "SetPosition", position, 0.2, this, this );
 
-			value.SetFloat( 0.0 );
-			g_EventQueue.AddEvent( this, "SetPosition", value, 0.3, this, this );
+			position.SetFloat( 0.0 );
+			g_EventQueue.AddEvent( this, "SetPosition", position, 0.3, this, this );
 
 			// Must be last! And must be late enough to cover the settling time.
 			g_EventQueue.AddEvent( this, "_EnableUpdateTarget", 0.5, this, this );

--- a/src/game/server/client.cpp
+++ b/src/game/server/client.cpp
@@ -239,14 +239,14 @@ void Host_Say( edict_t *pEdict, const CCommand &args, bool teamonly )
 #ifdef INFESTED_DLL
 		if ( CAlienSwarm *pAlienSwarm = ASWGameRules() )
 		{
-			ScriptVariant_t args[3];
-			args[0] = ToHScript( client );
-			args[1] = ToHScript( pPlayer );
-			args[2] = ScriptVariant_t( newText );
+			ScriptVariant_t scriptArgs[3];
+			scriptArgs[0] = ToHScript( client );
+			scriptArgs[1] = ToHScript( pPlayer );
+			scriptArgs[2] = ScriptVariant_t( newText );
 			
-			pAlienSwarm->RunScriptFunctionInListenerScopes( "OnReceivedTextMessage", &args[2], NELEMS(args), args );
+			pAlienSwarm->RunScriptFunctionInListenerScopes( "OnReceivedTextMessage", &scriptArgs[2], NELEMS(scriptArgs), scriptArgs );
 
-			ScriptVariant_t result = args[2];
+			ScriptVariant_t result = scriptArgs[2];
 			if ( result.m_type != FIELD_CSTRING )
 					continue;
 				

--- a/src/game/server/episodic/npc_hunter.cpp
+++ b/src/game/server/episodic/npc_hunter.cpp
@@ -6029,8 +6029,8 @@ void CNPC_Hunter::GetShootDir( Vector &vecDir, const Vector &vecSrc, CBaseEntity
 
 	Vector vecTarget = vecBodyTarget;
 
-	Vector vecDelta = pTargetEntity->GetAbsOrigin() - GetAbsOrigin();
-	float flDist = vecDelta.Length();
+	Vector vecAbsDelta = pTargetEntity->GetAbsOrigin() - GetAbsOrigin();
+	float flDist = vecAbsDelta.Length();
 
 	if ( !bStriderBuster )
 	{

--- a/src/game/server/hl2/cbasehelicopter.cpp
+++ b/src/game/server/hl2/cbasehelicopter.cpp
@@ -506,9 +506,9 @@ bool CBaseHelicopter::DoWashPush( washentity_t *pWash, const Vector &vecWashOrig
 		NDebugOverlay::Cross3D( pEntity->GetAbsOrigin(), -Vector(4,4,4), Vector(4,4,4), 255, 0, 0, true, 0.1f );
 		NDebugOverlay::Line( pEntity->GetAbsOrigin(), pEntity->GetAbsOrigin() + vecForce, 255, 255, 0, true, 0.1f );
 
-		IPhysicsObject *pPhysObject = pEntity->VPhysicsGetObject();
+		const float fPhysObjectMass = pEntity->VPhysicsGetObject()->GetMass();
 		Msg("Pushed %s (index %d) (mass %f) with force %f (min %.2f max %.2f) at time %.2f\n", 
-			pEntity->GetClassname(), pEntity->entindex(), pPhysObject->GetMass(), flWashAmount, 
+			pEntity->GetClassname(), pEntity->entindex(), fPhysObjectMass, flWashAmount, 
 			BASECHOPPER_WASH_PUSH_MIN * flMass, BASECHOPPER_WASH_PUSH_MAX * flMass, gpGlobals->curtime );
 	}
 

--- a/src/game/server/hltvdirector.cpp
+++ b/src/game/server/hltvdirector.cpp
@@ -378,17 +378,17 @@ void CHLTVDirector::StartBestPlayerCameraShot()
 		// search for camera ranking events
 		if ( Q_strcmp( dc.m_Event->GetName(), "hltv_rank_entity") == 0 )
 		{
-			int index = dc.m_Event->GetInt("index"); 
+			int iIndex = dc.m_Event->GetInt("index"); 
 
-			if ( index < MAX_PLAYERS )
+			if ( iIndex < MAX_PLAYERS )
 			{
-				flPlayerRanking[index] += dc.m_Event->GetFloat("rank" );
+				flPlayerRanking[iIndex] += dc.m_Event->GetFloat("rank" );
 
 				// find best camera
-				if ( flPlayerRanking[index] > flBestRank )
+				if ( flPlayerRanking[iIndex] > flBestRank )
 				{
-					iBestCamera = index;
-					flBestRank = flPlayerRanking[index];
+					iBestCamera = iIndex;
+					flBestRank = flPlayerRanking[iIndex];
 					iBestTarget = dc.m_Event->GetInt("target"); 
 				}
 			}
@@ -487,14 +487,14 @@ void CHLTVDirector::StartBestFixedCameraShot( bool bForce )
 		// search for camera ranking events
 		if ( Q_strcmp( dc.m_Event->GetName(), "hltv_rank_camera") == 0 )
 		{
-			int index = dc.m_Event->GetInt("index"); 
-			flCameraRanking[index] += dc.m_Event->GetFloat("rank" );
+			int iIndex = dc.m_Event->GetInt("index"); 
+			flCameraRanking[iIndex] += dc.m_Event->GetFloat("rank" );
 
 			// find best camera
-			if ( flCameraRanking[index] > flBestRank )
+			if ( flCameraRanking[iIndex] > flBestRank )
 			{
-				iBestCamera = index;
-				flBestRank = flCameraRanking[index];
+				iBestCamera = iIndex;
+				flBestRank = flCameraRanking[iIndex];
 				iBestTarget = dc.m_Event->GetInt("target"); 
 			}
 		}
@@ -686,11 +686,11 @@ bool CHLTVDirector::SetCameraMan( int iPlayerIndex )
 
 	for ( int i = 1; i <= gpGlobals->maxClients; i++ )
 	{
-		CBasePlayer *pPlayer = UTIL_PlayerByIndex( i );
+		CBasePlayer *pPRecipient = UTIL_PlayerByIndex( i );
 
-		if ( pPlayer && pPlayer->GetTeamNumber() == TEAM_SPECTATOR && !pPlayer->IsFakeClient() )
+		if ( pPRecipient && pPRecipient->GetTeamNumber() == TEAM_SPECTATOR && !pPRecipient->IsFakeClient() )
 		{
-			filter.AddRecipient( pPlayer );
+			filter.AddRecipient( pPRecipient );
 		}
 	}
 

--- a/src/game/server/nav_area.cpp
+++ b/src/game/server/nav_area.cpp
@@ -1326,25 +1326,25 @@ void CNavArea::FinishSplitEdit( CNavArea *newArea, NavDirType ignoreEdge )
 					break;
 			}
 
-			for ( int a = 0; a < m_incomingConnect[d].Count(); a++ )
-			{			
-				CNavArea *adj = m_incomingConnect[d][a].area;
+			for ( int ia = 0; ia < m_incomingConnect[d].Count(); ia++ )
+			{
+				CNavArea *incAdj = m_incomingConnect[d][ia].area;
 
 				switch( d )
 				{
 				case NORTH:
 				case SOUTH:
-					if (newArea->IsOverlappingX( adj ))
+					if (newArea->IsOverlappingX( incAdj ))
 					{
-						adj->ConnectTo( newArea, OppositeDirection( (NavDirType)d ) );
+						incAdj->ConnectTo( newArea, OppositeDirection( (NavDirType)d ) );
 					}
 					break;
 
 				case EAST:
 				case WEST:
-					if (newArea->IsOverlappingY( adj ))
+					if (newArea->IsOverlappingY( incAdj ))
 					{
-						adj->ConnectTo( newArea, OppositeDirection( (NavDirType)d ) );
+						incAdj->ConnectTo( newArea, OppositeDirection( (NavDirType)d ) );
 					}
 					break;
 				}
@@ -2973,7 +2973,7 @@ void CNavArea::Draw( void ) const
 
 	if ( IsBlocked( TEAM_ANY ) || HasAvoidanceObstacle() || IsDamaging() )
 	{
-		NavEditColor color = (IsBlocked( TEAM_ANY ) && ( m_attributeFlags & NAV_MESH_NAV_BLOCKER ) ) ? NavBlockedByFuncNavBlockerColor : NavBlockedByDoorColor;
+		NavEditColor blockedColor = (IsBlocked( TEAM_ANY ) && ( m_attributeFlags & NAV_MESH_NAV_BLOCKER ) ) ? NavBlockedByFuncNavBlockerColor : NavBlockedByDoorColor;
 		const float blockedInset = 4.0f;
 		nw.x += blockedInset;
 		nw.y += blockedInset;
@@ -2983,10 +2983,10 @@ void CNavArea::Draw( void ) const
 		sw.y -= blockedInset;
 		se.x -= blockedInset;
 		se.y -= blockedInset;
-		NavDrawLine( nw, ne, color );
-		NavDrawLine( ne, se, color );
-		NavDrawLine( se, sw, color );
-		NavDrawLine( sw, nw, color );
+		NavDrawLine( nw, ne, blockedColor );
+		NavDrawLine( ne, se, blockedColor );
+		NavDrawLine( se, sw, blockedColor );
+		NavDrawLine( sw, nw, blockedColor );
 	}
 }
 

--- a/src/game/server/nav_file.cpp
+++ b/src/game/server/nav_file.cpp
@@ -283,8 +283,7 @@ void CNavArea::Save( CUtlBuffer &fileBuffer, unsigned int version ) const
 	//
 	{
 		// save number of encounter paths for this area
-		unsigned int count = m_spotEncounters.Count();
-		fileBuffer.PutUnsignedInt( count );
+		fileBuffer.PutUnsignedInt( m_spotEncounters.Count() );
 
 		SpotEncounter *e;
 		FOR_EACH_VEC( m_spotEncounters, it )
@@ -348,8 +347,7 @@ void CNavArea::Save( CUtlBuffer &fileBuffer, unsigned int version ) const
 	for ( i=0; i<CNavLadder::NUM_LADDER_DIRECTIONS; ++i )
 	{
 		// save number of encounter paths for this area
-		unsigned int count = m_ladder[i].Count();
-		fileBuffer.PutUnsignedInt( count );
+		fileBuffer.PutUnsignedInt( m_ladder[i].Count() );
 
 		NavLadderConnect ladder;
 		FOR_EACH_VEC( m_ladder[i], it )

--- a/src/game/server/nav_generate.cpp
+++ b/src/game/server/nav_generate.cpp
@@ -2874,11 +2874,12 @@ bool CNavMesh::TestArea( CNavNode *node, int width, int height )
 	CNavNode *vertNode, *horizNode;
 
 	vertNode = node;
-	int x,y;
+	int y;
 	for( y=0; y<height; y++ )
 	{
 		horizNode = vertNode;
 
+		int x;
 		for( x=0; x<width; x++ )
 		{
 			//
@@ -3033,6 +3034,7 @@ bool CNavMesh::TestArea( CNavNode *node, int width, int height )
 	{
 		horizNode = vertNode;
 
+		int x;
 		for( x=0; x<width; x++ )
 		{
 			if ( !CheckObstacles( horizNode, width, height, x, y ) )
@@ -3792,8 +3794,7 @@ bool CNavMesh::UpdateGeneration( float maxTime )
 				return true; // wait for eyePos to settle
 
 			// Now try to compute lighting for remaining areas
-			int sit = 0;
-			while( sit < s_unlitAreas.Count() )
+			for ( int sit = 0; sit < s_unlitAreas.Count(); ) // while( sit < s_unlitAreas.Count() )
 			{
 				CNavArea *area = s_unlitAreas[sit];
 				if ( area->ComputeLighting() )
@@ -4038,8 +4039,7 @@ CNavNode *CNavMesh::AddNode( const Vector &destPos, const Vector &normal, NavDir
 	// determine if there's a cliff nearby and set an attribute on this node
 	for ( int i = 0; i < NUM_DIRECTIONS; i++ )
 	{
-		NavDirType dir = (NavDirType) i;
-		if ( CheckCliff( node->GetPosition(), dir ) )
+		if ( CheckCliff( node->GetPosition(), static_cast<NavDirType>(i) ) )
 		{
 			node->SetAttributes( node->GetAttributes() | NAV_MESH_CLIFF );
 			break;

--- a/src/game/server/physics_impact_damage.cpp
+++ b/src/game/server/physics_impact_damage.cpp
@@ -440,10 +440,10 @@ float CalculatePhysicsImpactDamage( int index, gamevcollisionevent_t *pEvent, co
 		CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
 		if ( pPlayer )
 		{
-			float mass = pPlayer->GetHeldObjectMass( pEvent->pObjects[index] );
-			if ( mass > 0 )
+			float massHeld = pPlayer->GetHeldObjectMass( pEvent->pObjects[index] );
+			if ( massHeld > 0 )
 			{
-				invMass = 1.0f / mass;
+				invMass = 1.0f / massHeld;
 			}
 		}
 	}

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -8789,7 +8789,7 @@ void CBasePlayer::SetPlayerName( const char *name )
 
 		if(rd_add_index_to_name.GetBool())
 		{
-			int n = V_snprintf(m_szNetname, sizeof(m_szNetname) - 1, "%d-%s", ENTINDEX(edict()), name);
+			V_snprintf(m_szNetname, sizeof(m_szNetname) - 1, "%d-%s", ENTINDEX(edict()), name);
 			UTIL_SafeUtf8Truncate(m_szNetname, sizeof(m_szNetname));
 		}
 		else

--- a/src/game/server/props.cpp
+++ b/src/game/server/props.cpp
@@ -1795,16 +1795,16 @@ void CBreakableProp::Break( CBaseEntity *pBreaker, const CTakeDamageInfo &info )
 	{
 		CPASFilter filter( WorldSpaceCenter() );
 
-		Vector velocity; velocity.Init();
+		Vector vVelocity; vVelocity.Init();
 
 		if ( pPhysics )
-			pPhysics->GetVelocity( &velocity, NULL );
+			pPhysics->GetVelocity( &vVelocity, NULL );
 
 		switch ( GetMultiplayerBreakMode() )
 		{
 		case MULTIPLAYER_BREAK_DEFAULT:		// default is to break client-side
 		case MULTIPLAYER_BREAK_CLIENTSIDE:
-			te->PhysicsProp( filter, -1, GetModelIndex(), m_nSkin, GetAbsOrigin(), GetAbsAngles(), velocity, true, GetEffects() );
+			te->PhysicsProp( filter, -1, GetModelIndex(), m_nSkin, GetAbsOrigin(), GetAbsAngles(), vVelocity, true, GetEffects() );
 			break;
 		case MULTIPLAYER_BREAK_SERVERSIDE:	// server-side break
 			if ( m_PerformanceMode != PM_NO_GIBS || breakable_disable_gib_limit.GetBool() )
@@ -1813,7 +1813,7 @@ void CBreakableProp::Break( CBaseEntity *pBreaker, const CTakeDamageInfo &info )
 			}
 			break;
 		case MULTIPLAYER_BREAK_BOTH:	// pieces break from both dlls
-			te->PhysicsProp( filter, -1, GetModelIndex(), m_nSkin, GetAbsOrigin(), GetAbsAngles(), velocity, true, GetEffects() );
+			te->PhysicsProp( filter, -1, GetModelIndex(), m_nSkin, GetAbsOrigin(), GetAbsAngles(), vVelocity, true, GetEffects() );
 			if ( m_PerformanceMode != PM_NO_GIBS || breakable_disable_gib_limit.GetBool() )
 			{
 				PropBreakableCreateAll( GetModelIndex(), pPhysics, params, this, -1, ( m_PerformanceMode == PM_FULL_GIBS ), false );

--- a/src/game/server/sceneentity.cpp
+++ b/src/game/server/sceneentity.cpp
@@ -1850,8 +1850,7 @@ void CSceneEntity::DispatchStartSpeak( CChoreoScene *scene, CBaseFlex *actor, CC
 				if ( !event->IsSuppressingCaptionAttenuation() && 
 					( filter.GetRecipientCount() > 0 ) )
 				{
-					int c = filter.GetRecipientCount();
-					for ( int i = c - 1 ; i >= 0; --i )
+					for ( int i = filter.GetRecipientCount() - 1 ; i >= 0; --i )
 					{
 						CBasePlayer *player = UTIL_PlayerByIndex( filter.GetRecipientIndex( i ) );
 						if ( !player )
@@ -2247,8 +2246,7 @@ void CSceneEntity::InputInterjectResponse( inputdata_t &inputdata )
 	}
 
 	CUtlVector< CAI_BaseActor * >	candidates;
-	int i;
-	for ( i = 0 ; i < m_pScene->GetNumActors(); i++ )
+	for ( int i = 0 ; i < m_pScene->GetNumActors(); i++ )
 	{
 		CBaseFlex *pTestActor = FindNamedActor( i );
 		if ( !pTestActor )

--- a/src/game/server/swarm/asw_gamerules_vscript.cpp
+++ b/src/game/server/swarm/asw_gamerules_vscript.cpp
@@ -1368,15 +1368,15 @@ void CAlienSwarm::RunScriptFunctionInListenerScopes( const char *szFunctionName,
 		CASW_Challenge_Thinker *pThinker = CASW_Challenge_Thinker::s_Thinkers[i];
 		if ( HSCRIPT hScope = pThinker->GetScriptScope() )
 		{
-			if ( HSCRIPT hFunc = g_pScriptVM->LookupFunction( szFunctionName, hScope ) )
+			if ( HSCRIPT hScopedFunc = g_pScriptVM->LookupFunction( szFunctionName, hScope ) )
 			{
-				ScriptStatus_t nStatus = g_pScriptVM->ExecuteFunction( hFunc, pArgs, nArgs, pReturn, hScope, false );
+				ScriptStatus_t nStatus = g_pScriptVM->ExecuteFunction( hScopedFunc, pArgs, nArgs, pReturn, hScope, false );
 				if ( nStatus != SCRIPT_DONE )
 				{
 					DevWarning( "%s VScript function for thinker #%d:%s did not finish!\n", szFunctionName, pThinker->entindex(), pThinker->GetDebugName() );
 				}
 
-				g_pScriptVM->ReleaseFunction( hFunc );
+				g_pScriptVM->ReleaseFunction( hScopedFunc );
 			}
 		}
 	}

--- a/src/game/shared/achievementmgr.cpp
+++ b/src/game/shared/achievementmgr.cpp
@@ -1605,8 +1605,7 @@ void CAchievementMgr::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStats
 			int iValue;
 			char pszProgressName[1024];
 			Q_snprintf( pszProgressName, 1024, "%s_STAT", pAchievement->GetName() );
-			bool bRet = SteamUserStats()->GetStat( pszProgressName, &iValue );
-			if ( bRet )
+			if ( SteamUserStats()->GetStat( pszProgressName, &iValue ) )
 			{
 				pAchievement->SetCount( iValue );
 			}
@@ -1618,8 +1617,7 @@ void CAchievementMgr::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStats
 			if ( pAchievement->HasComponents() )
 			{
 				Q_snprintf( pszProgressName, 1024, "%s_COMP", pAchievement->GetName() );
-				bool bRet = SteamUserStats()->GetStat( pszProgressName, &iValue );
-				if ( bRet )
+				if ( SteamUserStats()->GetStat( pszProgressName, &iValue ) )
 				{
 					pAchievement->SetComponentBits( iValue );
 				}

--- a/src/game/shared/util_shared.cpp
+++ b/src/game/shared/util_shared.cpp
@@ -1837,6 +1837,7 @@ int UTIL_CalcFrustumThroughConvexPolygon( const Vector *pPolyVertices, int iPoly
 			i3 = (iMinSideFirstPoint + 1)%(iOldVertCount);
 			i4 = (iMinSideFirstPoint + 2)%(iOldVertCount);
 
+#pragma warning(suppress : 4459) // declaration of 'p4' hides global declaration
 			Vector *p1, *p2, *p3, *p4;
 			p1 = &pClippedVerts[i1];
 			p2 = &pClippedVerts[i2];

--- a/src/public/sentence.cpp
+++ b/src/public/sentence.cpp
@@ -1373,9 +1373,9 @@ void CSentence::Append( float starttime, const CSentence& src )
 
 		// Offset times
 		int c = newWord->m_Phonemes.Count();
-		for ( int i = 0; i < c; ++i )
+		for ( int j = 0; j < c; ++j )
 		{
-			CPhonemeTag *tag = newWord->m_Phonemes[ i ];
+			CPhonemeTag *tag = newWord->m_Phonemes[ j ];
 			tag->AddStartTime( starttime );
 			tag->AddEndTime( starttime );
 		}


### PR DESCRIPTION
Most of these changes are simple renames to prevent name collisions between:

1. Function parameters and local declarations
2. Local declarations and loop variables
3. Variables in nested and outer loops

Nearly all renames were performed using LSP rename.