### PR TITLE
Prevent debug assertions in controller focus and weapon details

### DIFF
--- a/src/game/client/swarm/vgui/controller_focus.cpp
+++ b/src/game/client/swarm/vgui/controller_focus.cpp
@@ -77,11 +77,11 @@ void CControllerFocus::AddToFocusList( vgui::Panel *pPanel, bool bClickOnFocus, 
 	if ( !pPanel )
 		return;
 
+	if ( !IsInGame() )
+		return;
 	Assert( bModal || !m_iModalScope );
 
 	Assert( IsInGame() );
-	if ( !IsInGame() )
-		return;
 
 	FocusArea Focus;
 	Focus.hPanel = pPanel;

--- a/src/game/client/swarm/vgui/nb_weapon_detail.cpp
+++ b/src/game/client/swarm/vgui/nb_weapon_detail.cpp
@@ -273,8 +273,11 @@ void CNB_Weapon_Detail::UpdateLabels( CASW_EquipItem *pItem, CASW_WeaponInfo *pW
 	{
 		int iClipValue = pItem->MaxAmmo1();
 		int nMaxBulletsPerGun = GetAmmoDef()->MaxCarry( pItem->m_iAmmo1, NULL );
-		Assert( nMaxBulletsPerGun % iClipValue == 0 );
-		int iNumClips = ( nMaxBulletsPerGun / iClipValue ) + 1;
+		// MaxCarry is reserve ammo; challenge configs may leave a partial
+		// reserve clip, so do not assert that it divides evenly. Keep the original
+		// integer-floor count and include the loaded clip.
+		//Assert( nMaxBulletsPerGun % iClipValue == 0 );
+		int iNumClips = iClipValue > 0 ? ( nMaxBulletsPerGun / iClipValue ) + 1 : 0;
 
 		if ( pWeaponData->m_iDisplayClipSize >= 0 )
 			iClipValue = pWeaponData->m_iDisplayClipSize;
@@ -285,6 +288,10 @@ void CNB_Weapon_Detail::UpdateLabels( CASW_EquipItem *pItem, CASW_WeaponInfo *pW
 			// this displays an "infinity" symbol in the neosans font
 			V_snwprintf( wszClipValue, ARRAYSIZE( wszClipValue ), L"\u221E" );
 		}
+		else if ( iClipValue <= 0 )
+		{
+			V_snwprintf( wszClipValue, ARRAYSIZE( wszClipValue ), L"%s", g_pVGuiLocalize->Find( "#asw_weapon_altfire_NA" ) );
+		}
 		else if ( pWeaponData->m_bShowClipsInWeaponDetail )
 		{
 			V_snwprintf( wszClipValue, ARRAYSIZE( wszClipValue ), L"%d \u00d7 %d", iClipValue, iNumClips );
@@ -293,12 +300,19 @@ void CNB_Weapon_Detail::UpdateLabels( CASW_EquipItem *pItem, CASW_WeaponInfo *pW
 		{
 			V_snwprintf( wszClipValue, ARRAYSIZE( wszClipValue ), L"%d", iClipValue );
 		}
-		float flCurrent = MIN( ( float )iClipValue / 200.0f, 1.0f );
+		float flCurrent = iClipValue > 0 ? MIN( ( float )iClipValue / 200.0f, 1.0f ) : 0.0f;
 
 		m_pValueLabel->SetVisible( true );
 		m_pValueLabel->SetText( wszClipValue );
-		m_pStatsBar->SetVisible( true );
-		m_pStatsBar->Init( flCurrent, flCurrent, 0.1f, false, false );
+		if ( iClipValue > 0 )
+		{
+			m_pStatsBar->SetVisible( true );
+			m_pStatsBar->Init( flCurrent, flCurrent, 0.1f, false, false );
+		}
+		else
+		{
+			m_pStatsBar->SetVisible( false );
+		}
 	}
 	else if ( m_eWeaponFactType == RD_Swarmopedia::WeaponFact::Type_T::Secondary )
 	{


### PR DESCRIPTION
## Summary
- Avoid registering controller-focus panels while the client is outside an active game.
- Allow weapon detail tooltips to display challenge-defined reserve ammo that is not an exact multiple of the clip size.
- Handle non-positive clip sizes safely in the weapon detail UI.

## Problem
### Controller focus outside a game
`CControllerFocus::AddToFocusList()` asserted `IsInGame()` before reaching its existing early return. The challenge-selection panel can be opened from the main menu before a listen server exists, so a Debug client hits the assertion even though focus registration should simply be skipped.

### Weapon detail reserve ammo
`CNB_Weapon_Detail::UpdateLabels()` asserted `nMaxBulletsPerGun % iClipValue == 0`. `MaxCarry()` is reserve ammunition, and challenge configurations may intentionally use a partial reserve clip (for example, 18 reserve rounds with an 8-round clip). Release builds already continued with integer-floor calculation, so exact divisibility is not a valid universal invariant.

## Fix
- Return from `AddToFocusList()` before the in-game assertion when `IsInGame()` is false.
- Do not enforce exact divisibility for reserve ammo; preserve the existing Release integer-floor display plus the loaded clip.
- Guard non-positive clip sizes, show `N/A`, and hide the stat bar.

## Scope
Client-side UI robustness only. No VScript, challenge behavior, weapon values, or ammo configuration changes.

## Reproduction
1. Debug client: open challenge selection from the main mission/task UI before creating a listen server.
2. Debug client: in briefing, inspect a weapon whose challenge-defined reserve ammo is not divisible by its clip size.

## Validation
- Win32 Debug client build passed.
- Win32 Release client build passed.
- `git diff --check` passed.