### PR TITLE
fix: restore CASW_Inhabitable_NPC client class registration

### DIFF
--- a/src/game/client/swarm/c_asw_inhabitable_npc.cpp
+++ b/src/game/client/swarm/c_asw_inhabitable_npc.cpp
@@ -17,6 +17,7 @@ extern ConVar rd_highlight_active_character;
 extern ConVar glow_outline_color_alien;
 extern ConVar asw_controls;
 
+#undef CASW_Inhabitable_NPC
 IMPLEMENT_CLIENTCLASS_DT( C_ASW_Inhabitable_NPC, DT_ASW_Inhabitable_NPC, CASW_Inhabitable_NPC )
 	RecvPropEHandle( RECVINFO( m_Commander ) ),
 	RecvPropEHandle( RECVINFO( m_hUsingEntity ) ),


### PR DESCRIPTION
The #define CASW_Inhabitable_NPC C_ASW_Inhabitable_NPC from rd_inventory_shared.h was leaking into c_asw_inhabitable_npc.cpp via c_asw_player.h, causing the IMPLEMENT_CLIENTCLASS_DT invocation to expand incorrectly (third argument stringified as "C_ASW_Inhabitable_NPC" instead of "CASW_Inhabitable_NPC").

This caused the "Client missing DT class CASW_Inhabitable_NPC" error and a crash when parsing entity updates on maps with such entities (e.g. rd-par2hostile_places).

This matches the existing pattern in c_asw_player.cpp and c_asw_marine_resource.cpp.