### PR TITLE
Continue Steam SDK 1.65 API migration

### DIFF
--- a/src/game/client/achievement_notification_panel.cpp
+++ b/src/game/client/achievement_notification_panel.cpp
@@ -104,14 +104,22 @@ void CAchievementNotificationPanel::FireGameEvent( IGameEvent * event )
 		if ( IsPC() )
 		{
 			// shouldn't ever get achievement progress if steam not running and user logged in, but check just in case
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( !SteamUserStats() )
+#else
+			if ( !SteamUserStats() )
+#endif
 			{				
 				Msg( "Steam not running, achievement progress notification not displayed\n" );
 			}
 			else
 			{
 				// use Steam to show achievement progress UI
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				SteamUserStats()->IndicateAchievementProgress( pchName, iCur, iMax );
+#else
+				SteamUserStats()->IndicateAchievementProgress( pchName, iCur, iMax );
+#endif
 			}
 		}
 		else 

--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -973,8 +973,18 @@ bool InitGameSystems( CreateInterfaceFn appSystemFactory )
 
 	// SteamUtils wasn't ready yet when we initialized the ConVar, so check it again
 	extern ConVar rd_represented_country;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUtils() && rd_represented_country.GetString()[0] == '\0' )
+#else
+	if ( SteamUtils() && rd_represented_country.GetString()[0] == '\0' )
+#endif
+	{
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		rd_represented_country.SetValue( SteamUtils()->GetIPCountry() );
+	#else
+		rd_represented_country.SetValue( SteamUtils()->GetIPCountry() );
+	#endif
+	}
 
 	// Load the ClientScheme just once
 	vgui::scheme()->LoadSchemeFromFileEx( VGui_GetFullscreenRootVPANEL(), "resource/ClientScheme.res", "ClientScheme");
@@ -3075,4 +3085,3 @@ class CClientMaterialSystem : public IClientMaterialSystem
 static CClientMaterialSystem s_ClientMaterialSystem;
 IClientMaterialSystem *g_pClientMaterialSystem = &s_ClientMaterialSystem;
 EXPOSE_SINGLE_INTERFACE_GLOBALVAR( CClientMaterialSystem, IClientMaterialSystem, VCLIENTMATERIALSYSTEM_INTERFACE_VERSION, s_ClientMaterialSystem );
-

--- a/src/game/client/game_controls/ClientScoreBoardDialog.cpp
+++ b/src/game/client/game_controls/ClientScoreBoardDialog.cpp
@@ -551,17 +551,29 @@ bool CClientScoreBoardDialog::GetPlayerScoreInfo(int playerIndex, KeyValues *kv)
 void CClientScoreBoardDialog::UpdatePlayerAvatar( int playerIndex, KeyValues *kv )
 {
 	// Update their avatar
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( kv && ShowAvatars() && SteamFriends() && SteamUtils() )
+#else
+	if ( kv && ShowAvatars() && SteamFriends() && SteamUtils() )
+#endif
 	{
 		player_info_t pi;
 		if ( engine->GetPlayerInfo( playerIndex, &pi ) )
 		{
 			if ( pi.friendsID )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+#else
+				CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+#endif
 
 				// See if the avatar's changed
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				int iAvatar = SteamFriends()->GetSmallFriendAvatar( steamIDForPlayer );
+#else
+				int iAvatar = SteamFriends()->GetSmallFriendAvatar( steamIDForPlayer );
+#endif
 				if ( m_iImageAvatars[playerIndex] != iAvatar )
 				{
 					m_iImageAvatars[playerIndex] = iAvatar;

--- a/src/game/client/swarm/asw_briefing.cpp
+++ b/src/game/client/swarm/asw_briefing.cpp
@@ -467,7 +467,11 @@ CSteamID CASW_Briefing::GetCommanderSteamID( int nLobbySlot )
 	{
 		if ( pi.friendsID )
 		{
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+			#else
+			CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+			#endif
 			return steamIDForPlayer;
 		}
 	}

--- a/src/game/client/swarm/asw_in_main.cpp
+++ b/src/game/client/swarm/asw_in_main.cpp
@@ -735,7 +735,11 @@ void CASWInput::Init_All( void )
 	CInput::Init_All();
 	m_iOrderingMarine = 0;
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( IsX360() || ( SteamUtils() && SteamUtils()->IsSteamInBigPictureMode() ) )
+	#else
+	if ( IsX360() || ( SteamUtils() && SteamUtils()->IsSteamInBigPictureMode() ) )
+	#endif
 	{
 		EngageControllerMode();
 		SetControllerModeMouse( true );

--- a/src/game/client/swarm/asw_medal_store.cpp
+++ b/src/game/client/swarm/asw_medal_store.cpp
@@ -49,13 +49,25 @@ void C_ASW_Medal_Store::LoadMedalStore()
 #if defined(NO_STEAM)
 	AssertMsg( false, "SteamCloud not available." );
 #else
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+	#else
+	ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+	#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUser *pSteamUser = SteamUser();
+#else
+	ISteamUser *pSteamUser = SteamUser();
+#endif
 	if ( !pSteamUser )
 		return;
 
 	char szMedalFile[256];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Q_snprintf( szMedalFile, sizeof( szMedalFile ), "cfg/clientc_%I64u.dat", pSteamUser->GetSteamID().ConvertToUint64() );
+#else
+	Q_snprintf( szMedalFile, sizeof( szMedalFile ), "cfg/clientc_%I64u.dat", pSteamUser->GetSteamID().ConvertToUint64() );
+#endif
 	int len = Q_strlen( szMedalFile );
 	for ( int i = 0; i < len; i++ )
 	{
@@ -347,12 +359,20 @@ bool C_ASW_Medal_Store::SaveMedalStore()
 	}
 	UTIL_EncodeICE( ( unsigned char * )buf.Base(), buf.TellPut(), g_ucMedalStoreEncryptionKey );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUser *pSteamUser = SteamUser();
+#else
+	ISteamUser *pSteamUser = SteamUser();
+#endif
 	if ( !pSteamUser )
 		return false;
 
 	char szMedalFile[256];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Q_snprintf( szMedalFile, sizeof( szMedalFile ), "cfg/clientc_%I64u.dat", pSteamUser->GetSteamID().ConvertToUint64() );
+#else
+	Q_snprintf( szMedalFile, sizeof( szMedalFile ), "cfg/clientc_%I64u.dat", pSteamUser->GetSteamID().ConvertToUint64() );
+#endif
 	int len = Q_strlen( szMedalFile );
 	for ( int i = 0; i < len; i++ )
 	{
@@ -365,8 +385,12 @@ bool C_ASW_Medal_Store::SaveMedalStore()
 	{
 #if defined(NO_STEAM)
 		AssertMsg( false, "SteamCloud not available." );
-#else
+	#else
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+		#else
+		ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+		#endif
 
 		if ( asw_steam_cloud.GetBool() && pRemoteStorage )
 		{
@@ -894,4 +918,3 @@ int C_ASW_Medal_Store::GetPromotion()
 	}
 	return m_iPromotion;
 }
-

--- a/src/game/client/swarm/asw_view_scene.cpp
+++ b/src/game/client/swarm/asw_view_scene.cpp
@@ -365,10 +365,17 @@ bool CLanguagePreferenceProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues
 	}
 
 	const char *szTextureName = pKeyValues->GetString( "default", NULL );
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamApps() )
 	{
 		szTextureName = pKeyValues->GetString( SteamApps()->GetCurrentGameLanguage(), szTextureName);
 	}
+	#else
+	if ( SteamApps() )
+	{
+		szTextureName = pKeyValues->GetString( SteamApps()->GetCurrentGameLanguage(), szTextureName);
+	}
+	#endif
 
 	if ( !szTextureName )
 	{

--- a/src/game/client/swarm/c_asw_campaign_save.cpp
+++ b/src/game/client/swarm/c_asw_campaign_save.cpp
@@ -78,12 +78,20 @@ bool GetFileFromRemoteStorage( ISteamRemoteStorage *pRemoteStorage, const char *
 	bool bSuccess = false;
 
 	// check if file exists in Steam Cloud first
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	int32 nFileSize = pRemoteStorage->GetFileSize( pszRemoteFileName );
+#else
+	int32 nFileSize = pRemoteStorage->GetFileSize( pszRemoteFileName );
+#endif
 
 	if ( nFileSize > 0 )
 	{
 		CUtlMemory<char> buf( 0, nFileSize );
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pRemoteStorage->FileRead( pszRemoteFileName, buf.Base(), nFileSize ) == nFileSize )
+	#else
+		if ( pRemoteStorage->FileRead( pszRemoteFileName, buf.Base(), nFileSize ) == nFileSize )
+	#endif
 		{
 			FileHandle_t hFile = g_pFullFileSystem->Open( pszLocalFileName, "wb", "MOD" );
 			if( hFile )
@@ -123,7 +131,11 @@ bool WriteFileToRemoteStorage( ISteamRemoteStorage *pRemoteStorage, const char *
 			byte *pBuffer = (byte*) malloc( unSize );
 			if ( g_pFullFileSystem->Read( pBuffer, unSize, hFile ) == (int) unSize )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				bSuccess = pRemoteStorage->FileWrite( pszRemoteFileName, pBuffer, unSize );
+#else
+				bSuccess = pRemoteStorage->FileWrite( pszRemoteFileName, pBuffer, unSize );
+#endif
 			}
 			free( pBuffer );
 			g_pFullFileSystem->Close( hFile );

--- a/src/game/client/swarm/c_asw_concommands.cpp
+++ b/src/game/client/swarm/c_asw_concommands.cpp
@@ -811,11 +811,23 @@ ConCommand asw_debug_spectator( "asw_debug_spectator", asw_debug_spectator_f, "P
 // TODO: Remove this before ship?
 void reset_steam_stats_f()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamUserStats() );
+#else
+	Assert( SteamUserStats() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUserStats() )
+#else
+	if ( !SteamUserStats() )
+#endif
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUserStats()->ResetAllStats( false );
+#else
+	SteamUserStats()->ResetAllStats( false );
+#endif
 
 	C_ASW_Player *pPlayer = C_ASW_Player::GetLocalASWPlayer();
 	if ( pPlayer )
@@ -829,8 +841,16 @@ void rd_reset_level_and_promotion_f()
 {
 	Msg( "Resetting your level and promotion...\n" );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamUserStats() );
+#else
+	Assert( SteamUserStats() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUserStats() )
+#else
+	if ( !SteamUserStats() )
+#endif
 	{
 		Msg( "Error. Cannot access SteamUserStats()\n" );
 		return;
@@ -838,11 +858,31 @@ void rd_reset_level_and_promotion_f()
 
 	int32 m_iExperience = 0, m_iPromotion = 0;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUserStats()->SetStat( "experience", m_iExperience );
+#else
+	SteamUserStats()->SetStat( "experience", m_iExperience );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUserStats()->SetStat( "promotion", m_iPromotion );
+#else
+	SteamUserStats()->SetStat( "promotion", m_iPromotion );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUserStats()->SetStat( "level", 1 );
+#else
+	SteamUserStats()->SetStat( "level", 1 );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUserStats()->SetStat( "level.xprequired", 0 );
+#else
+	SteamUserStats()->SetStat( "level.xprequired", 0 );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUserStats()->StoreStats();
+#else
+	SteamUserStats()->StoreStats();
+#endif
 
 	C_ASW_Medal_Store *pStore = GetMedalStore();
 

--- a/src/game/client/swarm/c_asw_player.cpp
+++ b/src/game/client/swarm/c_asw_player.cpp
@@ -2992,7 +2992,11 @@ CSteamID C_ASW_Player::GetSteamID()
 	{
 		if ( pi.friendsID )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+#else
+			CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+#endif
 			return steamIDForPlayer;
 		}
 	}

--- a/src/game/client/swarm/c_asw_player.h
+++ b/src/game/client/swarm/c_asw_player.h
@@ -355,8 +355,16 @@ public:
 	CUtlVector<int> m_aNonLocalPlayerAchievementsEarned;	// list of achievements earned by this non-local player
 
 #if !defined(NO_STEAM)
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( C_ASW_Player, Steam_OnUserStatsReceived, UserStatsReceived_t );
+#else
+	STEAM_CALLBACK( C_ASW_Player, Steam_OnUserStatsReceived, UserStatsReceived_t );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( C_ASW_Player, Steam_OnUserStatsStored, UserStatsStored_t );
+#else
+	STEAM_CALLBACK( C_ASW_Player, Steam_OnUserStatsStored, UserStatsStored_t );
+#endif
 #endif
 
 	int m_iChallengeScratch;

--- a/src/game/client/swarm/c_asw_steamstats.cpp
+++ b/src/game/client/swarm/c_asw_steamstats.cpp
@@ -35,9 +35,17 @@ static void ValidateRDRepresentedCountry( IConVar *var, const char *pOldValue, f
 	switch ( V_strlen( ref.GetString() ) )
 	{
 	case 0:
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUtils() )
+		#else
+		if ( SteamUtils() )
+		#endif
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			const char *szCountry = SteamUtils()->GetIPCountry();
+#else
+			const char *szCountry = SteamUtils()->GetIPCountry();
+#endif
 			if ( V_strlen( szCountry ) == 2 )
 			{
 				ref.SetValue( szCountry );
@@ -58,6 +66,7 @@ ConVar rd_represented_country( "rd_represented_country", "", FCVAR_USERINFO, "If
 
 namespace 
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 #define FETCH_STEAM_STATS( apiname, membername ) \
 	{ const char * szApiName = apiname; \
 	if( !SteamUserStats()->GetUserStat( playerSteamID, szApiName, &membername ) ) \
@@ -65,10 +74,25 @@ namespace
 		bOK = false; \
 		DevMsg( "STEAMSTATS: Failed to retrieve stat %s.\n", szApiName ); \
 } }
+#else
+#define FETCH_STEAM_STATS( apiname, membername ) \
+	{ const char * szApiName = apiname; \
+	if( !SteamUserStats()->GetUserStat( playerSteamID, szApiName, &membername ) ) \
+	{ \
+		bOK = false; \
+		DevMsg( "STEAMSTATS: Failed to retrieve stat %s.\n", szApiName ); \
+} }
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 #define SEND_STEAM_STATS( apiname, membername ) \
 	{ const char * szApiName = apiname; \
 	SteamUserStats()->SetStat( szApiName, membername ); }
+#else
+#define SEND_STEAM_STATS( apiname, membername ) \
+	{ const char * szApiName = apiname; \
+	SteamUserStats()->SetStat( szApiName, membername ); }
+#endif
 
 	// Define some strings used by the stats API
 	const char* szGamesTotal = ".games.total";
@@ -539,10 +563,18 @@ static void __MsgFunc_RDAlienKillStat( bf_read &msg )
 	}
 
 	int32_t nCount = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUserStats() && SteamUserStats()->GetStat( szApiName, &nCount ) )
+#else
+	if ( SteamUserStats() && SteamUserStats()->GetStat( szApiName, &nCount ) )
+#endif
 	{
 		RD_Swarmopedia::CheckArticleUnlock( szApiName, nCount, nCount + 1 );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->SetStat( szApiName, nCount + 1 );
+#else
+		SteamUserStats()->SetStat( szApiName, nCount + 1 );
+#endif
 	}
 	else
 	{
@@ -563,9 +595,17 @@ static void __MsgFunc_RDCauseOfDeath( bf_read &msg )
 	const char *szApiName = g_szDeathCauseStatName[iCause];
 
 	int32_t nCount = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUserStats() && SteamUserStats()->GetStat( szApiName, &nCount ) )
+#else
+	if ( SteamUserStats() && SteamUserStats()->GetStat( szApiName, &nCount ) )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->SetStat( szApiName, nCount + 1 );
+#else
+		SteamUserStats()->SetStat( szApiName, nCount + 1 );
+#endif
 	}
 	else
 	{
@@ -790,7 +830,11 @@ bool CASW_Steamstats::FetchStats( CSteamID playerSteamID, CASW_Player *pPlayer )
 
 void CASW_Steamstats::PrepStatsForSend( CASW_Player *pPlayer )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if( !SteamUserStats() )
+#else
+	if( !SteamUserStats() )
+#endif
 		return;
 
 	if ( !GetDebriefStats() || !ASWGameResource() || !ASWGameRules() )
@@ -1047,16 +1091,36 @@ void CASW_Steamstats::PrepStatsForSend( CASW_Player *pPlayer )
 
 	// Check whether this is the first time we've played today.
 	int32_t iLastPlayedDay = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUserStats()->GetStat( "last_played_day", &iLastPlayedDay ) )
+#else
+	if ( SteamUserStats()->GetStat( "last_played_day", &iLastPlayedDay ) )
+#endif
 	{
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		int32_t iToday = SteamUtils()->GetServerRealTime() / 86400u;
+	#else
+		int32_t iToday = SteamUtils()->GetServerRealTime() / 86400u;
+	#endif
 		if ( iLastPlayedDay < iToday )
 		{
 			int32_t iTotalDaysPlayed = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( SteamUserStats()->GetStat( "played_on_days", &iTotalDaysPlayed ) )
+#else
+			if ( SteamUserStats()->GetStat( "played_on_days", &iTotalDaysPlayed ) )
+#endif
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				SteamUserStats()->SetStat( "last_played_day", iToday );
+#else
+				SteamUserStats()->SetStat( "last_played_day", iToday );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				SteamUserStats()->SetStat( "played_on_days", iTotalDaysPlayed + 1 );
+#else
+				SteamUserStats()->SetStat( "played_on_days", iTotalDaysPlayed + 1 );
+#endif
 			}
 		}
 	}
@@ -1065,7 +1129,11 @@ void CASW_Steamstats::PrepStatsForSend( CASW_Player *pPlayer )
 	ReactiveDropInventory::CheckPlaytimeItemGenerators();
 
 	char szBetaBranch[256]{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamInventory() && SteamApps()->GetCurrentBetaName( szBetaBranch, sizeof( szBetaBranch ) ) && !V_stricmp( szBetaBranch, "beta" ) )
+#else
+	if ( SteamInventory() && SteamApps()->GetCurrentBetaName( szBetaBranch, sizeof( szBetaBranch ) ) && !V_stricmp( szBetaBranch, "beta" ) )
+#endif
 	{
 		// beta tester medal
 		ReactiveDropInventory::AddPromoItem( 13 );
@@ -1248,7 +1316,11 @@ bool DifficultyStats_t::FetchDifficultyStats( CSteamID playerSteamID, int iDiffi
 
 void DifficultyStats_t::PrepStatsForSend( CASW_Player *pPlayer )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if( !SteamUserStats() )
+#else
+	if( !SteamUserStats() )
+#endif
 		return;
 
 	// Update stats from the briefing screen
@@ -1532,7 +1604,11 @@ static uint32 GetGameVersion()
 
 void CASW_Steamstats::PrepStatsForSend_Leaderboard( CASW_Player *pPlayer, bool bUnofficial )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUserStats() || ASWDeathmatchMode() || !ASWGameRules() || !ASWGameResource() || !GetDebriefStats() || engine->IsPlayingDemo() || ASWGameRules()->m_bCheated )
+#else
+	if ( !SteamUserStats() || ASWDeathmatchMode() || !ASWGameRules() || !ASWGameResource() || !GetDebriefStats() || engine->IsPlayingDemo() || ASWGameRules()->m_bCheated )
+#endif
 	{
 		return;
 	}
@@ -1671,7 +1747,11 @@ void CASW_Steamstats::PrepStatsForSend_Leaderboard( CASW_Player *pPlayer, bool b
 		m_LeaderboardScoreDetails.m_iSquadSecondaryWeapon[i] = 0;
 		m_LeaderboardScoreDetails.m_iSquadExtraWeapon[i] = 0;
 	}
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_LeaderboardScoreDetails.m_iTimestamp = SteamUtils()->GetServerRealTime();
+	#else
+	m_LeaderboardScoreDetails.m_iTimestamp = SteamUtils()->GetServerRealTime();
+	#endif
 	const char *pszCountry = rd_represented_country.GetString();
 	m_LeaderboardScoreDetails.m_CountryCode[0] = pszCountry[0];
 	m_LeaderboardScoreDetails.m_CountryCode[1] = pszCountry[1];
@@ -1692,7 +1772,11 @@ void CASW_Steamstats::PrepStatsForSend_Leaderboard( CASW_Player *pPlayer, bool b
 
 	if ( IsLBWhitelisted( szLeaderboardName ) )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hAPICall = SteamUserStats()->FindOrCreateLeaderboard( szLeaderboardName, eSortMethod, eDisplayType );
+#else
+		SteamAPICall_t hAPICall = SteamUserStats()->FindOrCreateLeaderboard( szLeaderboardName, eSortMethod, eDisplayType );
+#endif
 		m_LeaderboardFindResultCallback.Set( hAPICall, this, &CASW_Steamstats::LeaderboardFindResultCallback );
 	}
 	else if ( asw_stats_leaderboard_debug.GetBool() )
@@ -1702,7 +1786,11 @@ void CASW_Steamstats::PrepStatsForSend_Leaderboard( CASW_Player *pPlayer, bool b
 
 	if ( IsLBWhitelisted( szDifficultyLeaderboardName ) )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hAPICall = SteamUserStats()->FindOrCreateLeaderboard( szDifficultyLeaderboardName, eSortMethod, eDisplayType );
+#else
+		SteamAPICall_t hAPICall = SteamUserStats()->FindOrCreateLeaderboard( szDifficultyLeaderboardName, eSortMethod, eDisplayType );
+#endif
 		m_LeaderboardDifficultyFindResultCallback.Set( hAPICall, this, &CASW_Steamstats::LeaderboardDifficultyFindResultCallback );
 	}
 	else if ( asw_stats_leaderboard_debug.GetBool() )
@@ -1737,8 +1825,13 @@ void CASW_Steamstats::LeaderboardFindResultCallback( LeaderboardFindResult_t *pR
 		pMissionCompletePanel->OnLeaderboardFound( pResult->m_hSteamLeaderboard );
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = SteamUserStats()->UploadLeaderboardScore( pResult->m_hSteamLeaderboard, k_ELeaderboardUploadScoreMethodKeepBest,
 		m_iLeaderboardScore, reinterpret_cast<const int32 *>( &m_LeaderboardScoreDetails ), sizeof( m_LeaderboardScoreDetails ) / sizeof( int32 ) );
+#else
+	SteamAPICall_t hAPICall = SteamUserStats()->UploadLeaderboardScore( pResult->m_hSteamLeaderboard, k_ELeaderboardUploadScoreMethodKeepBest,
+		m_iLeaderboardScore, reinterpret_cast<const int32 *>( &m_LeaderboardScoreDetails ), sizeof( m_LeaderboardScoreDetails ) / sizeof( int32 ) );
+#endif
 	m_LeaderboardScoreUploadedCallback.Set( hAPICall, this, &CASW_Steamstats::LeaderboardScoreUploadedCallback );
 }
 
@@ -1758,8 +1851,13 @@ void CASW_Steamstats::LeaderboardDifficultyFindResultCallback( LeaderboardFindRe
 		DevMsg( "Sending leaderboard entry to (difficulty) leaderboard ID: %llu\n", pResult->m_hSteamLeaderboard );
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = SteamUserStats()->UploadLeaderboardScore( pResult->m_hSteamLeaderboard, k_ELeaderboardUploadScoreMethodKeepBest,
 		m_iLeaderboardScore, reinterpret_cast<const int32 *>( &m_LeaderboardScoreDetails ), sizeof( m_LeaderboardScoreDetails ) / sizeof( int32 ) );
+#else
+	SteamAPICall_t hAPICall = SteamUserStats()->UploadLeaderboardScore( pResult->m_hSteamLeaderboard, k_ELeaderboardUploadScoreMethodKeepBest,
+		m_iLeaderboardScore, reinterpret_cast<const int32 *>( &m_LeaderboardScoreDetails ), sizeof( m_LeaderboardScoreDetails ) / sizeof( int32 ) );
+#endif
 	m_LeaderboardDifficultyScoreUploadedCallback.Set( hAPICall, this, &CASW_Steamstats::LeaderboardDifficultyScoreUploadedCallback );
 }
 
@@ -1782,7 +1880,11 @@ void CASW_Steamstats::LeaderboardScoreUploadedCallback( LeaderboardScoreUploaded
 	if ( pMissionCompletePanel && pResult->m_bScoreChanged )
 	{
 		RD_LeaderboardEntry_t entry;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		entry.entry.m_steamIDUser = SteamUser()->GetSteamID();
+#else
+		entry.entry.m_steamIDUser = SteamUser()->GetSteamID();
+#endif
 		entry.entry.m_nGlobalRank = pResult->m_nGlobalRankNew;
 		entry.entry.m_nScore = pResult->m_nScore;
 		entry.entry.m_cDetails = sizeof( LeaderboardScoreDetails_v2_t ) / sizeof( int32 );
@@ -1883,7 +1985,11 @@ void CASW_Steamstats::ReadDownloadedLeaderboard( CUtlVector<RD_LeaderboardEntry_
 
 	for ( int i = 0; i < nCount; i++ )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->GetDownloadedLeaderboardEntry( hEntries, i, &entries[i].entry, reinterpret_cast<int32 *>( &entries[i].details ), sizeof( entries[i].details ) / sizeof( int32 ) );
+#else
+		SteamUserStats()->GetDownloadedLeaderboardEntry( hEntries, i, &entries[i].entry, reinterpret_cast<int32 *>( &entries[i].details ), sizeof( entries[i].details ) / sizeof( int32 ) );
+#endif
 	}
 }
 
@@ -1899,19 +2005,39 @@ void CASW_Steamstats::ReadDownloadedLeaderboard( CUtlVector<RD_LeaderboardEntry_
 
 bool CASW_Steamstats::AreGlobalStatsReady()
 {
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUtils *pUtils = SteamUtils();
+	#else
+	ISteamUtils *pUtils = SteamUtils();
+	#endif
 	Assert( pUtils );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUserStats *pUserStats = SteamUserStats();
+#else
+	ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 	Assert( pUserStats );
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !m_GlobalStatsReceivedCallback.IsActive() && pUtils && pUserStats && pUtils->GetServerRealTime() >= m_iNextGlobalStatsRefresh )
+	#else
+	if ( !m_GlobalStatsReceivedCallback.IsActive() && pUtils && pUserStats && pUtils->GetServerRealTime() >= m_iNextGlobalStatsRefresh )
+	#endif
 	{
 		// main menu ticker feed requires 60 days, so no point in requesting a variable amount
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hCall = pUserStats->RequestGlobalStats( 60 );
+#else
+		SteamAPICall_t hCall = pUserStats->RequestGlobalStats( 60 );
+#endif
 		m_GlobalStatsReceivedCallback.Set( hCall, this, &CASW_Steamstats::GlobalStatsReceivedCallback );
 		// if our request fails for some reason, don't request again for 15 minutes
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_iNextGlobalStatsRefresh = pUtils->GetServerRealTime() + 900;
+	#else
+		m_iNextGlobalStatsRefresh = pUtils->GetServerRealTime() + 900;
+	#endif
 	}
 
 	return m_iGlobalStatsReceived != 0;
@@ -2083,7 +2209,11 @@ void CASW_Steamstats::GlobalStatsReceivedCallback( GlobalStatsReceived_t *pResul
 	if ( !bIOFailure && pResult->m_eResult == k_EResultOK )
 	{
 		// if we successfully retrieve stats, allow refreshing after a minute.
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_iNextGlobalStatsRefresh = SteamUtils()->GetServerRealTime() + 60;
+	#else
+		m_iNextGlobalStatsRefresh = SteamUtils()->GetServerRealTime() + 60;
+	#endif
 		m_iGlobalStatsReceived++;
 	}
 	else

--- a/src/game/client/swarm/c_asw_steamstats.h
+++ b/src/game/client/swarm/c_asw_steamstats.h
@@ -253,19 +253,39 @@ private:
 	float GetFavoriteMarineClassPercent( void );
 	float GetFavoriteDifficultyPercent( void );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CASW_Steamstats, LeaderboardFindResult_t> m_LeaderboardFindResultCallback;
+#else
+	CCallResult<CASW_Steamstats, LeaderboardFindResult_t> m_LeaderboardFindResultCallback;
+#endif
 	void LeaderboardFindResultCallback( LeaderboardFindResult_t *pResult, bool bIOFailure );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CASW_Steamstats, LeaderboardFindResult_t> m_LeaderboardDifficultyFindResultCallback;
+#else
+	CCallResult<CASW_Steamstats, LeaderboardFindResult_t> m_LeaderboardDifficultyFindResultCallback;
+#endif
 	void LeaderboardDifficultyFindResultCallback( LeaderboardFindResult_t *pResult, bool bIOFailure );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CASW_Steamstats, LeaderboardScoreUploaded_t> m_LeaderboardScoreUploadedCallback;
+#else
+	CCallResult<CASW_Steamstats, LeaderboardScoreUploaded_t> m_LeaderboardScoreUploadedCallback;
+#endif
 	void LeaderboardScoreUploadedCallback( LeaderboardScoreUploaded_t *pResult, bool bIOFailure );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CASW_Steamstats, LeaderboardScoreUploaded_t> m_LeaderboardDifficultyScoreUploadedCallback;
+#else
+	CCallResult<CASW_Steamstats, LeaderboardScoreUploaded_t> m_LeaderboardDifficultyScoreUploadedCallback;
+#endif
 	void LeaderboardDifficultyScoreUploadedCallback( LeaderboardScoreUploaded_t *pResult, bool bIOFailure );
 
 	int32 m_iLeaderboardScore;
 	LeaderboardScoreDetails_v2_t m_LeaderboardScoreDetails;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CASW_Steamstats, GlobalStatsReceived_t> m_GlobalStatsReceivedCallback;
+#else
+	CCallResult<CASW_Steamstats, GlobalStatsReceived_t> m_GlobalStatsReceivedCallback;
+#endif
 	void GlobalStatsReceivedCallback( GlobalStatsReceived_t *pResult, bool bIOFailure );
 	RTime32 m_iNextGlobalStatsRefresh{};
 	int m_iGlobalStatsReceived{};

--- a/src/game/client/swarm/c_asw_weapon.cpp
+++ b/src/game/client/swarm/c_asw_weapon.cpp
@@ -774,10 +774,18 @@ bool C_ASW_Weapon::GetUseAction( ASWUseAction &action, C_ASW_Inhabitable_NPC *pU
 		wchar_t wszWeaponShortName[128];
 		TryLocalize( pItem->m_szShortName, wszWeaponShortName, sizeof( wszWeaponShortName ) );
 		wchar_t wszWeaponName[128];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( IsInventoryEquipSlotValid() && SteamFriends() )
+#else
+		if ( IsInventoryEquipSlotValid() && SteamFriends() )
+#endif
 		{
 			wchar_t wszPlayerName[128];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			V_UTF8ToUnicode( SteamFriends()->GetFriendPersonaName( m_hOriginalOwnerMR->m_OriginalCommander->GetSteamID() ), wszPlayerName, sizeof( wszPlayerName ) );
+#else
+			V_UTF8ToUnicode( SteamFriends()->GetFriendPersonaName( m_hOriginalOwnerMR->m_OriginalCommander->GetSteamID() ), wszPlayerName, sizeof( wszPlayerName ) );
+#endif
 			g_pVGuiLocalize->ConstructString( wszWeaponName, sizeof( wszWeaponName ), g_pVGuiLocalize->Find( "#asw_owned_weapon_format" ), 2, wszPlayerName, wszWeaponShortName );
 		}
 		else

--- a/src/game/client/swarm/c_rd_infection_deathmatch_stats.cpp
+++ b/src/game/client/swarm/c_rd_infection_deathmatch_stats.cpp
@@ -36,13 +36,17 @@ void CRD_Infection_Deathmatch_Stats::OnUpdate( C_RD_HUD_VScript *pHUD )
 	if ( !pLocalPlayer || pHUD->m_hDataEntity.Get() != pLocalPlayer )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !m_bStatsRequested && SteamUserStats() )
+#else
+	if ( !m_bStatsRequested && SteamUserStats() )
+#endif
 	{
 		// Valve:
 		// This call is no longer required as it is managed by the Steam client. The game stats and achievements
 		// will be synchronized with Steam before the game process begins.
 		// [Obsolete("No longer required. Automatically handled by the Steam client.", false)]
-#if defined(STEAMAPPS_INTERFACE_VERSION008)
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->RequestCurrentStats();
 #else
 		SteamUserStats()->RequestUserStats(SteamUser()->GetSteamID());
@@ -128,10 +132,15 @@ void CRD_Infection_Deathmatch_Stats::OnUpdate( C_RD_HUD_VScript *pHUD )
 				ReactiveDropInventory::CommitDynamicProperties();
 
 				// store any pending stats before we clear them
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				ISteamUserStats *pUserStats = SteamUserStats();
+#else
+				ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 				if ( pUserStats && m_bStatsLoaded )
 				{
 					bool bAnyStatChanged = false;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 #define SAVE_PER_PLAYER_TYPE_STAT( statname, playertypename, statvar, playertypeid ) \
 					if ( statvar##Pending[playertypeid - 1] != 0 ) \
 					{ \
@@ -139,6 +148,15 @@ void CRD_Infection_Deathmatch_Stats::OnUpdate( C_RD_HUD_VScript *pHUD )
 						pUserStats->SetStat( "infectiondm." statname "." playertypename, statvar##Saved[playertypeid - 1] ); \
 						bAnyStatChanged = true; \
 					}
+#else
+#define SAVE_PER_PLAYER_TYPE_STAT( statname, playertypename, statvar, playertypeid ) \
+					if ( statvar##Pending[playertypeid - 1] != 0 ) \
+					{ \
+						statvar##Saved[playertypeid - 1] += statvar##Pending[playertypeid - 1]; \
+						pUserStats->SetStat( "infectiondm." statname "." playertypename, statvar##Saved[playertypeid - 1] ); \
+						bAnyStatChanged = true; \
+					}
+#endif
 #define SAVE_PER_PLAYER_TYPE_STATS( statname, statvar ) \
 					SAVE_PER_PLAYER_TYPE_STAT( statname, "prime", statvar, IPT_ZOMBIE_PRIME ) \
 					SAVE_PER_PLAYER_TYPE_STAT( statname, "zombie", statvar, IPT_ZOMBIE_CONVERTED ) \
@@ -152,7 +170,11 @@ void CRD_Infection_Deathmatch_Stats::OnUpdate( C_RD_HUD_VScript *pHUD )
 
 					if ( bAnyStatChanged )
 					{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 						pUserStats->StoreStats();
+#else
+						pUserStats->StoreStats();
+#endif
 					}
 				}
 			}
@@ -229,16 +251,37 @@ void CRD_Infection_Deathmatch_Stats::OnUpdate( C_RD_HUD_VScript *pHUD )
 
 void CRD_Infection_Deathmatch_Stats::OnStatsLoaded( UserStatsReceived_t *pParam )
 {
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( pParam->m_nGameID == SteamUtils()->GetAppID() );
+	#else
+	Assert( pParam->m_nGameID == SteamUtils()->GetAppID() );
+	#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( pParam->m_nGameID == SteamUtils()->GetAppID() && pParam->m_steamIDUser == SteamUser()->GetSteamID() && pParam->m_eResult == k_EResultOK )
+#else
+	if ( pParam->m_nGameID == SteamUtils()->GetAppID() && pParam->m_steamIDUser == SteamUser()->GetSteamID() && pParam->m_eResult == k_EResultOK )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUserStats *pUserStats = SteamUserStats();
+#else
+		ISteamUserStats *pUserStats = SteamUserStats();
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 #define INIT_PER_PLAYER_TYPE_STAT( statname, playertypename, statvar, playertypeid ) \
 		if ( !pUserStats->GetStat( "infectiondm." statname "." playertypename, &statvar##Saved[playertypeid - 1] ) ) \
 		{ \
 			Warning( "Failed to load Steam user stat infectiondm." statname "." playertypename "; setting to 0\n" ); \
 			statvar##Saved[playertypeid - 1] = 0; \
 		}
+#else
+#define INIT_PER_PLAYER_TYPE_STAT( statname, playertypename, statvar, playertypeid ) \
+		if ( !pUserStats->GetStat( "infectiondm." statname "." playertypename, &statvar##Saved[playertypeid - 1] ) ) \
+		{ \
+			Warning( "Failed to load Steam user stat infectiondm." statname "." playertypename "; setting to 0\n" ); \
+			statvar##Saved[playertypeid - 1] = 0; \
+		}
+#endif
 #define INIT_PER_PLAYER_TYPE_STATS( statname, statvar ) \
 		INIT_PER_PLAYER_TYPE_STAT( statname, "prime", statvar, IPT_ZOMBIE_PRIME ) \
 		INIT_PER_PLAYER_TYPE_STAT( statname, "zombie", statvar, IPT_ZOMBIE_CONVERTED ) \

--- a/src/game/client/swarm/c_rd_infection_deathmatch_stats.h
+++ b/src/game/client/swarm/c_rd_infection_deathmatch_stats.h
@@ -10,7 +10,11 @@ public:
 	CRD_Infection_Deathmatch_Stats() {}
 
 	void OnUpdate( C_RD_HUD_VScript *pHUD );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Infection_Deathmatch_Stats, OnStatsLoaded, UserStatsReceived_t );
+#else
+	STEAM_CALLBACK( CRD_Infection_Deathmatch_Stats, OnStatsLoaded, UserStatsReceived_t );
+#endif
 
 	static bool ShouldInit( C_RD_HUD_VScript *pHUD );
 

--- a/src/game/client/swarm/gameui/optionssubaudio.cpp
+++ b/src/game/client/swarm/gameui/optionssubaudio.cpp
@@ -148,11 +148,19 @@ void COptionsSubAudio::OnResetData()
    // In a Steam environment we get the current language 
 #if !defined( NO_STEAM )
    // When Steam isn't running we can't get the language info... 
+   #if defined( STEAMAPPS_INTERFACE_VERSION008 )
    if ( SteamApps() )
    {
       Q_strncpy( szCurrentLanguage, SteamApps()->GetCurrentGameLanguage(), sizeof(szCurrentLanguage) );
 	  Q_strncpy( szAvailableLanguages, SteamApps()->GetAvailableGameLanguages(), sizeof(szAvailableLanguages) );
    }
+   #else
+   if ( SteamApps() )
+   {
+      Q_strncpy( szCurrentLanguage, SteamApps()->GetCurrentGameLanguage(), sizeof(szCurrentLanguage) );
+	  Q_strncpy( szAvailableLanguages, SteamApps()->GetAvailableGameLanguages(), sizeof(szAvailableLanguages) );
+   }
+   #endif
 #endif
 
    // Get the spoken language and store it for comparison purposes

--- a/src/game/client/swarm/gameui/swarm/basemodframe.cpp
+++ b/src/game/client/swarm/gameui/swarm/basemodframe.cpp
@@ -806,6 +806,7 @@ bool CBaseModFrame::CheckAndDisplayErrorIfNotLoggedIn()
 #ifndef NO_STEAM
 #ifndef SWDS
 	// if we have Steam interfaces and user is logged on, everything is OK
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUser() && SteamMatchmaking() )
 	{
 		/*
@@ -818,6 +819,20 @@ bool CBaseModFrame::CheckAndDisplayErrorIfNotLoggedIn()
 
 		return false;
 	}
+#else
+	if ( SteamUser() && SteamMatchmaking() )
+	{
+		/*
+		// Try starting to log on
+		if ( !SteamUser()->BLoggedOn() )
+		{
+		SteamUser()->LogOn();
+		}
+		*/
+
+		return false;
+	}
+#endif
 	
 #endif
 #endif

--- a/src/game/client/swarm/gameui/swarm/basemodpanel.cpp
+++ b/src/game/client/swarm/gameui/swarm/basemodpanel.cpp
@@ -150,9 +150,17 @@ CBaseModPanel::CBaseModPanel(): BaseClass(0, "CBaseModPanel"),
 {
 #if !defined( _X360 ) && !defined( NOSTEAM )
 	// Set Steam overlay position
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUtils() )
+	#else
+	if ( SteamUtils() )
+	#endif
 	{
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUtils()->SetOverlayNotificationPosition( k_EPositionTopRight );
+	#else
+		SteamUtils()->SetOverlayNotificationPosition( k_EPositionTopRight );
+	#endif
 	}
 #endif
 

--- a/src/game/client/swarm/gameui/swarm/rd_challenge_selection.cpp
+++ b/src/game/client/swarm/gameui/swarm/rd_challenge_selection.cpp
@@ -225,7 +225,11 @@ void BaseModUI::ReactiveDropChallengeSelectionListItem::PopulateChallenge( const
 		m_imgIcon->SetVisible( false );
 	}
 	m_szChallengeDescription = pKV->GetString( "description", item.details.m_rgchDescription[0] ? item.details.m_rgchDescription : "#rd_challenge_selection_no_description" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_szChallengeAuthor = pKV->GetString( "author", item.details.m_ulSteamIDOwner ? SteamFriends()->GetFriendPersonaName( item.details.m_ulSteamIDOwner ) : "" );
+#else
+	m_szChallengeAuthor = pKV->GetString( "author", item.details.m_ulSteamIDOwner ? SteamFriends()->GetFriendPersonaName( item.details.m_ulSteamIDOwner ) : "" );
+#endif
 
 	if ( m_nWorkshopID == k_PublishedFileIdInvalid )
 	{
@@ -461,7 +465,11 @@ void BaseModUI::ReactiveDropChallengeSelection::SetDetailsForChallenge( Reactive
 	const CReactiveDropWorkshop::WorkshopItem_t &item = pChallenge->GetWorkshopItem();
 	if ( item.details.m_nPublishedFileId )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		const char *szName = SteamFriends()->GetFriendPersonaName( item.details.m_ulSteamIDOwner );
+#else
+		const char *szName = SteamFriends()->GetFriendPersonaName( item.details.m_ulSteamIDOwner );
+#endif
 		wchar_t wszAuthorName[k_cwchPersonaNameMax];
 		Q_UTF8ToUnicode( szName, wszAuthorName, sizeof( wszAuthorName ) );
 

--- a/src/game/client/swarm/gameui/swarm/rd_workshop_frame.cpp
+++ b/src/game/client/swarm/gameui/swarm/rd_workshop_frame.cpp
@@ -270,7 +270,11 @@ void ReactiveDropWorkshop::OnCommand( const char *command )
 		if ( rd_workshop_allow_item_creation.GetBool() )
 		{
 			CUIGameData::Get()->OpenWaitScreen( "#rd_workshop_creating_item", 0 );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamAPICall_t hAPICall = SteamUGC()->CreateItem( SteamUtils()->GetAppID(), k_EWorkshopFileTypeCommunity );
+#else
+			SteamAPICall_t hAPICall = SteamUGC()->CreateItem( SteamUtils()->GetAppID(), k_EWorkshopFileTypeCommunity );
+#endif
 			m_CreateItemCall.Set( hAPICall, this, &ReactiveDropWorkshop::CreateItemCall );
 		}
 		else
@@ -331,11 +335,19 @@ void ReactiveDropWorkshop::OnCommand( const char *command )
 	}
 	else if ( !V_strcmp( command, "SubmitEdit" ) )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hUpdate = SteamUGC()->StartItemUpdate( SteamUtils()->GetAppID(), m_nEditingWorkshopID );
+#else
+		m_hUpdate = SteamUGC()->StartItemUpdate( SteamUtils()->GetAppID(), m_nEditingWorkshopID );
+#endif
 
 		if ( !m_szPreviewImage.IsEmpty() )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( !SteamUGC()->SetItemPreview( m_hUpdate, m_szPreviewImage ) )
+#else
+			if ( !SteamUGC()->SetItemPreview( m_hUpdate, m_szPreviewImage ) )
+#endif
 			{
 				CUIGameData::Get()->DisplayOkOnlyMsgBox( this, "#rd_workshop_error_title", "#rd_workshop_error_update_preview" );
 				return;
@@ -344,7 +356,11 @@ void ReactiveDropWorkshop::OnCommand( const char *command )
 
 		if ( !g_ReactiveDropWorkshop.m_szContentPath.IsEmpty() )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( !SteamUGC()->SetItemContent( m_hUpdate, g_ReactiveDropWorkshop.m_szContentPath ) )
+#else
+			if ( !SteamUGC()->SetItemContent( m_hUpdate, g_ReactiveDropWorkshop.m_szContentPath ) )
+#endif
 			{
 				CUIGameData::Get()->DisplayOkOnlyMsgBox( this, "#rd_workshop_error_title", "#rd_workshop_error_update_content" );
 				return;
@@ -386,7 +402,11 @@ void ReactiveDropWorkshop::OnCommand( const char *command )
 		SteamParamStringArray_t tags;
 		tags.m_nNumStrings = g_ReactiveDropWorkshop.m_aszTags.Count();
 		tags.m_ppStrings = const_cast<const char **>( g_ReactiveDropWorkshop.m_aszTags.Base() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamUGC()->SetItemTags( m_hUpdate, &tags ) )
+#else
+		if ( !SteamUGC()->SetItemTags( m_hUpdate, &tags ) )
+#endif
 		{
 			CUIGameData::Get()->DisplayOkOnlyMsgBox( this, "#rd_workshop_error_title", "#rd_workshop_error_update_tags" );
 			return;
@@ -398,7 +418,11 @@ void ReactiveDropWorkshop::OnCommand( const char *command )
 		{
 			V_strncpy( szTitle, "Untitled Addon", sizeof(szTitle) );
 		}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamUGC()->SetItemTitle( m_hUpdate, szTitle ) )
+#else
+		if ( !SteamUGC()->SetItemTitle( m_hUpdate, szTitle ) )
+#endif
 		{
 			CUIGameData::Get()->DisplayOkOnlyMsgBox( this, "#rd_workshop_error_title", "#rd_workshop_error_update_title" );
 			return;
@@ -406,7 +430,11 @@ void ReactiveDropWorkshop::OnCommand( const char *command )
 
 		char szDescription[k_cchPublishedDocumentDescriptionMax];
 		m_pTxtEditingDescription->GetText( szDescription, sizeof( szDescription ) );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamUGC()->SetItemDescription( m_hUpdate, szDescription ) )
+#else
+		if ( !SteamUGC()->SetItemDescription( m_hUpdate, szDescription ) )
+#endif
 		{
 			CUIGameData::Get()->DisplayOkOnlyMsgBox( this, "#rd_workshop_error_title", "#rd_workshop_error_update_description" );
 			return;
@@ -417,7 +445,11 @@ void ReactiveDropWorkshop::OnCommand( const char *command )
 
 		char szChangeDescription[k_cchPublishedDocumentChangeDescriptionMax];
 		m_pTxtEditingChangeDescription->GetText( szChangeDescription, sizeof( szChangeDescription ) );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hAPICall = SteamUGC()->SubmitItemUpdate( m_hUpdate, szChangeDescription );
+#else
+		SteamAPICall_t hAPICall = SteamUGC()->SubmitItemUpdate( m_hUpdate, szChangeDescription );
+#endif
 		m_SubmitItemUpdateCall.Set( hAPICall, this, &ReactiveDropWorkshop::SubmitItemUpdateCall );
 
 		InitWait();
@@ -455,7 +487,11 @@ void ReactiveDropWorkshop::OnThink()
 	if ( m_SubmitItemUpdateCall.IsActive() )
 	{
 		uint64 nBytesProcessed, nBytesTotal;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		EItemUpdateStatus status = SteamUGC()->GetItemUpdateProgress( m_hUpdate, &nBytesProcessed, &nBytesTotal );
+#else
+		EItemUpdateStatus status = SteamUGC()->GetItemUpdateProgress( m_hUpdate, &nBytesProcessed, &nBytesTotal );
+#endif
 
 		switch ( status )
 		{
@@ -621,7 +657,11 @@ void ReactiveDropWorkshop::InitReady()
 
 	PublishedFileId_t nDummyItem = k_PublishedFileIdInvalid;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CSteamID currentUser = SteamUser()->GetSteamID();
+#else
+	CSteamID currentUser = SteamUser()->GetSteamID();
+#endif
 	FOR_EACH_VEC( g_ReactiveDropWorkshop.m_EnabledAddons, i )
 	{
 		if ( currentUser == g_ReactiveDropWorkshop.m_EnabledAddons[i].details.m_ulSteamIDOwner )
@@ -756,10 +796,26 @@ void ReactiveDropWorkshop::RequestSingleItem( PublishedFileId_t nPublishedFileID
 
 	CUIGameData::Get()->OpenWaitScreen( "#rd_workshop_retrieving_item_details", 0 );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_hSingleItemQuery = SteamUGC()->CreateQueryUGCDetailsRequest( &nPublishedFileID, 1 );
+#else
+	m_hSingleItemQuery = SteamUGC()->CreateQueryUGCDetailsRequest( &nPublishedFileID, 1 );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUGC()->SetReturnLongDescription( m_hSingleItemQuery, true );
+#else
+	SteamUGC()->SetReturnLongDescription( m_hSingleItemQuery, true );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUGC()->SetReturnKeyValueTags( m_hSingleItemQuery, true );
+#else
+	SteamUGC()->SetReturnKeyValueTags( m_hSingleItemQuery, true );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = SteamUGC()->SendQueryUGCRequest( m_hSingleItemQuery );
+#else
+	SteamAPICall_t hAPICall = SteamUGC()->SendQueryUGCRequest( m_hSingleItemQuery );
+#endif
 	m_RequestSingleItemCall.Set( hAPICall, this, &ReactiveDropWorkshop::RequestSingleItemCall );
 }
 
@@ -814,7 +870,11 @@ void ReactiveDropWorkshop::RequestSingleItemCall( SteamUGCQueryCompleted_t *pRes
 	}
 
 	SteamUGCDetails_t details;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUGC()->GetQueryUGCResult( m_hSingleItemQuery, 0, &details );
+#else
+	SteamUGC()->GetQueryUGCResult( m_hSingleItemQuery, 0, &details );
+#endif
 
 	g_ReactiveDropWorkshop.AddAddonsToCache( pResult, bIOFailure, m_hSingleItemQuery );
 

--- a/src/game/client/swarm/gameui/swarm/rd_workshop_frame.h
+++ b/src/game/client/swarm/gameui/swarm/rd_workshop_frame.h
@@ -106,12 +106,24 @@ namespace BaseModUI
 		template<typename Result_t>
 		bool OnAPIResult( const Result_t *pResult, bool bIOFailure, const char *szCallName );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		CCallResult<ReactiveDropWorkshop, SteamUGCQueryCompleted_t> m_RequestSingleItemCall;
+#else
+		CCallResult<ReactiveDropWorkshop, SteamUGCQueryCompleted_t> m_RequestSingleItemCall;
+#endif
 		void RequestSingleItemCall( SteamUGCQueryCompleted_t *pResult, bool bIOFailure );
 		UGCQueryHandle_t m_hSingleItemQuery;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		CCallResult<ReactiveDropWorkshop, CreateItemResult_t> m_CreateItemCall;
+#else
+		CCallResult<ReactiveDropWorkshop, CreateItemResult_t> m_CreateItemCall;
+#endif
 		void CreateItemCall( CreateItemResult_t *pResult, bool bIOFailure );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		CCallResult<ReactiveDropWorkshop, SubmitItemUpdateResult_t> m_SubmitItemUpdateCall;
+#else
+		CCallResult<ReactiveDropWorkshop, SubmitItemUpdateResult_t> m_SubmitItemUpdateCall;
+#endif
 		void SubmitItemUpdateCall( SubmitItemUpdateResult_t *pResult, bool bIOFailure );
 	};
 }

--- a/src/game/client/swarm/gameui/swarm/uiavatarimage.cpp
+++ b/src/game/client/swarm/gameui/swarm/uiavatarimage.cpp
@@ -38,16 +38,28 @@ bool CGameUiAvatarImage::SetAvatarSteamID( CSteamID steamIDUser )
 {
 	ClearAvatarSteamID();
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamFriends() && SteamUtils() )
+#else
+	if ( SteamFriends() && SteamUtils() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		int iAvatar = SteamFriends()->GetMediumFriendAvatar( steamIDUser );
+#else
+		int iAvatar = SteamFriends()->GetMediumFriendAvatar( steamIDUser );
+#endif
 
 		/*
 		// See if it's in our list already
 		*/
 
 		uint32 wide, tall;
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUtils()->GetImageSize( iAvatar, &wide, &tall ) )
+		#else
+		if ( SteamUtils()->GetImageSize( iAvatar, &wide, &tall ) )
+		#endif
 		{
 			bool bUseSteamImage = true;
 			if ( wide == 0 || tall == 0 )
@@ -62,7 +74,11 @@ bool CGameUiAvatarImage::SetAvatarSteamID( CSteamID steamIDUser )
 			byte *rgubDest = (byte*)_alloca( cubImage );
 			if ( bUseSteamImage )
 			{
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				SteamUtils()->GetImageRGBA( iAvatar, rgubDest, cubImage );
+			#else
+				SteamUtils()->GetImageRGBA( iAvatar, rgubDest, cubImage );
+			#endif
 			}
 			else
 			{

--- a/src/game/client/swarm/gameui/swarm/uigamedata.cpp
+++ b/src/game/client/swarm/gameui/swarm/uigamedata.cpp
@@ -156,6 +156,7 @@ static void GoToMarketplaceForOffer()
 #endif
 }
 
+
 static void ShowMarketplaceUiForOffer()
 {
 #ifdef _X360
@@ -427,9 +428,17 @@ void CUIGameData::OpenInviteUI( char const *szInviteUiType )
 		Assert( 0 );
 	}
 #else
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamFriends() && SteamUtils() && SteamUtils()->IsOverlayEnabled() )
+#else
+	if ( SteamFriends() && SteamUtils() && SteamUtils()->IsOverlayEnabled() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamFriends()->ActivateGameOverlayInviteDialog( UTIL_RD_GetCurrentLobbyID() );
+#else
+		SteamFriends()->ActivateGameOverlayInviteDialog( UTIL_RD_GetCurrentLobbyID() );
+#endif
 	}
 	else
 	{
@@ -441,8 +450,18 @@ void CUIGameData::OpenInviteUI( char const *szInviteUiType )
 void CUIGameData::ExecuteOverlayCommand( char const *szCommand )
 {
 	CSteamID steamID;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUser() )
+#else
+	if ( SteamUser() )
+#endif
+	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		steamID = SteamUser()->GetSteamID();
+#else
+		steamID = SteamUser()->GetSteamID();
+#endif
+	}
 
 	ExecuteOverlayCommand( szCommand, steamID );
 }
@@ -450,9 +469,17 @@ void CUIGameData::ExecuteOverlayCommand( char const *szCommand )
 void CUIGameData::ExecuteOverlayCommand( char const *szCommand, CSteamID steamID )
 {
 #if !defined( _X360 ) && !defined( NO_STEAM )
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamFriends() && SteamUtils() && SteamUtils()->IsOverlayEnabled() )
+#else
+	if ( SteamFriends() && SteamUtils() && SteamUtils()->IsOverlayEnabled() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamFriends()->ActivateGameOverlayToUser( szCommand, steamID );
+#else
+		SteamFriends()->ActivateGameOverlayToUser( szCommand, steamID );
+#endif
 	}
 	else
 	{
@@ -467,9 +494,17 @@ void CUIGameData::ExecuteOverlayCommand( char const *szCommand, CSteamID steamID
 void CUIGameData::ExecuteOverlayUrl( char const *szUrl, bool bModal, bool bOpenInBrowserIfOverlayDisabled )
 {
 #if !defined( _X360 ) && !defined( NO_STEAM )
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamFriends() && SteamUtils() && SteamUtils()->IsOverlayEnabled() )
+#else
+	if ( SteamFriends() && SteamUtils() && SteamUtils()->IsOverlayEnabled() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamFriends()->ActivateGameOverlayToWebPage( szUrl, bModal ? k_EActivateGameOverlayToWebPageMode_Modal : k_EActivateGameOverlayToWebPageMode_Default );
+#else
+		SteamFriends()->ActivateGameOverlayToWebPage( szUrl, bModal ? k_EActivateGameOverlayToWebPageMode_Modal : k_EActivateGameOverlayToWebPageMode_Default );
+#endif
 	}
 	else if ( bOpenInBrowserIfOverlayDisabled )
 	{
@@ -849,12 +884,20 @@ char const * CUIGameData::GetPlayerName( XUID playerID, char const *szPlayerName
 		return "WWWWWWWWWWWWWWW";
 
 #if !defined( _X360 ) && !defined( NO_STEAM )
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUtils() && SteamFriends() && SteamUser() )
+	#else
+	if ( SteamUtils() && SteamFriends() && SteamUser() )
+	#endif
 	{
 		int iIndex = m_mapUserXuidToName.Find( playerID );
 		if ( iIndex == m_mapUserXuidToName.InvalidIndex() )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			char const *szName = SteamFriends()->GetFriendPersonaName( playerID );
+#else
+			char const *szName = SteamFriends()->GetFriendPersonaName( playerID );
+#endif
 			if ( szName && *szName )
 			{
 				CUtlString szNameFiltered( szName );

--- a/src/game/client/swarm/gameui/swarm/uigamedata.h
+++ b/src/game/client/swarm/gameui/swarm/uigamedata.h
@@ -187,7 +187,11 @@ public:
 	char const * GetPlayerName( XUID playerID, char const *szPlayerNameSpeculative );
 
 #if !defined( _X360 ) && !defined( NO_STEAM )
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CUIGameData, Steam_OnPersonaStateChanged, PersonaStateChange_t );
+#else
+	STEAM_CALLBACK( CUIGameData, Steam_OnPersonaStateChanged, PersonaStateChange_t );
+#endif
 #endif
 
 	void ReloadScheme();

--- a/src/game/client/swarm/gameui/swarm/vaddons.cpp
+++ b/src/game/client/swarm/gameui/swarm/vaddons.cpp
@@ -272,7 +272,11 @@ void AddonListItem::ShowWorkshopStatistic()
 		}
 		case 1:
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			V_UTF8ToUnicode( SteamFriends() ? SteamFriends()->GetFriendPersonaName( item.details.m_ulSteamIDOwner ) : "?", wszParameter1, sizeof( wszParameter1 ) );
+#else
+			V_UTF8ToUnicode( SteamFriends() ? SteamFriends()->GetFriendPersonaName( item.details.m_ulSteamIDOwner ) : "?", wszParameter1, sizeof( wszParameter1 ) );
+#endif
 			pszTranslationKey = "#workshop_stat_author";
 			break;
 		}
@@ -367,11 +371,19 @@ void AddonListItem::Paint()
 		int nPanelWide, nPanelTall;
 		GetSize( nPanelWide, nPanelTall );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		uint32 nState = SteamUGC()->GetItemState( m_nPublishedFileId );
+#else
+		uint32 nState = SteamUGC()->GetItemState( m_nPublishedFileId );
+#endif
 		if ( nState & k_EItemStateDownloading )
 		{
 			uint64 nBytesDownloaded, nBytesTotal;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( SteamUGC()->GetItemDownloadInfo( m_nPublishedFileId, &nBytesDownloaded, &nBytesTotal ) )
+#else
+			if ( SteamUGC()->GetItemDownloadInfo( m_nPublishedFileId, &nBytesDownloaded, &nBytesTotal ) )
+#endif
 			{
 				surface()->DrawSetColor( Color( 169, 213, 255, 128 ) );
 				surface()->DrawFilledRect( 0, 0, 10 + ( nPanelWide - 10 ) * nBytesDownloaded / nBytesTotal, nPanelTall );
@@ -945,7 +957,11 @@ void Addons::SetDetailsUIForWorkshopItem( PublishedFileId_t id )
 void Addons::SetDetailsUIForWorkshopItem( const CReactiveDropWorkshop::WorkshopItem_t &item )
 {
 	wchar_t wsAuthorName[k_cwchPersonaNameMax];
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	V_UTF8ToUnicode( SteamFriends()->GetFriendPersonaName( item.details.m_ulSteamIDOwner ), wsAuthorName, sizeof( wsAuthorName ) );
+	#else
+	V_UTF8ToUnicode( SteamFriends()->GetFriendPersonaName( item.details.m_ulSteamIDOwner ), wsAuthorName, sizeof( wsAuthorName ) );
+	#endif
 
 	wchar_t wsAuthorLabel[130];
 	V_snwprintf( wsAuthorLabel, ARRAYSIZE( wsAuthorLabel ), L"%s%s", g_pVGuiLocalize->Find( "#L4D360UI_Addon_By" ), wsAuthorName );

--- a/src/game/client/swarm/gameui/swarm/vaudio.cpp
+++ b/src/game/client/swarm/gameui/swarm/vaudio.cpp
@@ -238,11 +238,19 @@ void Audio::Activate()
 		// In a Steam environment we get the current language 
 #if !defined( NO_STEAM )
 		// When Steam isn't running we can't get the language info... 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamApps() )
 		{
 			Q_strncpy( szCurrentLanguage, SteamApps()->GetCurrentGameLanguage(), sizeof(szCurrentLanguage) );
 			Q_strncpy( szAvailableLanguages, SteamApps()->GetAvailableGameLanguages(), sizeof(szAvailableLanguages) );
 		}
+		#else
+		if ( SteamApps() )
+		{
+			Q_strncpy( szCurrentLanguage, SteamApps()->GetCurrentGameLanguage(), sizeof(szCurrentLanguage) );
+			Q_strncpy( szAvailableLanguages, SteamApps()->GetAvailableGameLanguages(), sizeof(szAvailableLanguages) );
+		}
+		#endif
 #endif
 
 		// Get the spoken language and store it for comparison purposes

--- a/src/game/client/swarm/gameui/swarm/vcommanderprofile.cpp
+++ b/src/game/client/swarm/gameui/swarm/vcommanderprofile.cpp
@@ -59,12 +59,24 @@ void CommanderProfile::SetDataSettings( KeyValues *pSettings )
 
 void CommanderProfile::InitForLocalPlayer()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamUser() );
+#else
+	Assert( SteamUser() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUser() )
+#else
+	if ( !SteamUser() )
+#endif
 		return;
 
 	m_Mode = MODE_LOCAL_PLAYER;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_SteamID = SteamUser()->GetSteamID();
+#else
+	m_SteamID = SteamUser()->GetSteamID();
+#endif
 
 	C_ASW_Medal_Store *pMedalStore = GetMedalStore();
 	Assert( pMedalStore );
@@ -114,7 +126,11 @@ void CommanderProfile::TempOpenStatsWebsiteAndClose()
 {
 	// TODO FIXME: until the actual page is implemented, open the stats website in the Steam Overlay
 	char szStatsWeb[256];
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	V_snprintf( szStatsWeb, sizeof( szStatsWeb ), "https://stats.reactivedrop.com/profiles/%I64u?lang=%s&utm_source=profilewip", m_SteamID.ConvertToUint64(), SteamApps()->GetCurrentGameLanguage() );
+	#else
+	V_snprintf( szStatsWeb, sizeof( szStatsWeb ), "https://stats.reactivedrop.com/profiles/%I64u?lang=%s&utm_source=profilewip", m_SteamID.ConvertToUint64(), SteamApps()->GetCurrentGameLanguage() );
+	#endif
 	BaseModUI::CUIGameData::Get()->ExecuteOverlayUrl( szStatsWeb );
 
 	m_iTempCloseAfter = 5;
@@ -144,7 +160,11 @@ void CommanderProfile::FetchSteamIDMedalsAndExperience()
 {
 	Assert( m_SteamID.IsValid() && m_SteamID.BIndividualAccount() );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamHTTP *pHTTP = SteamHTTP();
+#else
+	ISteamHTTP *pHTTP = SteamHTTP();
+#endif
 	Assert( pHTTP );
 	if ( !pHTTP )
 	{
@@ -152,14 +172,34 @@ void CommanderProfile::FetchSteamIDMedalsAndExperience()
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_hHTTPRequest = pHTTP->CreateHTTPRequest( k_EHTTPMethodGET, "https://stats.reactivedrop.com/api/get_equipped_medals" );
+#else
+	m_hHTTPRequest = pHTTP->CreateHTTPRequest( k_EHTTPMethodGET, "https://stats.reactivedrop.com/api/get_equipped_medals" );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->SetHTTPRequestGetOrPostParameter( m_hHTTPRequest, "steamid", CFmtStr{ "%llu", m_SteamID.ConvertToUint64() } );
+#else
+	pHTTP->SetHTTPRequestGetOrPostParameter( m_hHTTPRequest, "steamid", CFmtStr{ "%llu", m_SteamID.ConvertToUint64() } );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->SetHTTPRequestUserAgentInfo( m_hHTTPRequest, "CommanderProfileFetch" );
+#else
+	pHTTP->SetHTTPRequestUserAgentInfo( m_hHTTPRequest, "CommanderProfileFetch" );
+#endif
 
 	SteamAPICall_t hCall = k_uAPICallInvalid;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->SendHTTPRequest( m_hHTTPRequest, &hCall );
+#else
+	pHTTP->SendHTTPRequest( m_hHTTPRequest, &hCall );
+#endif
 	// user is looking, so try to be quick
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->PrioritizeHTTPRequest( m_hHTTPRequest );
+#else
+	pHTTP->PrioritizeHTTPRequest( m_hHTTPRequest );
+#endif
 
 	m_SteamIDProfileDataFetched.Set( hCall, this, &CommanderProfile::OnSteamIDProfileDataFetched );
 }
@@ -168,7 +208,11 @@ void CommanderProfile::FetchHoIAFSeasonStats()
 {
 	Assert( m_SteamID.IsValid() && m_SteamID.BIndividualAccount() );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUserStats *pUserStats = SteamUserStats();
+#else
+	ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 	Assert( pUserStats );
 	if ( !pUserStats )
 	{
@@ -176,13 +220,21 @@ void CommanderProfile::FetchHoIAFSeasonStats()
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hCall = pUserStats->DownloadLeaderboardEntriesForUsers( STEAM_LEADERBOARD_HOIAF_CURRENT_SEASON, &m_SteamID, 1 );
+#else
+	SteamAPICall_t hCall = pUserStats->DownloadLeaderboardEntriesForUsers( STEAM_LEADERBOARD_HOIAF_CURRENT_SEASON, &m_SteamID, 1 );
+#endif
 	m_HoIAFSeasonStatsFetched.Set( hCall, this, &CommanderProfile::OnHoIAFSeasonStatsFetched );
 }
 
 void CommanderProfile::OnHoIAFSeasonStatsFetched( LeaderboardScoresDownloaded_t *pParam, bool bIOFailure )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUserStats *pUserStats = SteamUserStats();
+#else
+	ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 	Assert( pUserStats );
 
 	if ( bIOFailure )
@@ -197,7 +249,11 @@ void CommanderProfile::OnHoIAFSeasonStatsFetched( LeaderboardScoresDownloaded_t 
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	bool bOK = pUserStats->GetDownloadedLeaderboardEntry( pParam->m_hSteamLeaderboardEntries, 0, &m_HoIAFLeaderboardEntry, reinterpret_cast< int32 * >( &m_HoIAFDetails ), sizeof( m_HoIAFDetails ) / sizeof( int32 ) );
+#else
+	bool bOK = pUserStats->GetDownloadedLeaderboardEntry( pParam->m_hSteamLeaderboardEntries, 0, &m_HoIAFLeaderboardEntry, reinterpret_cast< int32 * >( &m_HoIAFDetails ), sizeof( m_HoIAFDetails ) / sizeof( int32 ) );
+#endif
 	Assert( bOK ); ( void )bOK;
 	Assert( m_HoIAFLeaderboardEntry.m_cDetails == sizeof( m_HoIAFDetails ) / sizeof( int32 ) );
 
@@ -206,14 +262,22 @@ void CommanderProfile::OnHoIAFSeasonStatsFetched( LeaderboardScoresDownloaded_t 
 
 void CommanderProfile::OnSteamIDProfileDataFetched( HTTPRequestCompleted_t *pParam, bool bIOFailure )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamHTTP *pHTTP = SteamHTTP();
+#else
+	ISteamHTTP *pHTTP = SteamHTTP();
+#endif
 	Assert( pHTTP );
 
 	Assert( bIOFailure || ( pParam && pParam->m_hRequest == m_hHTTPRequest ) );
 	if ( bIOFailure || !pParam->m_bRequestSuccessful )
 	{
 		Assert( !"TODO: failed to send request at all" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pHTTP->ReleaseHTTPRequest( m_hHTTPRequest );
+#else
+		pHTTP->ReleaseHTTPRequest( m_hHTTPRequest );
+#endif
 		m_hHTTPRequest = INVALID_HTTPREQUEST_HANDLE;
 		return;
 	}
@@ -221,19 +285,35 @@ void CommanderProfile::OnSteamIDProfileDataFetched( HTTPRequestCompleted_t *pPar
 	if ( pParam->m_eStatusCode != k_EHTTPStatusCode200OK )
 	{
 		Assert( !"TODO: error returned by server" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pHTTP->ReleaseHTTPRequest( m_hHTTPRequest);
+#else
+		pHTTP->ReleaseHTTPRequest( m_hHTTPRequest);
+#endif
 		m_hHTTPRequest = INVALID_HTTPREQUEST_HANDLE;
 		return;
 	}
 
 	uint32 nDataSize{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->GetHTTPResponseBodySize( m_hHTTPRequest, &nDataSize );
+#else
+	pHTTP->GetHTTPResponseBodySize( m_hHTTPRequest, &nDataSize );
+#endif
 	CUtlBuffer buf;
 	buf.EnsureCapacity( nDataSize );
 	buf.SeekPut( CUtlBuffer::SEEK_HEAD, nDataSize );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->GetHTTPResponseBodyData( m_hHTTPRequest, static_cast< uint8 * >( buf.Base() ), nDataSize );
+#else
+	pHTTP->GetHTTPResponseBodyData( m_hHTTPRequest, static_cast< uint8 * >( buf.Base() ), nDataSize );
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->ReleaseHTTPRequest( m_hHTTPRequest );
+#else
+	pHTTP->ReleaseHTTPRequest( m_hHTTPRequest );
+#endif
 	m_hHTTPRequest = INVALID_HTTPREQUEST_HANDLE;
 
 	KeyValues::AutoDelete pKV{ "EM" };

--- a/src/game/client/swarm/gameui/swarm/vcommanderprofile.h
+++ b/src/game/client/swarm/gameui/swarm/vcommanderprofile.h
@@ -47,11 +47,19 @@ public:
 
 	LeaderboardEntry_t m_HoIAFLeaderboardEntry;
 	LeaderboardScoreDetails_Points_t m_HoIAFDetails;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CommanderProfile, LeaderboardScoresDownloaded_t> m_HoIAFSeasonStatsFetched;
+#else
+	CCallResult<CommanderProfile, LeaderboardScoresDownloaded_t> m_HoIAFSeasonStatsFetched;
+#endif
 	void OnHoIAFSeasonStatsFetched( LeaderboardScoresDownloaded_t *pParam, bool bIOFailure );
 
 	HTTPRequestHandle m_hHTTPRequest{ INVALID_HTTPREQUEST_HANDLE };
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CommanderProfile, HTTPRequestCompleted_t> m_SteamIDProfileDataFetched;
+#else
+	CCallResult<CommanderProfile, HTTPRequestCompleted_t> m_SteamIDProfileDataFetched;
+#endif
 	void OnSteamIDProfileDataFetched( HTTPRequestCompleted_t *pParam, bool bIOFailure );
 };
 

--- a/src/game/client/swarm/gameui/swarm/vfoundgames.cpp
+++ b/src/game/client/swarm/gameui/swarm/vfoundgames.cpp
@@ -386,7 +386,11 @@ bool FoundGameListItem::Info::SetFromFriend( CSteamID friendID, const FriendGame
 	if ( info.m_steamIDLobby.IsLobby() )
 	{
 		// ask for the lobby; maybe we'll have it next time
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamMatchmaking()->RequestLobbyData( info.m_steamIDLobby );
+#else
+		SteamMatchmaking()->RequestLobbyData( info.m_steamIDLobby );
+#endif
 
 		return false;
 	}
@@ -404,12 +408,20 @@ bool FoundGameListItem::Info::SetFromLobby( CSteamID lobby )
 {
 	Assert( lobby.IsLobby() );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamMatchmaking *pMatchmaking = SteamMatchmaking();
+#else
+	ISteamMatchmaking *pMatchmaking = SteamMatchmaking();
+#endif
 	Assert( pMatchmaking );
 	if ( !pMatchmaking )
 		return false;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 #define LOBBY_DATA( key ) pMatchmaking->GetLobbyData( lobby, key )
+#else
+#define LOBBY_DATA( key ) pMatchmaking->GetLobbyData( lobby, key )
+#endif
 
 #ifndef _DEBUG
 	if ( V_strcmp( LOBBY_DATA( "game:dlcrequired" ), "0" ) || V_strcmp( LOBBY_DATA( "game:state" ), "game" ) || V_strcmp( LOBBY_DATA( "system:lock" ), "" ) || V_strcmp( LOBBY_DATA( "system:network" ), "LIVE" ) )
@@ -485,12 +497,23 @@ bool FoundGameListItem::Info::SetFromLobby( CSteamID lobby )
 	m_iCurPlayers = V_atoi( LOBBY_DATA( "members:numPlayers" ) );
 	m_iMaxPlayers = V_atoi( LOBBY_DATA( "members:numSlots" ) );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( ISteamNetworkingUtils *pNetworkingUtils = SteamNetworkingUtils() )
+#else
+	if ( ISteamNetworkingUtils *pNetworkingUtils = SteamNetworkingUtils() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pNetworkingUtils->ParsePingLocationString( LOBBY_DATA( "system:rd_lobby_location" ), m_PingLocation ) )
 		{
 			m_iPingMS = pNetworkingUtils->EstimatePingTimeFromLocalHost( m_PingLocation );
 		}
+#else
+		if ( pNetworkingUtils->ParsePingLocationString( LOBBY_DATA( "system:rd_lobby_location" ), m_PingLocation ) )
+		{
+			m_iPingMS = pNetworkingUtils->EstimatePingTimeFromLocalHost( m_PingLocation );
+		}
+#endif
 	}
 
 	m_ePingCategory = GetPingCategory( m_iPingMS );
@@ -1236,7 +1259,11 @@ void FoundGameListItem::PostChildPaint()
 		int iFriendLabelXOffset, discard;
 		m_pLblPlayerGamerTag->GetPos( iFriendLabelXOffset, discard );
 		Color FriendColor = HasFocus() || HasMouseover() || IsSelected() ? Color( 255, 255, 255, 255 ) : Color( 100, 100, 100, 255 );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( ISteamFriends *pSteamFriends = SteamFriends() )
+#else
+		if ( ISteamFriends *pSteamFriends = SteamFriends() )
+#endif
 		{
 			vgui::surface()->DrawSetTextFont( m_hTextFont );
 			vgui::surface()->DrawSetTextColor( FriendColor );
@@ -1244,7 +1271,11 @@ void FoundGameListItem::PostChildPaint()
 			FOR_EACH_VEC( m_FullInfo.m_Friends, i )
 			{
 				wchar_t wszFriendName[k_cwchPersonaNameMax];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				V_UTF8ToUnicode( pSteamFriends->GetFriendPersonaName( m_FullInfo.m_Friends[i] ), wszFriendName, sizeof( wszFriendName ) );
+#else
+				V_UTF8ToUnicode( pSteamFriends->GetFriendPersonaName( m_FullInfo.m_Friends[i] ), wszFriendName, sizeof( wszFriendName ) );
+#endif
 				g_RDTextFiltering.FilterTextName( wszFriendName, m_FullInfo.m_Friends[i] );
 
 				int w, t;
@@ -1520,12 +1551,20 @@ void FoundGameListItem::PerformLayout()
 		int iFriendLabelXOffset, discard;
 		m_pLblPlayerGamerTag->GetPos( iFriendLabelXOffset, discard );
 		iAdditionalTall = YRES( 2 );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( ISteamFriends *pSteamFriends = SteamFriends() )
+#else
+		if ( ISteamFriends *pSteamFriends = SteamFriends() )
+#endif
 		{
 			FOR_EACH_VEC( m_FullInfo.m_Friends, i )
 			{
 				wchar_t wszFriendName[k_cwchPersonaNameMax];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				V_UTF8ToUnicode( pSteamFriends->GetFriendPersonaName( m_FullInfo.m_Friends[i] ), wszFriendName, sizeof( wszFriendName ) );
+#else
+				V_UTF8ToUnicode( pSteamFriends->GetFriendPersonaName( m_FullInfo.m_Friends[i] ), wszFriendName, sizeof( wszFriendName ) );
+#endif
 
 				int w, t;
 				vgui::surface()->GetTextSize( m_hTextFont, wszFriendName, w, t );
@@ -1836,7 +1875,11 @@ void FoundGames::OpenPlayerFlyout( BaseModHybridButton *button, uint64 playerId,
 	{
 		flyout = dynamic_cast< FlyoutMenu * >( FindChildByName( "FlmPlayerFlyout_SteamGroup" ) );
 	}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	else if ( SteamFriends()->GetFriendRelationship( playerId ) == k_EFriendRelationshipFriend )
+#else
+	else if ( SteamFriends()->GetFriendRelationship( playerId ) == k_EFriendRelationshipFriend )
+#endif
 	{
 		flyout = dynamic_cast< FlyoutMenu * >( FindChildByName( "FlmPlayerFlyout" ) );
 	}
@@ -2138,20 +2181,41 @@ void FoundGames::AddServersToList()
 
 void FoundGames::AddFriendGamesToList( bool bMergeOnly )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pFriends = SteamFriends();
+#else
+	ISteamFriends *pFriends = SteamFriends();
+#endif
 	Assert( pFriends );
 	if ( !pFriends )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	const static AppId_t s_iAppID = SteamUtils()->GetAppID();
+#else
+	const static AppId_t s_iAppID = SteamUtils()->GetAppID();
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	int count = pFriends->GetFriendCount( k_EFriendFlagImmediate );
+#else
+	int count = pFriends->GetFriendCount( k_EFriendFlagImmediate );
+#endif
 	for ( int i = 0; i < count; i++ )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		CSteamID friendID = pFriends->GetFriendByIndex( i, k_EFriendFlagImmediate );
+#else
+		CSteamID friendID = pFriends->GetFriendByIndex( i, k_EFriendFlagImmediate );
+#endif
 		FriendGameInfo_t gameInfo;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pFriends->GetFriendGamePlayed( friendID, &gameInfo ) )
 			continue; // not playing a game
+#else
+		if ( !pFriends->GetFriendGamePlayed( friendID, &gameInfo ) )
+			continue; // not playing a game
+#endif
 		if ( !gameInfo.m_gameID.IsSteamApp() || gameInfo.m_gameID.AppID() != s_iAppID )
 			continue; // not playing AS:RD
 
@@ -2633,7 +2697,11 @@ void FoundGames::OnItemSelected( const char *panelName )
 		}
 
 		btnWebsite->SetText( finalString );
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		btnWebsite->SetVisible( finalString[0] != 0 && ( gameListItem->GetFullInfo().m_iMissionWorkshopID == k_PublishedFileIdInvalid || !SteamUtils() || !SteamUtils()->IsOverlayEnabled() ) );
+		#else
+		btnWebsite->SetVisible( finalString[0] != 0 && ( gameListItem->GetFullInfo().m_iMissionWorkshopID == k_PublishedFileIdInvalid || !SteamUtils() || !SteamUtils()->IsOverlayEnabled() ) );
+		#endif
 	}
 
 	vgui::Label *lblAccess = dynamic_cast< vgui::Label * >( FindChildByName( "LblPlayerAccess" ) );

--- a/src/game/client/swarm/gameui/swarm/vfoundgroupgames.cpp
+++ b/src/game/client/swarm/gameui/swarm/vfoundgroupgames.cpp
@@ -67,16 +67,28 @@ void FoundGroupGames::OnEvent( KeyValues *pEvent )
 //=============================================================================
 void FoundGroupGames::AddServersToList( void )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pFriends = SteamFriends();
+#else
+	ISteamFriends *pFriends = SteamFriends();
+#endif
 	Assert( pFriends );
 	if ( !pFriends )
 		return;
 
 	CUtlVector<CSteamID> GroupIDs;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	GroupIDs.SetCount( pFriends->GetClanCount() );
+#else
+	GroupIDs.SetCount( pFriends->GetClanCount() );
+#endif
 	FOR_EACH_VEC( GroupIDs, i )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		GroupIDs[i] = pFriends->GetClanByIndex( i );
+#else
+		GroupIDs[i] = pFriends->GetClanByIndex( i );
+#endif
 	}
 
 	g_ReactiveDropServerList.m_InternetServers.WantUpdatedServerList();

--- a/src/game/client/swarm/gameui/swarm/vfoundpublicgames.cpp
+++ b/src/game/client/swarm/gameui/swarm/vfoundpublicgames.cpp
@@ -377,9 +377,17 @@ void FoundPublicGames::Activate()
 	m_bShowHardcoreDifficulties = UTIL_ASW_CommanderLevelAtLeast( NULL, 15 );
 
 #if !defined( _X360 ) && !defined( NO_STEAM )
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( ISteamUserStats *pSteamUserStats = SteamUserStats() )
+#else
+	if ( ISteamUserStats *pSteamUserStats = SteamUserStats() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hSteamAPICall = pSteamUserStats->GetNumberOfCurrentPlayers();
+#else
+		SteamAPICall_t hSteamAPICall = pSteamUserStats->GetNumberOfCurrentPlayers();
+#endif
 		m_callbackNumberOfCurrentPlayers.Set( hSteamAPICall, this, &FoundPublicGames::Steam_OnNumberOfCurrentPlayers );
 	}
 #endif

--- a/src/game/client/swarm/gameui/swarm/vfoundpublicgames.h
+++ b/src/game/client/swarm/gameui/swarm/vfoundpublicgames.h
@@ -66,7 +66,11 @@ namespace BaseModUI {
 		bool CanCreateGame();
 
 #if !defined( _X360 ) && !defined( NO_STEAM )
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		CCallResult<FoundPublicGames, NumberOfCurrentPlayers_t> m_callbackNumberOfCurrentPlayers;
+#else
+		CCallResult<FoundPublicGames, NumberOfCurrentPlayers_t> m_callbackNumberOfCurrentPlayers;
+#endif
 		void Steam_OnNumberOfCurrentPlayers( NumberOfCurrentPlayers_t *pResult, bool bError );
 #endif
 

--- a/src/game/client/swarm/gameui/swarm/vgamelobby.h
+++ b/src/game/client/swarm/gameui/swarm/vgamelobby.h
@@ -56,7 +56,11 @@ public:
 	MESSAGE_FUNC( MsgChangeGameSettings, "ChangeGameSettings" );
 
 #if !defined( _X360 ) && !defined( NO_STEAM )
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( GameLobby, Steam_OnPersonaStateChanged, PersonaStateChange_t );
+#else
+	STEAM_CALLBACK( GameLobby, Steam_OnPersonaStateChanged, PersonaStateChange_t );
+#endif
 #endif
 
 protected:

--- a/src/game/client/swarm/gameui/swarm/vgamesettings.cpp
+++ b/src/game/client/swarm/gameui/swarm/vgamesettings.cpp
@@ -371,7 +371,11 @@ void GameSettings::Activate()
 		m_pHeaderFooter->SetGradientBarPos( 110, 240 );
 
 		wchar_t wszPlayerName[k_cwchPersonaNameMax];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		V_UTF8ToUnicode( SteamFriends() ? SteamFriends()->GetPersonaName() : "", wszPlayerName, sizeof( wszPlayerName ) );
+#else
+		V_UTF8ToUnicode( SteamFriends() ? SteamFriends()->GetPersonaName() : "", wszPlayerName, sizeof( wszPlayerName ) );
+#endif
 		m_pLobbyNamePlaceholder->SetText( wszPlayerName );
 	}
 	else
@@ -665,8 +669,16 @@ void GameSettings::OnCommand(const char *command)
 		static ConVarRef hostname{ "hostname" };
 		if ( rd_lobby_hostname.GetString()[0] != '\0' )
 			hostname.SetValue( rd_lobby_hostname.GetString() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		else if ( SteamFriends() )
+#else
+		else if ( SteamFriends() )
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			hostname.SetValue( SteamFriends()->GetPersonaName() );
+#else
+			hostname.SetValue( SteamFriends()->GetPersonaName() );
+#endif
 
 		char const *szNetwork = m_pSettings->GetString( "system/network", "offline" );
 		if ( !Q_stricmp( szNetwork, "offline" ) )

--- a/src/game/client/swarm/gameui/swarm/vitemshowcase.cpp
+++ b/src/game/client/swarm/gameui/swarm/vitemshowcase.cpp
@@ -414,7 +414,11 @@ void ItemShowcase::ShowItems( SteamInventoryResult_t hResult, int iStart, int iC
 {
 	SteamItemDetails_t itemDetails{};
 	uint32 nItemCount{ 1 };
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamInventory()->GetResultItems( hResult, &itemDetails, &nItemCount ) && nItemCount == 1 && itemDetails.m_itemId == 0 )
+#else
+	if ( SteamInventory()->GetResultItems( hResult, &itemDetails, &nItemCount ) && nItemCount == 1 && itemDetails.m_itemId == 0 )
+#endif
 	{
 		nItemCount = 0;
 	}

--- a/src/game/client/swarm/gameui/swarm/vloadingprogress.cpp
+++ b/src/game/client/swarm/gameui/swarm/vloadingprogress.cpp
@@ -541,7 +541,11 @@ void LoadingProgress::SetPosterData( KeyValues *pMissionInfo, KeyValues *pChapte
 
 void LoadingProgress::SetLeaderboardData( const char *pszLevelName, PublishedFileId_t nLevelAddon, const char *pszLevelDisplayName, const char *pszChallengeName, PublishedFileId_t nChallengeAddon, const char *pszChallengeDisplayName )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !rd_show_leaderboard_loading.GetBool() || !SteamUserStats() || !SteamFriends() )
+#else
+	if ( !rd_show_leaderboard_loading.GetBool() || !SteamUserStats() || !SteamFriends() )
+#endif
 	{
 		return;
 	}
@@ -583,7 +587,11 @@ void LoadingProgress::SetLeaderboardData( const char *pszLevelName, PublishedFil
 		Q_snwprintf( m_wszLeaderboardTitle, ARRAYSIZE( m_wszLeaderboardTitle ), L"%s", wszLevelDisplayName );
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hCall = SteamUserStats()->FindLeaderboard( szLeaderboardName );
+#else
+	SteamAPICall_t hCall = SteamUserStats()->FindLeaderboard( szLeaderboardName );
+#endif
 	m_LeaderboardFind.Set( hCall, this, &LoadingProgress::LeaderboardFind );
 }
 
@@ -594,9 +602,17 @@ void LoadingProgress::LeaderboardFind( LeaderboardFindResult_t *pResult, bool bI
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_pLeaderboardPanel->SetDisplayType( SteamUserStats()->GetLeaderboardDisplayType( pResult->m_hSteamLeaderboard ) );
+#else
+	m_pLeaderboardPanel->SetDisplayType( SteamUserStats()->GetLeaderboardDisplayType( pResult->m_hSteamLeaderboard ) );
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hCall = SteamUserStats()->DownloadLeaderboardEntries( pResult->m_hSteamLeaderboard, k_ELeaderboardDataRequestFriends, 0, 0 );
+#else
+	SteamAPICall_t hCall = SteamUserStats()->DownloadLeaderboardEntries( pResult->m_hSteamLeaderboard, k_ELeaderboardDataRequestFriends, 0, 0 );
+#endif
 	m_LeaderboardDownloaded.Set( hCall, this, &LoadingProgress::LeaderboardDownloaded );
 }
 

--- a/src/game/client/swarm/gameui/swarm/vloadingprogress.h
+++ b/src/game/client/swarm/gameui/swarm/vloadingprogress.h
@@ -79,9 +79,17 @@ private:
 
 	bool				m_bFullscreenPoster;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<LoadingProgress, LeaderboardFindResult_t> m_LeaderboardFind;
+#else
+	CCallResult<LoadingProgress, LeaderboardFindResult_t> m_LeaderboardFind;
+#endif
 	void LeaderboardFind( LeaderboardFindResult_t *pResult, bool bIOError );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<LoadingProgress, LeaderboardScoresDownloaded_t> m_LeaderboardDownloaded;
+#else
+	CCallResult<LoadingProgress, LeaderboardScoresDownloaded_t> m_LeaderboardDownloaded;
+#endif
 	void LeaderboardDownloaded( LeaderboardScoresDownloaded_t *pResult, bool bIOError );
 
 	// Poster Data

--- a/src/game/client/swarm/gameui/swarm/vloadouts.cpp
+++ b/src/game/client/swarm/gameui/swarm/vloadouts.cpp
@@ -566,32 +566,54 @@ void Loadouts::StartPublishingLoadouts( const char *szTitle, const char *szDescr
 	CUtlBuffer buf;
 	ReactiveDropLoadout::WriteLoadoutsForSharing( buf, loadouts );
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+	#else
+	ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+	#endif
 	Assert( pRemoteStorage );
 	if ( !pRemoteStorage )
 	{
 		DisplayPublishingError( "#rd_loadout_share_failed_api" );
 		return;
 	}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pRemoteStorage->FileWrite( "integrated_guide.bin", buf.Base(), buf.TellMaxPut() );
+#else
+	pRemoteStorage->FileWrite( "integrated_guide.bin", buf.Base(), buf.TellMaxPut() );
+#endif
 
 	buf.Purge();
 	if ( !g_pFullFileSystem->ReadFile( szPreviewFile, NULL, buf ) )
 	{
 		DisplayPublishingError( "#rd_loadout_share_failed_preview_image" );
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pRemoteStorage->FileDelete( "integrated_guide.bin" );
+	#else
+		pRemoteStorage->FileDelete( "integrated_guide.bin" );
+	#endif
 		return;
 	}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pRemoteStorage->FileWrite( "integrated_guide_preview.jpeg", buf.Base(), buf.TellMaxPut() );
+#else
+	pRemoteStorage->FileWrite( "integrated_guide_preview.jpeg", buf.Base(), buf.TellMaxPut() );
+#endif
 
 	const char *szLoadoutTag = "Loadouts";
 	SteamParamStringArray_t tags;
 	tags.m_ppStrings = &szLoadoutTag;
 	tags.m_nNumStrings = 1;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hCall = pRemoteStorage->PublishWorkshopFile( "integrated_guide.bin", "integrated_guide_preview.jpeg",
 		SteamUtils()->GetAppID(), szTitle, szDescription,
 		k_ERemoteStoragePublishedFileVisibilityPublic, &tags, k_EWorkshopFileTypeIntegratedGuide );
+#else
+	SteamAPICall_t hCall = pRemoteStorage->PublishWorkshopFile( "integrated_guide.bin", "integrated_guide_preview.jpeg",
+		SteamUtils()->GetAppID(), szTitle, szDescription,
+		k_ERemoteStoragePublishedFileVisibilityPublic, &tags, k_EWorkshopFileTypeIntegratedGuide );
+#endif
 	m_RemoteStoragePublishFileResult.Set( hCall, this, &Loadouts::OnRemoteStoragePublishFileResult );
 
 	GenericWaitScreen *pWait = assert_cast< GenericWaitScreen * >( CBaseModPanel::GetSingleton().OpenWindow( WT_GENERICWAITSCREEN, this, false ) );
@@ -619,8 +641,16 @@ void Loadouts::OnRemoteStoragePublishFileResult( RemoteStoragePublishFileResult_
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pRemoteStorage->FileDelete( "integrated_guide.bin" );
+#else
+	pRemoteStorage->FileDelete( "integrated_guide.bin" );
+#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pRemoteStorage->FileDelete( "integrated_guide_preview.jpeg" );
+	#else
+	pRemoteStorage->FileDelete( "integrated_guide_preview.jpeg" );
+	#endif
 
 	if ( pParam->m_eResult != k_EResultOK )
 	{
@@ -1044,8 +1074,13 @@ bool CRD_VGUI_Loadout_List_Item::SetMarineForSlot( int iSlot, SteamItemInstanceI
 		ReactiveDropLoadout::Loadouts[iLoadoutIndex].MarineIncluded[iSlot] = true;
 		ReactiveDropLoadout::Loadouts[iLoadoutIndex].Marines[iSlot].Suit = iItemInstance;
 		ReactiveDropLoadout::Loadouts[iLoadoutIndex].Marines[iSlot].SuitDef = iItemDef;
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( ISteamUtils *pUtils = SteamUtils() )
 			ReactiveDropLoadout::Loadouts[iLoadoutIndex].LastModified = pUtils->GetServerRealTime();
+		#else
+		if ( ISteamUtils *pUtils = SteamUtils() )
+			ReactiveDropLoadout::Loadouts[iLoadoutIndex].LastModified = pUtils->GetServerRealTime();
+		#endif
 		ReactiveDropLoadout::WriteLoadouts();
 
 		m_Loadout = ReactiveDropLoadout::Loadouts[iLoadoutIndex];
@@ -1147,8 +1182,13 @@ bool CRD_VGUI_Loadout_List_Item::SetWeaponForSlot( int iSlot, ASW_Inventory_slot
 			ReactiveDropLoadout::Loadouts[iLoadoutIndex].Marines[iSlot].ExtraItem = iItemInstance;
 			ReactiveDropLoadout::Loadouts[iLoadoutIndex].Marines[iSlot].ExtraDef = iItemDef;
 		}
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( ISteamUtils *pUtils = SteamUtils() )
 			ReactiveDropLoadout::Loadouts[iLoadoutIndex].LastModified = pUtils->GetServerRealTime();
+		#else
+		if ( ISteamUtils *pUtils = SteamUtils() )
+			ReactiveDropLoadout::Loadouts[iLoadoutIndex].LastModified = pUtils->GetServerRealTime();
+		#endif
 		ReactiveDropLoadout::WriteLoadouts();
 
 		m_Loadout = ReactiveDropLoadout::Loadouts[iLoadoutIndex];
@@ -1198,7 +1238,11 @@ void CRD_VGUI_Loadout_List_Addon_Header::OnThink()
 	if ( m_bLoadedAddonDetails )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pFriends = SteamFriends();
+#else
+	ISteamFriends *pFriends = SteamFriends();
+#endif
 	Assert( pFriends );
 	if ( !pFriends )
 		return;
@@ -1220,14 +1264,22 @@ void CRD_VGUI_Loadout_List_Addon_Header::OnThink()
 		m_pImgAuthorAvatar->SetAvatarBySteamID( &authorID );
 
 		wchar_t wszPersonaName[k_cwchPersonaNameMax];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		V_UTF8ToUnicode( pFriends->GetFriendPersonaName( authorID ), wszPersonaName, sizeof( wszPersonaName ) );
+#else
+		V_UTF8ToUnicode( pFriends->GetFriendPersonaName( authorID ), wszPersonaName, sizeof( wszPersonaName ) );
+#endif
 		m_pLblAuthorName->SetText( wszPersonaName );
 	}
 }
 
 void CRD_VGUI_Loadout_List_Addon_Header::OnPersonaStateChange( PersonaStateChange_t *pParam )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pFriends = SteamFriends();
+#else
+	ISteamFriends *pFriends = SteamFriends();
+#endif
 	Assert( pFriends );
 	if ( !pFriends )
 		return;
@@ -1239,7 +1291,11 @@ void CRD_VGUI_Loadout_List_Addon_Header::OnPersonaStateChange( PersonaStateChang
 		return;
 
 	wchar_t wszPersonaName[k_cwchPersonaNameMax];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	V_UTF8ToUnicode( pFriends->GetFriendPersonaName( pParam->m_ulSteamID ), wszPersonaName, sizeof( wszPersonaName ) );
+#else
+	V_UTF8ToUnicode( pFriends->GetFriendPersonaName( pParam->m_ulSteamID ), wszPersonaName, sizeof( wszPersonaName ) );
+#endif
 	m_pLblAuthorName->SetText( wszPersonaName );
 }
 

--- a/src/game/client/swarm/gameui/swarm/vloadouts.h
+++ b/src/game/client/swarm/gameui/swarm/vloadouts.h
@@ -64,7 +64,11 @@ public:
 	void DisplayPublishingError( const char *szMessage, int nArgs = 0, const wchar_t *wszArg1 = NULL, const wchar_t *wszArg2 = NULL, const wchar_t *wszArg3 = NULL, const wchar_t *wszArg4 = NULL );
 	void StartPublishingLoadouts( const char *szTitle, const char *szDescription, const char *szPreviewFile, const CUtlDict<ReactiveDropLoadout::LoadoutData_t> &loadouts );
 	void OnRemoteStoragePublishFileResult( RemoteStoragePublishFileResult_t *pParam, bool bIOFailure );
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<Loadouts, RemoteStoragePublishFileResult_t> m_RemoteStoragePublishFileResult;
+	#else
+	CCallResult<Loadouts, RemoteStoragePublishFileResult_t> m_RemoteStoragePublishFileResult;
+	#endif
 
 	// IBriefing implementation
 	const char *GetLeaderName() override { return ""; }
@@ -175,7 +179,11 @@ public:
 	vgui::Label *m_pLblAuthorName;
 	bool m_bLoadedAddonDetails;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_VGUI_Loadout_List_Addon_Header, OnPersonaStateChange, PersonaStateChange_t );
+#else
+	STEAM_CALLBACK( CRD_VGUI_Loadout_List_Addon_Header, OnPersonaStateChange, PersonaStateChange_t );
+#endif
 };
 
 class CRD_VGUI_Loadout_Marine : public vgui::EditablePanel

--- a/src/game/client/swarm/gameui/swarm/vmainmenu.cpp
+++ b/src/game/client/swarm/gameui/swarm/vmainmenu.cpp
@@ -261,7 +261,11 @@ void MainMenu::Activate()
 	if ( HoIAF()->GetLastUpdateDate( iPatchYear, iPatchMonth, iPatchDay ) )
 	{
 		char szBranchName[64]{};
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamApps() && SteamApps()->GetCurrentBetaName( szBranchName, sizeof(szBranchName) ) && szBranchName[0] != '\0' )
+		#else
+		if ( SteamApps() && SteamApps()->GetCurrentBetaName( szBranchName, sizeof(szBranchName) ) && szBranchName[0] != '\0' )
+		#endif
 		{
 			// we are on a branch. doesn't matter if it's beta, releasecandidate,
 			// bugtest, or something else. show the beta notes message.
@@ -291,7 +295,11 @@ void MainMenu::Activate()
 		m_iLastTimerUpdate = 0;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUserStats *pUserStats = SteamUserStats();
+#else
+	ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 	if ( pUserStats && !m_bIsLegacy && rd_hoiaf_leaderboard_on_main_menu.GetBool() )
 	{
 		for ( int i = 0; i < s_nHoIAFCachedEntries; i++ )
@@ -305,23 +313,55 @@ void MainMenu::Activate()
 			m_pTopLeaderboardEntries[i]->SetVisible( false );
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hCall = pUserStats->DownloadLeaderboardEntries( STEAM_LEADERBOARD_HOIAF_CURRENT_SEASON, rd_hoiaf_leaderboard_friends_only.GetBool() ? k_ELeaderboardDataRequestFriends : k_ELeaderboardDataRequestGlobal, 1, 10 );
+#else
+		SteamAPICall_t hCall = pUserStats->DownloadLeaderboardEntries( STEAM_LEADERBOARD_HOIAF_CURRENT_SEASON, rd_hoiaf_leaderboard_friends_only.GetBool() ? k_ELeaderboardDataRequestFriends : k_ELeaderboardDataRequestGlobal, 1, 10 );
+#endif
 		m_HoIAFTop10Callback.Set( hCall, this, &MainMenu::OnHoIAFTop10ScoresDownloaded );
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pUGC = SteamUGC();
+#else
+	ISteamUGC *pUGC = SteamUGC();
+#endif
 	if ( pUGC && rd_trending_workshop_tags.GetString()[0] != '\0' )
 	{
 		CSplitString AllowedTags( rd_trending_workshop_tags.GetString(), "," );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		UGCQueryHandle_t hQuery = pUGC->CreateQueryAllUGCRequest( k_EUGCQuery_RankedByTrend, k_EUGCMatchingUGCType_Items_ReadyToUse, 563560, 563560 );
+#else
+		UGCQueryHandle_t hQuery = pUGC->CreateQueryAllUGCRequest( k_EUGCQuery_RankedByTrend, k_EUGCMatchingUGCType_Items_ReadyToUse, 563560, 563560 );
+#endif
 		SteamParamStringArray_t RequiredTags;
 		RequiredTags.m_ppStrings = const_cast< const char ** >( AllowedTags.Base() );
 		RequiredTags.m_nNumStrings = AllowedTags.Count();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->AddRequiredTagGroup( hQuery, &RequiredTags );
+#else
+		pUGC->AddRequiredTagGroup( hQuery, &RequiredTags );
+#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( ISteamApps *pApps = SteamApps() )
+	#else
+		if ( ISteamApps *pApps = SteamApps() )
+	#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pUGC->SetLanguage( hQuery, pApps->GetCurrentGameLanguage() );
+#else
+			pUGC->SetLanguage( hQuery, pApps->GetCurrentGameLanguage() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->SetAllowCachedResponse( hQuery, 3600 );
+#else
+		pUGC->SetAllowCachedResponse( hQuery, 3600 );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hCall = pUGC->SendQueryUGCRequest( hQuery );
+#else
+		SteamAPICall_t hCall = pUGC->SendQueryUGCRequest( hQuery );
+#endif
 		m_WorkshopTrendingItemsCallback.Set( hCall, this, &MainMenu::OnWorkshopTrendingItems );
 	}
 
@@ -347,7 +387,11 @@ void MainMenu::LoadLayout()
 		m_bIsLegacy = true;
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( CommandLine()->FindParm( "-teststeamapiloadfail" ) || !g_pMatchFramework || !g_pMatchFramework->GetMatchSystem() || !g_pMatchFramework->GetMatchSystem()->GetPlayerManager() || !g_pMatchFramework->GetMatchSystem()->GetPlayerManager()->GetLocalPlayer(0) || !SteamApps() || !SteamFriends() || !SteamHTTP() || !SteamInput() || !SteamMatchmaking() || !SteamMatchmakingServers() || !SteamRemoteStorage() || !SteamUGC() || !SteamUser() || !SteamUserStats() || !SteamUtils())
+	#else
+	if ( CommandLine()->FindParm( "-teststeamapiloadfail" ) || !g_pMatchFramework || !g_pMatchFramework->GetMatchSystem() || !g_pMatchFramework->GetMatchSystem()->GetPlayerManager() || !g_pMatchFramework->GetMatchSystem()->GetPlayerManager()->GetLocalPlayer(0) || !SteamApps() || !SteamFriends() || !SteamHTTP() || !SteamInput() || !SteamMatchmaking() || !SteamMatchmakingServers() || !SteamRemoteStorage() || !SteamUGC() || !SteamUser() || !SteamUserStats() || !SteamUtils())
+	#endif
 	{
 		pSettings = "Resource/UI/BaseModUI/MainMenuStub.res";
 		m_bIsStub = true;
@@ -460,14 +504,22 @@ void MainMenu::ApplySchemeSettings( IScheme *pScheme )
 			bool bUsesCloud = false;
 
 #ifdef IS_WINDOWS_PC
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+			#else
+			ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+			#endif
 #else
 			ISteamRemoteStorage *pRemoteStorage =  NULL; 
 			AssertMsg( false, "This branch run on a PC build without IS_WINDOWS_PC defined." );
 #endif
 
 			uint64 availableBytes, totalBytes = 0;
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( pRemoteStorage && pRemoteStorage->GetQuota( &totalBytes, &availableBytes ) )
+			#else
+			if ( pRemoteStorage && pRemoteStorage->GetQuota( &totalBytes, &availableBytes ) )
+			#endif
 			{
 				if ( totalBytes > 0 )
 				{
@@ -516,11 +568,19 @@ void MainMenu::ApplySchemeSettings( IScheme *pScheme )
 #endif
 
 	m_pBranchDisclaimer = dynamic_cast< vgui::Label * >( FindChildByName( "LblBranchDisclaimer" ) );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamApps *pApps = SteamApps();
+#else
+	ISteamApps *pApps = SteamApps();
+#endif
 	if ( m_pBranchDisclaimer && pApps )
 	{
 		char szBranch[256]{};
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pApps->GetCurrentBetaName( szBranch, sizeof( szBranch ) ) )
+		#else
+		if ( !pApps->GetCurrentBetaName( szBranch, sizeof( szBranch ) ) )
+		#endif
 		{
 			m_pBranchDisclaimer->SetVisible( false );
 		}
@@ -684,17 +744,29 @@ void MainMenu::OnCommand( const char *command )
 		data.pWindowTitle = "#rd_no_steam_service";
 		data.pMessageText = "#rd_no_steam_solutions";
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !CommandLine()->FindParm( "-teststeamapiloadfail" ) && SteamApps() && SteamFriends() && SteamHTTP() && SteamInput() && SteamMatchmaking() && SteamMatchmakingServers() && SteamRemoteStorage() && SteamUGC() && SteamUser() && SteamUserStats() && SteamUtils() )
+		#else
+		if ( !CommandLine()->FindParm( "-teststeamapiloadfail" ) && SteamApps() && SteamFriends() && SteamHTTP() && SteamInput() && SteamMatchmaking() && SteamMatchmakingServers() && SteamRemoteStorage() && SteamUGC() && SteamUser() && SteamUserStats() && SteamUtils() )
+		#endif
 		{
 			// The NO STEAM main menu is active, but the Steam API is available. This should never happen. Please contact https://reactivedrop.com/feedback
 			data.pMessageText = "#rd_no_steam_solutions_api";
 		}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		else if ( !SteamAPI_IsSteamRunning() )
+#else
+		else if ( !SteamAPI_IsSteamRunning() )
+#endif
 		{
 			// Did not detect an instance of the Steam Client. If the Steam Client is running, try selecting Steam->Exit and then restarting Steam.
 			data.pMessageText = "#rd_no_steam_solutions_client";
 		}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		else if ( !SteamAPI_GetSteamInstallPath() )
+#else
+		else if ( !SteamAPI_GetSteamInstallPath() )
+#endif
 		{
 			// Could not determine the location of the Steam Client through the registry. Try restarting Steam.
 			data.pMessageText = "#rd_no_steam_solutions_path";
@@ -1194,7 +1266,11 @@ void MainMenu::OnCommand( const char *command )
 	else if ( !V_stricmp( command, "UpdateNotes" ) )
 	{
 		char szBranchName[64]{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamApps() && SteamApps()->GetCurrentBetaName( szBranchName, sizeof( szBranchName ) ) && szBranchName[0] != '\0' )
+#else
+		if ( SteamApps() && SteamApps()->GetCurrentBetaName( szBranchName, sizeof( szBranchName ) ) && szBranchName[0] != '\0' )
+#endif
 		{
 			OpenNewsURL( "https://reactivedrop.com/beta-updates/" );
 		}
@@ -1383,7 +1459,11 @@ void MainMenu::OnThink()
 		return;
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	uint32 iCurrentTime = SteamUtils() ? SteamUtils()->GetServerRealTime() : std::time( NULL );
+	#else
+	uint32 iCurrentTime = SteamUtils() ? SteamUtils()->GetServerRealTime() : std::time( NULL );
+	#endif
 	uint32 iCurrentMinute = iCurrentTime / 60;
 	if ( m_iLastTimerUpdate != iCurrentMinute )
 	{
@@ -1739,7 +1819,11 @@ void MainMenu::PaintBackground()
 	HUD_SHEET_DRAW_PANEL( m_pBtnNewsShowcase, MainMenuSheet, UV_news );
 	HUD_SHEET_DRAW_PANEL( m_pBtnUpdateNotes, MainMenuSheet, UV_update );
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	int iCurrentMinute = ( ( SteamUtils() ? SteamUtils()->GetServerRealTime() : std::time( NULL ) ) / 60 );
+	#else
+	int iCurrentMinute = ( ( SteamUtils() ? SteamUtils()->GetServerRealTime() : std::time( NULL ) ) / 60 );
+	#endif
 
 	int iNumNewsShowcases = HoIAF()->CountFeaturedNews();
 	if ( iNumNewsShowcases && m_pBtnNewsShowcase->IsVisible() )
@@ -1962,7 +2046,11 @@ void MainMenu::OpenNewsURL( const char *szURL )
 		return;
 
 	char szFormattedURL[1024];
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	V_snprintf( szFormattedURL, sizeof( szFormattedURL ), szURL, SteamApps() ? SteamApps()->GetCurrentGameLanguage() : "" );
+	#else
+	V_snprintf( szFormattedURL, sizeof( szFormattedURL ), szURL, SteamApps() ? SteamApps()->GetCurrentGameLanguage() : "" );
+	#endif
 	CUIGameData::Get()->ExecuteOverlayUrl( szFormattedURL );
 }
 
@@ -2046,7 +2134,11 @@ void MainMenu::OnHoIAFTop10ScoresDownloaded( LeaderboardScoresDownloaded_t *pPar
 		s_nHoIAFCachedEntries = MIN( pParam->m_cEntryCount, NELEMS( m_pTopLeaderboardEntries ) );
 		for ( int i = 0; i < pParam->m_cEntryCount && i < NELEMS( m_pTopLeaderboardEntries ); i++ )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			bool bOK = SteamUserStats()->GetDownloadedLeaderboardEntry( pParam->m_hSteamLeaderboardEntries, i, &s_HoIAFLeaderboardEntryCache[i], reinterpret_cast< int32 * >( &s_HoIAFLeaderboardDetailsCache[i] ), sizeof( s_HoIAFLeaderboardDetailsCache[i] ) / sizeof( int32 ) );
+#else
+			bool bOK = SteamUserStats()->GetDownloadedLeaderboardEntry( pParam->m_hSteamLeaderboardEntries, i, &s_HoIAFLeaderboardEntryCache[i], reinterpret_cast< int32 * >( &s_HoIAFLeaderboardDetailsCache[i] ), sizeof( s_HoIAFLeaderboardDetailsCache[i] ) / sizeof( int32 ) );
+#endif
 			Assert( bOK );
 			Assert( s_HoIAFLeaderboardEntryCache[i].m_cDetails == sizeof( s_HoIAFLeaderboardDetailsCache[i] ) / sizeof( int32 ) );
 
@@ -2082,7 +2174,11 @@ void MainMenu::OnWorkshopTrendingItems( SteamUGCQueryCompleted_t *pParam, bool b
 	for ( uint32 i = 0; i < pParam->m_unNumResultsReturned && i < NELEMS( m_iWorkshopTrendingFileID ); i++ )
 	{
 		SteamUGCDetails_t details;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bool bOK = SteamUGC()->GetQueryUGCResult( pParam->m_handle, i, &details );
+#else
+		bool bOK = SteamUGC()->GetQueryUGCResult( pParam->m_handle, i, &details );
+#endif
 		Assert( bOK );
 		if ( bOK )
 		{
@@ -2090,7 +2186,11 @@ void MainMenu::OnWorkshopTrendingItems( SteamUGCQueryCompleted_t *pParam, bool b
 			V_UTF8ToUnicode( details.m_rgchTitle, m_wszWorkshopTrendingTitle[i], sizeof( m_wszWorkshopTrendingTitle[i] ) );
 			m_hWorkshopTrendingPreview[i] = details.m_hPreviewFile;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamAPICall_t hCall = SteamRemoteStorage()->UGCDownload( details.m_hPreviewFile, 0 );
+#else
+			SteamAPICall_t hCall = SteamRemoteStorage()->UGCDownload( details.m_hPreviewFile, 0 );
+#endif
 			m_WorkshopPreviewImageCallback[i].Set( hCall, this, &MainMenu::OnWorkshopPreviewImage );
 
 			if ( iCurrentWorkshopShowcase == i )
@@ -2106,7 +2206,11 @@ void MainMenu::OnWorkshopPreviewImage( RemoteStorageDownloadUGCResult_t *pParam,
 	if ( bIOFailure || pParam->m_eResult != k_EResultOK )
 		return;
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( pParam->m_nAppID == SteamUtils()->GetAppID() );
+	#else
+	Assert( pParam->m_nAppID == SteamUtils()->GetAppID() );
+	#endif
 
 	for ( int i = 0; i < NELEMS( m_hWorkshopTrendingPreview ); i++ )
 	{
@@ -2114,7 +2218,11 @@ void MainMenu::OnWorkshopPreviewImage( RemoteStorageDownloadUGCResult_t *pParam,
 			continue;
 
 		CUtlBuffer buf;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		int32 nBytesRead = SteamRemoteStorage()->UGCRead( pParam->m_hFile, buf.AccessForDirectRead( pParam->m_nSizeInBytes ), pParam->m_nSizeInBytes, 0, k_EUGCRead_Close );
+#else
+		int32 nBytesRead = SteamRemoteStorage()->UGCRead( pParam->m_hFile, buf.AccessForDirectRead( pParam->m_nSizeInBytes ), pParam->m_nSizeInBytes, 0, k_EUGCRead_Close );
+#endif
 		Assert( nBytesRead == pParam->m_nSizeInBytes );
 		buf.SeekPut( CUtlBuffer::SEEK_HEAD, nBytesRead );
 
@@ -2127,13 +2235,21 @@ void MainMenu::OnWorkshopPreviewImage( RemoteStorageDownloadUGCResult_t *pParam,
 	Assert( !"unexpected workshop preview image handle on main menu" );
 
 	// kill the file handle anyway
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamRemoteStorage()->UGCRead( pParam->m_hFile, NULL, 0, 0, k_EUGCRead_Close );
+#else
+	SteamRemoteStorage()->UGCRead( pParam->m_hFile, NULL, 0, 0, k_EUGCRead_Close );
+#endif
 }
 
 #ifndef _X360
 CON_COMMAND_F( openserverbrowser, "Opens server browser", 0 )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	bool isSteam = IsPC() && SteamFriends() && SteamUtils();
+#else
+	bool isSteam = IsPC() && SteamFriends() && SteamUtils();
+#endif
 	if ( isSteam )
 	{
 		if ( !ui_old_server_browser.GetBool() )

--- a/src/game/client/swarm/gameui/swarm/vmainmenu.h
+++ b/src/game/client/swarm/gameui/swarm/vmainmenu.h
@@ -120,9 +120,21 @@ public:
 	HUDGlowHelper_t m_InactiveHideQuickJoinFriends;
 	float m_flLastActiveTime;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<MainMenu, LeaderboardScoresDownloaded_t> m_HoIAFTop10Callback;
+#else
+	CCallResult<MainMenu, LeaderboardScoresDownloaded_t> m_HoIAFTop10Callback;
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<MainMenu, SteamUGCQueryCompleted_t> m_WorkshopTrendingItemsCallback;
+#else
+	CCallResult<MainMenu, SteamUGCQueryCompleted_t> m_WorkshopTrendingItemsCallback;
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<MainMenu, RemoteStorageDownloadUGCResult_t> m_WorkshopPreviewImageCallback[5];
+#else
+	CCallResult<MainMenu, RemoteStorageDownloadUGCResult_t> m_WorkshopPreviewImageCallback[5];
+#endif
 
 	void OnHoIAFTop10ScoresDownloaded( LeaderboardScoresDownloaded_t *pParam, bool bIOFailure );
 	void OnWorkshopTrendingItems( SteamUGCQueryCompleted_t *pParam, bool bIOFailure );

--- a/src/game/client/swarm/gameui/swarm/vpromooptin.cpp
+++ b/src/game/client/swarm/gameui/swarm/vpromooptin.cpp
@@ -26,7 +26,11 @@ static class CRD_PromoOptIn
 public:
 	void BeginRequest()
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUser *pUser = SteamUser();
+#else
+		ISteamUser *pUser = SteamUser();
+#endif
 		Assert( pUser );
 		if ( !pUser )
 		{
@@ -37,7 +41,11 @@ public:
 
 		CUIGameData::Get()->OpenWaitScreen( "#rd_redeem_special_waiting_steam" );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hAuthTicket = pUser->GetAuthTicketForWebApi( "redeem_special_4034" );
+#else
+		m_hAuthTicket = pUser->GetAuthTicketForWebApi( "redeem_special_4034" );
+#endif
 	}
 
 	void ShowMessage( const char *szMessage )
@@ -62,7 +70,11 @@ public:
 		pConfirmation->SetUsageData( data );
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_PromoOptIn, OnTicket, GetTicketForWebApiResponse_t )
+#else
+	STEAM_CALLBACK( CRD_PromoOptIn, OnTicket, GetTicketForWebApiResponse_t )
+#endif
 	{
 		if ( pParam->m_hAuthTicket != m_hAuthTicket )
 			return;
@@ -79,7 +91,11 @@ public:
 		char szHexTicket[sizeof( pParam->m_rgubTicket ) * 2 + 1];
 		UTIL_RD_BinToHex( pParam->m_rgubTicket, pParam->m_cubTicket, szHexTicket, sizeof( szHexTicket ) );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamHTTP *pHTTP = SteamHTTP();
+#else
+		ISteamHTTP *pHTTP = SteamHTTP();
+#endif
 		Assert( pHTTP );
 		if ( !pHTTP )
 		{
@@ -88,12 +104,32 @@ public:
 			return;
 		}
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		HTTPRequestHandle hRequest = pHTTP->CreateHTTPRequest( k_EHTTPMethodPOST, "https://stats.reactivedrop.com/api/redeem_special" );
+		#else
+		HTTPRequestHandle hRequest = pHTTP->CreateHTTPRequest( k_EHTTPMethodPOST, "https://stats.reactivedrop.com/api/redeem_special" );
+		#endif
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pHTTP->SetHTTPRequestUserAgentInfo( hRequest, "RDPromoOptIn" );
+		#else
+		pHTTP->SetHTTPRequestUserAgentInfo( hRequest, "RDPromoOptIn" );
+		#endif
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pHTTP->SetHTTPRequestGetOrPostParameter( hRequest, "itemid", "4034" );
+		#else
+		pHTTP->SetHTTPRequestGetOrPostParameter( hRequest, "itemid", "4034" );
+		#endif
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pHTTP->SetHTTPRequestGetOrPostParameter( hRequest, "ticket", szHexTicket );
+		#else
+		pHTTP->SetHTTPRequestGetOrPostParameter( hRequest, "ticket", szHexTicket );
+		#endif
 		SteamAPICall_t hCall = k_uAPICallInvalid;
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pHTTP->SendHTTPRequest( hRequest, &hCall ) )
+		#else
+		if ( pHTTP->SendHTTPRequest( hRequest, &hCall ) )
+		#endif
 		{
 			m_HTTPComplete.Set( hCall, this, &CRD_PromoOptIn::OnHTTPComplete );
 
@@ -115,7 +151,11 @@ public:
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamHTTP *pHTTP = SteamHTTP();
+#else
+		ISteamHTTP *pHTTP = SteamHTTP();
+#endif
 		Assert( pHTTP );
 		if ( !pHTTP )
 		{
@@ -128,7 +168,11 @@ public:
 		{
 			Warning( "Network failure! Cannot request opt-in!\n" );
 			ShowMessage( "#rd_redeem_special_error" );
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+			#else
+			pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+			#endif
 			return;
 		}
 
@@ -136,7 +180,11 @@ public:
 		{
 			Warning( "Server returned wrong status code %d! Cannot request opt-in!\n", pParam->m_eStatusCode );
 			ShowMessage( "#rd_redeem_special_error" );
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+			#else
+			pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+			#endif
 			return;
 		}
 
@@ -145,12 +193,24 @@ public:
 		{
 			Warning( "Body size (%d) too big! Cannot request opt-in!\n", pParam->m_unBodySize );
 			ShowMessage( "#rd_redeem_special_error" );
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+			#else
+			pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+			#endif
 			return;
 		}
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pHTTP->GetHTTPResponseBodyData( pParam->m_hRequest, ( uint8 * )szMessage, pParam->m_unBodySize );
+		#else
+		pHTTP->GetHTTPResponseBodyData( pParam->m_hRequest, ( uint8 * )szMessage, pParam->m_unBodySize );
+		#endif
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+		#else
+		pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+		#endif
 
 		szMessage[pParam->m_unBodySize] = '\0';
 		if ( pParam->m_unBodySize && szMessage[pParam->m_unBodySize - 1] == '\n' )
@@ -163,7 +223,11 @@ public:
 	}
 
 	HAuthTicket m_hAuthTicket{ k_HAuthTicketInvalid };
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CRD_PromoOptIn, HTTPRequestCompleted_t> m_HTTPComplete;
+#else
+	CCallResult<CRD_PromoOptIn, HTTPRequestCompleted_t> m_HTTPComplete;
+#endif
 } s_RD_PromoOptIn;
 #endif
 
@@ -184,7 +248,11 @@ PromoOptIn::PromoOptIn( Panel *parent, const char *panelName ) :
 
 #if 0
 	wchar_t wszPlayerName[k_cwchPersonaNameMax + 1];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	V_UTF8ToUnicode( SteamFriends() ? SteamFriends()->GetPersonaName() : "", wszPlayerName, sizeof( wszPlayerName ) );
+#else
+	V_UTF8ToUnicode( SteamFriends() ? SteamFriends()->GetPersonaName() : "", wszPlayerName, sizeof( wszPlayerName ) );
+#endif
 	wchar_t wszFlavor[4096];
 	g_pVGuiLocalize->ConstructString( wszFlavor, sizeof( wszFlavor ), g_pVGuiLocalize->Find( "#rd_crafting_beta2_signup_flavor" ), 1, wszPlayerName );
 	m_pLblFlavor = new MultiFontRichText( this, "LblFlavor" );
@@ -193,7 +261,11 @@ PromoOptIn::PromoOptIn( Panel *parent, const char *panelName ) :
 	m_pLblFlavor->InsertString( wszFlavor );
 
 	m_pLblFlavor->InsertZbalermornaString( "\ndoi li'ai " );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	AccountID_t iAccount = SteamUser() ? SteamUser()->GetSteamID().GetAccountID() : 0;
+#else
+	AccountID_t iAccount = SteamUser() ? SteamUser()->GetSteamID().GetAccountID() : 0;
+#endif
 	m_pLblFlavor->InsertString( UTIL_RD_ZbalermornaNumberHex( iAccount ) );
 	m_pLblFlavor->InsertZbalermornaString( " jatna i xu do sidju i do ba penmi lo derxi" );
 

--- a/src/game/client/swarm/gameui/swarm/vquickjoinpublic.cpp
+++ b/src/game/client/swarm/gameui/swarm/vquickjoinpublic.cpp
@@ -81,16 +81,27 @@ void QuickJoinPublicPanel::AddServersToList( void )
 		V_UTF8ToUnicode( g_ReactiveDropServerList.m_PublicServers.GetName( iServer ), m_FriendInfo[iInfo].m_wszName, sizeof( m_FriendInfo[iInfo].m_wszName ) );
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( ISteamMatchmaking *pMatchmaking = SteamMatchmaking() )
+#else
+	if ( ISteamMatchmaking *pMatchmaking = SteamMatchmaking() )
+#endif
 	{
 		int nLobbies = 0;
 		FOR_EACH_VEC( g_ReactiveDropServerList.m_PublicLobbies.m_MatchingLobbies, i )
 		{
 			// skip lobbies on dedicated servers in the count
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( !V_strcmp( pMatchmaking->GetLobbyData( g_ReactiveDropServerList.m_PublicLobbies.m_MatchingLobbies[i], "options:server" ), "listen" ) )
 			{
 				nLobbies++;
 			}
+#else
+			if ( !V_strcmp( pMatchmaking->GetLobbyData( g_ReactiveDropServerList.m_PublicLobbies.m_MatchingLobbies[i], "options:server" ), "listen" ) )
+			{
+				nLobbies++;
+			}
+#endif
 		}
 
 		if ( nLobbies > 0 )

--- a/src/game/client/swarm/gameui/swarm/vreportproblem.cpp
+++ b/src/game/client/swarm/gameui/swarm/vreportproblem.cpp
@@ -472,9 +472,17 @@ public:
 
 		m_pImgAvatar->SetAvatarBySteamID( &steamID );
 		wchar_t wszPlayerName[k_cwchPersonaNameMax + 1];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( ISteamFriends *pFriends = SteamFriends() )
+#else
+		if ( ISteamFriends *pFriends = SteamFriends() )
+#endif
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			V_UTF8ToUnicode( pFriends->GetFriendPersonaName( steamID ), wszPlayerName, sizeof( wszPlayerName ) );
+#else
+			V_UTF8ToUnicode( pFriends->GetFriendPersonaName( steamID ), wszPlayerName, sizeof( wszPlayerName ) );
+#endif
 		}
 		else
 		{
@@ -534,9 +542,17 @@ void ReportProblem::ResumeInProgressReport()
 
 		m_pImgPlayerAvatar->SetAvatarBySteamID( &s_RD_Current_Report.Player );
 		wchar_t wszPlayerName[k_cwchPersonaNameMax + 1];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( ISteamFriends *pFriends = SteamFriends() )
+#else
+		if ( ISteamFriends *pFriends = SteamFriends() )
+#endif
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			V_UTF8ToUnicode( pFriends->GetFriendPersonaName( s_RD_Current_Report.Player ), wszPlayerName, sizeof( wszPlayerName ) );
+#else
+			V_UTF8ToUnicode( pFriends->GetFriendPersonaName( s_RD_Current_Report.Player ), wszPlayerName, sizeof( wszPlayerName ) );
+#endif
 		}
 		else
 		{

--- a/src/game/client/swarm/rd_collections_crafting.cpp
+++ b/src/game/client/swarm/rd_collections_crafting.cpp
@@ -854,7 +854,11 @@ void CRD_Crafting_Panel::UpdateCraftState()
 			m_pGridOutputs->AddItemDef( m_SelectedRecipeOutput, 1, false );
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUser() && SteamUser()->BLoggedOn() )
+#else
+		if ( SteamUser() && SteamUser()->BLoggedOn() )
+#endif
 		{
 			m_pBtnCraft->SetText( "#rd_crafting_submit_ready" );
 			m_pBtnCraft->SetEnabled( true );

--- a/src/game/client/swarm/rd_collections_crafting.h
+++ b/src/game/client/swarm/rd_collections_crafting.h
@@ -100,11 +100,19 @@ public:
 	int m_iSelectedRecipe;
 	int m_iLastFullInventoryUpdates;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Crafting_Panel, OnSteamServersConnected, SteamServersConnected_t )
 	{
 		// Automatically transition from "you can't craft because you're offline" to "crafting is ready", but don't care about the other way around (the crafting attempt will simply result in an error).
 		UpdateCraftState();
 	}
+#else
+	STEAM_CALLBACK( CRD_Crafting_Panel, OnSteamServersConnected, SteamServersConnected_t )
+	{
+		// Automatically transition from "you can't craft because you're offline" to "crafting is ready", but don't care about the other way around (the crafting attempt will simply result in an error).
+		UpdateCraftState();
+	}
+#endif
 };
 
 namespace BaseModUI

--- a/src/game/client/swarm/rd_collections_crafting_research.cpp
+++ b/src/game/client/swarm/rd_collections_crafting_research.cpp
@@ -49,11 +49,19 @@ CRD_Crafting_Research_Panel::~CRD_Crafting_Research_Panel()
 
 	if ( m_hGetStateRequest != INVALID_HTTPREQUEST_HANDLE )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamHTTP *pSteamHTTP = SteamHTTP();
+		#else
+		ISteamHTTP *pSteamHTTP = SteamHTTP();
+		#endif
 		Assert( pSteamHTTP );
 		if ( pSteamHTTP )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamHTTP->ReleaseHTTPRequest( m_hGetStateRequest );
+#else
+			pSteamHTTP->ReleaseHTTPRequest( m_hGetStateRequest );
+#endif
 		}
 	}
 }
@@ -171,7 +179,11 @@ void CRD_Crafting_Research_Panel::ShowError( const char *szError )
 
 void CRD_Crafting_Research_Panel::RequestResearchState()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUser *pSteamUser = SteamUser();
+#else
+	ISteamUser *pSteamUser = SteamUser();
+#endif
 	Assert( pSteamUser );
 	if ( !pSteamUser )
 	{
@@ -181,7 +193,11 @@ void CRD_Crafting_Research_Panel::RequestResearchState()
 	}
 
 	// prove our identity to the server to get our personal contribution to the crafting project (this isn't stored or used for any other purpose)
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_hGetStateAuth = pSteamUser->GetAuthTicketForWebApi( "ocm_research_get_state" );
+#else
+	m_hGetStateAuth = pSteamUser->GetAuthTicketForWebApi( "ocm_research_get_state" );
+#endif
 }
 
 void CRD_Crafting_Research_Panel::OnGetTicketForWebApiResponse( GetTicketForWebApiResponse_t *pParam )
@@ -198,7 +214,11 @@ void CRD_Crafting_Research_Panel::OnGetTicketForWebApiResponse( GetTicketForWebA
 			return;
 		}
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamHTTP *pSteamHTTP = SteamHTTP();
+		#else
+		ISteamHTTP *pSteamHTTP = SteamHTTP();
+		#endif
 		Assert( pSteamHTTP );
 		if ( !pSteamHTTP )
 		{
@@ -210,12 +230,32 @@ void CRD_Crafting_Research_Panel::OnGetTicketForWebApiResponse( GetTicketForWebA
 		char szHexTicket[sizeof( pParam->m_rgubTicket ) * 2 + 1];
 		UTIL_RD_BinToHex( pParam->m_rgubTicket, pParam->m_cubTicket, szHexTicket, sizeof( szHexTicket ) );
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hGetStateRequest = pSteamHTTP->CreateHTTPRequest( k_EHTTPMethodPOST, "https://stats.reactivedrop.com/api/ocm-research/state.bin" );
+		#else
+		m_hGetStateRequest = pSteamHTTP->CreateHTTPRequest( k_EHTTPMethodPOST, "https://stats.reactivedrop.com/api/ocm-research/state.bin" );
+		#endif
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hGetStateRequest, "lang", SteamApps() ? SteamApps()->GetCurrentGameLanguage() : "" );
+		#else
+		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hGetStateRequest, "lang", SteamApps() ? SteamApps()->GetCurrentGameLanguage() : "" );
+		#endif
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hGetStateRequest, "ticket", szHexTicket );
+		#else
+		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hGetStateRequest, "ticket", szHexTicket );
+		#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestUserAgentInfo( m_hGetStateRequest, "CRD_Crafting_Research_Panel" );
+#else
+		pSteamHTTP->SetHTTPRequestUserAgentInfo( m_hGetStateRequest, "CRD_Crafting_Research_Panel" );
+#endif
 		SteamAPICall_t hAPICall = k_uAPICallInvalid;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SendHTTPRequest( m_hGetStateRequest, &hAPICall );
+#else
+		pSteamHTTP->SendHTTPRequest( m_hGetStateRequest, &hAPICall );
+#endif
 
 		m_OnGetStateRequestCompleted.Set( hAPICall, this, &CRD_Crafting_Research_Panel::OnGetStateRequestCompleted );
 
@@ -233,11 +273,19 @@ void CRD_Crafting_Research_Panel::OnGetStateRequestCompleted( HTTPRequestComplet
 		// don't refresh while the donate modal is open
 		m_flNextUpdateTime = Plat_FloatTime() + 60.0;
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !bIOFailure && SteamHTTP() )
+		#else
+		if ( !bIOFailure && SteamHTTP() )
+		#endif
 		{
 			Assert( m_hGetStateRequest == pParam->m_hRequest );
 			m_hGetStateRequest = INVALID_HTTPREQUEST_HANDLE;
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamHTTP()->ReleaseHTTPRequest( pParam->m_hRequest );
+			#else
+			SteamHTTP()->ReleaseHTTPRequest( pParam->m_hRequest );
+			#endif
 		}
 
 		return;
@@ -250,7 +298,11 @@ void CRD_Crafting_Research_Panel::OnGetStateRequestCompleted( HTTPRequestComplet
 		return;
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamHTTP *pSteamHTTP = SteamHTTP();
+	#else
+	ISteamHTTP *pSteamHTTP = SteamHTTP();
+	#endif
 	Assert( pSteamHTTP );
 	if ( !pSteamHTTP )
 	{
@@ -266,7 +318,11 @@ void CRD_Crafting_Research_Panel::OnGetStateRequestCompleted( HTTPRequestComplet
 	{
 		Warning( "Could not connect to server! Cannot parse research state response.\n" );
 		ShowError( "#rd_crafting_research_error_connection" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 		return;
 	}
 
@@ -274,21 +330,37 @@ void CRD_Crafting_Research_Panel::OnGetStateRequestCompleted( HTTPRequestComplet
 	{
 		Warning( "Server returned error (%d)! Cannot parse research state response.\n", pParam->m_eStatusCode );
 		ShowError( "#rd_crafting_research_error_unknown" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 		return;
 	}
 
 	CUtlBuffer body{ 0, int( pParam->m_unBodySize ) };
 	body.SeekPut( CUtlBuffer::SEEK_HEAD, pParam->m_unBodySize );
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !pSteamHTTP->GetHTTPResponseBodyData( pParam->m_hRequest, ( uint8 * )body.Base(), pParam->m_unBodySize ) )
+	#else
+	if ( !pSteamHTTP->GetHTTPResponseBodyData( pParam->m_hRequest, ( uint8 * )body.Base(), pParam->m_unBodySize ) )
+	#endif
 	{
 		Warning( "Failed to get response body. Cannot parse research state response.\n" );
 		ShowError( "#rd_crafting_research_error_connection" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+	pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 
 	KeyValues::AutoDelete pKV( "RDRD" );
 	if ( !pKV->ReadAsBinary( body ) )
@@ -427,7 +499,11 @@ void CRD_Crafting_Research_Slot::UpdateTimer()
 	if ( !pSlot )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	RTime32 now = SteamUtils() ? SteamUtils()->GetServerRealTime() : std::time( nullptr );
+#else
+	RTime32 now = SteamUtils() ? SteamUtils()->GetServerRealTime() : std::time( nullptr );
+#endif
 
 	if ( pSlot->WaitUntil == 0 || pSlot->WaitUntil < now )
 	{
@@ -697,11 +773,19 @@ CRD_Crafting_Research_Donate_Modal::~CRD_Crafting_Research_Donate_Modal()
 {
 	if ( m_hDonateRequest != INVALID_HTTPREQUEST_HANDLE )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamHTTP *pSteamHTTP = SteamHTTP();
+		#else
+		ISteamHTTP *pSteamHTTP = SteamHTTP();
+		#endif
 		Assert( pSteamHTTP );
 		if ( pSteamHTTP )
 		{
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamHTTP->ReleaseHTTPRequest( m_hDonateRequest );
+			#else
+			pSteamHTTP->ReleaseHTTPRequest( m_hDonateRequest );
+			#endif
 		}
 	}
 }
@@ -738,7 +822,11 @@ void CRD_Crafting_Research_Donate_Modal::OnCommand( const char *szCommand )
 {
 	if ( !V_stricmp( szCommand, "ConfirmDonation" ) )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUser *pSteamUser = SteamUser();
+#else
+		ISteamUser *pSteamUser = SteamUser();
+#endif
 		Assert( pSteamUser );
 		if ( !pSteamUser )
 		{
@@ -750,7 +838,11 @@ void CRD_Crafting_Research_Donate_Modal::OnCommand( const char *szCommand )
 		}
 
 		// prove our identity to the server because we're going to edit our inventory (our Steam ID gets stored in the database in the record of the donation)
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hDonateAuth = pSteamUser->GetAuthTicketForWebApi( CFmtStr( "don8_%d_%d_%u_%d", m_iSelectedProjectID, m_iDonateComponentID, uint32_t( m_iDonateItemInstance ), m_iDonatedQuantity ) );
+#else
+		m_hDonateAuth = pSteamUser->GetAuthTicketForWebApi( CFmtStr( "don8_%d_%d_%u_%d", m_iSelectedProjectID, m_iDonateComponentID, uint32_t( m_iDonateItemInstance ), m_iDonatedQuantity ) );
+#endif
 		BaseModUI::CBaseModPanel::GetSingleton().PlayUISound( BaseModUI::UISOUND_ACCEPT );
 
 		m_pQuantitySlider->SetEnabled( false );
@@ -775,7 +867,11 @@ void CRD_Crafting_Research_Donate_Modal::OnGetTicketForWebApiResponse( GetTicket
 	{
 		m_hDonateAuth = k_HAuthTicketInvalid;
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamHTTP *pSteamHTTP = SteamHTTP();
+		#else
+		ISteamHTTP *pSteamHTTP = SteamHTTP();
+		#endif
 		Assert( pSteamHTTP );
 		if ( !pSteamHTTP )
 		{
@@ -789,15 +885,47 @@ void CRD_Crafting_Research_Donate_Modal::OnGetTicketForWebApiResponse( GetTicket
 		UTIL_RD_BinToHex( pParam->m_rgubTicket, pParam->m_cubTicket, szHexTicket, sizeof( szHexTicket ) );
 
 		Assert( m_hDonateRequest == INVALID_HTTPREQUEST_HANDLE );
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hDonateRequest = pSteamHTTP->CreateHTTPRequest( k_EHTTPMethodPOST, "https://stats.reactivedrop.com/api/ocm-research/donate" );
+		#else
+		m_hDonateRequest = pSteamHTTP->CreateHTTPRequest( k_EHTTPMethodPOST, "https://stats.reactivedrop.com/api/ocm-research/donate" );
+		#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hDonateRequest, "project", CFmtStr( "%d", m_iSelectedProjectID ) );
+#else
+		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hDonateRequest, "project", CFmtStr( "%d", m_iSelectedProjectID ) );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hDonateRequest, "order", CFmtStr( "%d", m_iDonateComponentID ) );
+#else
+		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hDonateRequest, "order", CFmtStr( "%d", m_iDonateComponentID ) );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hDonateRequest, "instance", CFmtStr( "%llu", m_iDonateItemInstance ) );
+#else
+		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hDonateRequest, "instance", CFmtStr( "%llu", m_iDonateItemInstance ) );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hDonateRequest, "quantity", CFmtStr( "%d", m_iDonatedQuantity ) );
+#else
+		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hDonateRequest, "quantity", CFmtStr( "%d", m_iDonatedQuantity ) );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hDonateRequest, "ticket", szHexTicket );
+#else
+		pSteamHTTP->SetHTTPRequestGetOrPostParameter( m_hDonateRequest, "ticket", szHexTicket );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestUserAgentInfo( m_hDonateRequest, "CRD_Crafting_Research_Donate_Modal" );
+#else
+		pSteamHTTP->SetHTTPRequestUserAgentInfo( m_hDonateRequest, "CRD_Crafting_Research_Donate_Modal" );
+#endif
 		SteamAPICall_t hAPICall = k_uAPICallInvalid;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SendHTTPRequest( m_hDonateRequest, &hAPICall );
+#else
+		pSteamHTTP->SendHTTPRequest( m_hDonateRequest, &hAPICall );
+#endif
 
 		m_OnDonateRequestCompleted.Set( hAPICall, this, &CRD_Crafting_Research_Donate_Modal::OnDonateRequestCompleted );
 
@@ -822,7 +950,11 @@ void CRD_Crafting_Research_Donate_Modal::OnDonateRequestCompleted( HTTPRequestCo
 		return;
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamHTTP *pSteamHTTP = SteamHTTP();
+	#else
+	ISteamHTTP *pSteamHTTP = SteamHTTP();
+	#endif
 	Assert( pSteamHTTP );
 	if ( !pSteamHTTP )
 	{
@@ -838,7 +970,11 @@ void CRD_Crafting_Research_Donate_Modal::OnDonateRequestCompleted( HTTPRequestCo
 	if ( !pParam->m_bRequestSuccessful )
 	{
 		Warning( "Could not connect to server! Cannot check donation result.\n" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 		m_pParent->ShowError( "#rd_crafting_research_error_connection" );
 		MarkForDeletion();
 		return;
@@ -846,7 +982,11 @@ void CRD_Crafting_Research_Donate_Modal::OnDonateRequestCompleted( HTTPRequestCo
 
 	if ( pParam->m_eStatusCode == k_EHTTPStatusCode202Accepted )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 		m_pParent->ShowError( "#rd_crafting_research_donation_success" );
 		ReactiveDropInventory::RequestFullInventoryRefresh();
 		MarkForDeletion();
@@ -857,16 +997,28 @@ void CRD_Crafting_Research_Donate_Modal::OnDonateRequestCompleted( HTTPRequestCo
 	{
 		CUtlBuffer body{ 0, int( pParam->m_unBodySize ) };
 		body.SeekPut( CUtlBuffer::SEEK_HEAD, pParam->m_unBodySize );
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pSteamHTTP->GetHTTPResponseBodyData( pParam->m_hRequest, ( uint8 * )body.Base(), pParam->m_unBodySize ) )
+		#else
+		if ( !pSteamHTTP->GetHTTPResponseBodyData( pParam->m_hRequest, ( uint8 * )body.Base(), pParam->m_unBodySize ) )
+		#endif
 		{
 			Warning( "Failed to get response body. Cannot check donation result.\n" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+			pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 			m_pParent->ShowError( "#rd_crafting_research_error_connection" );
 			MarkForDeletion();
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 
 		if ( !V_strnicmp( ( char * )body.Base(), "INVENTORY\n", pParam->m_unBodySize ) )
 		{
@@ -885,7 +1037,11 @@ void CRD_Crafting_Research_Donate_Modal::OnDonateRequestCompleted( HTTPRequestCo
 	}
 	else
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+		#else
+		pSteamHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+		#endif
 	}
 
 	Warning( "Donation request returned HTTP status code %d.\n", pParam->m_eStatusCode );

--- a/src/game/client/swarm/rd_collections_crafting_research.h
+++ b/src/game/client/swarm/rd_collections_crafting_research.h
@@ -37,13 +37,21 @@ public:
 
 	void ShowError( const char *szError );
 	void RequestResearchState();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Crafting_Research_Panel, OnGetTicketForWebApiResponse, GetTicketForWebApiResponse_t );
+#else
+	STEAM_CALLBACK( CRD_Crafting_Research_Panel, OnGetTicketForWebApiResponse, GetTicketForWebApiResponse_t );
+#endif
 	void OnGetStateRequestCompleted( HTTPRequestCompleted_t *pParam, bool bIOFailure );
 
 	CRD_Collection_Tab_Crafting_Research *m_pParent = nullptr;
 	HAuthTicket m_hGetStateAuth = k_HAuthTicketInvalid;
 	HTTPRequestHandle m_hGetStateRequest = INVALID_HTTPREQUEST_HANDLE;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CRD_Crafting_Research_Panel, HTTPRequestCompleted_t> m_OnGetStateRequestCompleted;
+#else
+	CCallResult<CRD_Crafting_Research_Panel, HTTPRequestCompleted_t> m_OnGetStateRequestCompleted;
+#endif
 
 	vgui::DHANDLE<CRD_Crafting_Research_Donate_Modal> m_hDonateModal;
 	vgui::Label *m_pLblUpdateTimer;
@@ -141,14 +149,22 @@ public:
 	void ApplySchemeSettings( vgui::IScheme *pScheme ) override;
 	void OnCommand( const char *szCommand ) override;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Crafting_Research_Donate_Modal, OnGetTicketForWebApiResponse, GetTicketForWebApiResponse_t );
+#else
+	STEAM_CALLBACK( CRD_Crafting_Research_Donate_Modal, OnGetTicketForWebApiResponse, GetTicketForWebApiResponse_t );
+#endif
 	void OnDonateRequestCompleted( HTTPRequestCompleted_t *pParam, bool bIOFailure );
 	MESSAGE_FUNC_PTR( OnCurrentOptionChanged, "CurrentOptionChanged", panel );
 
 	CRD_Crafting_Research_Panel *m_pParent = nullptr;
 	HAuthTicket m_hDonateAuth = k_HAuthTicketInvalid;
 	HTTPRequestHandle m_hDonateRequest = INVALID_HTTPREQUEST_HANDLE;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CRD_Crafting_Research_Donate_Modal, HTTPRequestCompleted_t> m_OnDonateRequestCompleted;
+#else
+	CCallResult<CRD_Crafting_Research_Donate_Modal, HTTPRequestCompleted_t> m_OnDonateRequestCompleted;
+#endif
 
 	int m_iSelectedProjectID = 0;
 	int m_iDonateComponentID = 0;

--- a/src/game/client/swarm/rd_collections_equipment.cpp
+++ b/src/game/client/swarm/rd_collections_equipment.cpp
@@ -370,7 +370,11 @@ void CRD_Collection_Details_Equipment::DisplayEntry( TGD_Entry *pEntry )
 
 		if ( rd_swarmopedia_global_stat_window_days.GetInt() >= 0 && g_ASW_Steamstats.AreGlobalStatsReady() )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			Assert( SteamUserStats() );
+#else
+			Assert( SteamUserStats() );
+#endif
 
 			wchar_t wszDays[4]{};
 			V_snwprintf( wszDays, ARRAYSIZE( wszDays ), L"%d", rd_swarmopedia_global_stat_window_days.GetInt() );
@@ -388,11 +392,19 @@ void CRD_Collection_Details_Equipment::DisplayEntry( TGD_Entry *pEntry )
 				int64 nStat[61]{};
 				if ( rd_swarmopedia_global_stat_window_days.GetInt() == 0 )
 				{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					nOK = SteamUserStats()->GetGlobalStat( pWeapon->GlobalStats[i]->StatName, &nStat[1] ) ? 1 : 0;
+#else
+					nOK = SteamUserStats()->GetGlobalStat( pWeapon->GlobalStats[i]->StatName, &nStat[1] ) ? 1 : 0;
+#endif
 				}
 				else
 				{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					nOK = SteamUserStats()->GetGlobalStatHistory( pWeapon->GlobalStats[i]->StatName, &nStat[1], sizeof( nStat ) - sizeof( nStat[0] ) );
+#else
+					nOK = SteamUserStats()->GetGlobalStatHistory( pWeapon->GlobalStats[i]->StatName, &nStat[1], sizeof( nStat ) - sizeof( nStat[0] ) );
+#endif
 				}
 
 				for ( int j = 1; j <= nOK; j++ )

--- a/src/game/client/swarm/rd_collections_swarmopedia.cpp
+++ b/src/game/client/swarm/rd_collections_swarmopedia.cpp
@@ -155,7 +155,11 @@ void CRD_Collection_Details_Swarmopedia::DisplayEntry( TGD_Entry *pEntry )
 		{
 			m_pLblError->SetText( L"" );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			Assert( SteamUserStats() );
+#else
+			Assert( SteamUserStats() );
+#endif
 
 			wchar_t wszDays[4]{};
 			V_snwprintf( wszDays, ARRAYSIZE( wszDays ), L"%d", rd_swarmopedia_global_stat_window_days.GetInt() );
@@ -173,11 +177,19 @@ void CRD_Collection_Details_Swarmopedia::DisplayEntry( TGD_Entry *pEntry )
 				int64 nStat[61]{};
 				if ( rd_swarmopedia_global_stat_window_days.GetInt() == 0 )
 				{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					nOK = SteamUserStats()->GetGlobalStat( pAlien->GlobalStats[i]->StatName, &nStat[1] ) ? 1 : 0;
+#else
+					nOK = SteamUserStats()->GetGlobalStat( pAlien->GlobalStats[i]->StatName, &nStat[1] ) ? 1 : 0;
+#endif
 				}
 				else
 				{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					nOK = SteamUserStats()->GetGlobalStatHistory( pAlien->GlobalStats[i]->StatName, &nStat[1], sizeof( nStat ) - sizeof( nStat[0] ) );
+#else
+					nOK = SteamUserStats()->GetGlobalStatHistory( pAlien->GlobalStats[i]->StatName, &nStat[1], sizeof( nStat ) - sizeof( nStat[0] ) );
+#endif
 				}
 
 				for ( int j = 1; j <= nOK; j++ )

--- a/src/game/client/swarm/rd_inventory_description.cpp
+++ b/src/game/client/swarm/rd_inventory_description.cpp
@@ -18,7 +18,11 @@ void ReactiveDropInventory::ItemInstance_t::FormatDescription( wchar_t *wszBuf, 
 	if ( bIsSteamCommunityDesc && DynamicProps.GetNumStrings() == 0 )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInventory *pInventory = SteamInventory();
+#else
+	ISteamInventory *pInventory = SteamInventory();
+#endif
 	Assert( pInventory );
 	if ( !pInventory )
 		return;

--- a/src/game/client/swarm/rd_inventory_icon.cpp
+++ b/src/game/client/swarm/rd_inventory_icon.cpp
@@ -20,15 +20,27 @@ public:
 		char szDebugName[512];
 		V_snprintf( szDebugName, sizeof( szDebugName ), "inventory item icon %s", szURL );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamHTTP *pHTTP = SteamHTTP();
+#else
+		ISteamHTTP *pHTTP = SteamHTTP();
+#endif
 		Assert( pHTTP );
 		if ( pHTTP )
 		{
 			// The medal images send a Cache-Control header of "public, max-age=315569520" (1 decade).
 			// The Steam API will automatically cache stuff for us, so we don't have to manage cache ourselves.
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			HTTPRequestHandle hRequest = pHTTP->CreateHTTPRequest( k_EHTTPMethodGET, szURL );
+			#else
+			HTTPRequestHandle hRequest = pHTTP->CreateHTTPRequest( k_EHTTPMethodGET, szURL );
+			#endif
 			SteamAPICall_t hAPICall;
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( pHTTP->SendHTTPRequest( hRequest, &hAPICall ) )
+			#else
+			if ( pHTTP->SendHTTPRequest( hRequest, &hAPICall ) )
+			#endif
 			{
 				m_szDebugName = strdup( szDebugName );
 				m_HTTPRequestCompleted.Set( hAPICall, this, &CSteamItemIcon::OnRequestCompleted );
@@ -66,7 +78,11 @@ private:
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamHTTP *pHTTP = SteamHTTP();
+#else
+		ISteamHTTP *pHTTP = SteamHTTP();
+#endif
 		Assert( pHTTP );
 		if ( !pHTTP )
 		{
@@ -82,19 +98,31 @@ private:
 		}
 
 		CUtlMemory<uint8_t> data( 0, pParam->m_unBodySize );
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pHTTP->GetHTTPResponseBodyData( pParam->m_hRequest, data.Base(), pParam->m_unBodySize ) )
+		#else
+		if ( !pHTTP->GetHTTPResponseBodyData( pParam->m_hRequest, data.Base(), pParam->m_unBodySize ) )
+		#endif
 		{
 			Warning( "Failed to get inventory item icon from successful request. Programmer error?\n" );
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+		pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 
 		OnPNGDataReady( data.Base(), pParam->m_unBodySize, m_szDebugName );
 		free( m_szDebugName );
 		m_szDebugName = NULL;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CSteamItemIcon, HTTPRequestCompleted_t> m_HTTPRequestCompleted;
+#else
+	CCallResult<CSteamItemIcon, HTTPRequestCompleted_t> m_HTTPRequestCompleted;
+#endif
 };
 
 vgui::IImage *GetSteamItemIcon( const char *szURL, bool bForceLoadRemote )
@@ -170,7 +198,11 @@ CON_COMMAND_F( rd_load_all_inventory_defs, "load data and icons for all defined 
 	// 900000000 <= id <= 999999999 - "unique" items; one copy of each exists (this is an AS:RD restriction, not an inventory service one). IDs are consecutive.
 	// 1000000000 <= id - Steam internal reserved ID range.
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInventory *pInventory = SteamInventory();
+#else
+	ISteamInventory *pInventory = SteamInventory();
+#endif
 	Assert( pInventory );
 	if ( !pInventory )
 	{
@@ -179,9 +211,17 @@ CON_COMMAND_F( rd_load_all_inventory_defs, "load data and icons for all defined 
 	}
 
 	uint32_t nItemDefCount{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pInventory->GetItemDefinitionIDs( NULL, &nItemDefCount );
+#else
+	pInventory->GetItemDefinitionIDs( NULL, &nItemDefCount );
+#endif
 	CUtlMemory<SteamItemDef_t> DefIDs{ 0, int( nItemDefCount ) };
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	bool bOK = pInventory->GetItemDefinitionIDs( DefIDs.Base(), &nItemDefCount );
+#else
+	bool bOK = pInventory->GetItemDefinitionIDs( DefIDs.Base(), &nItemDefCount );
+#endif
 	Assert( bOK ); ( void )bOK;
 
 	Msg( "Checking %d item defs...\n", nItemDefCount );
@@ -207,14 +247,26 @@ CON_COMMAND_F( rd_load_all_inventory_defs, "load data and icons for all defined 
 		}
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hCall = pInventory->RequestPrices();
+#else
+	SteamAPICall_t hCall = pInventory->RequestPrices();
+#endif
 	bool bFailed{};
 	SteamInventoryRequestPricesResult_t param{};
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	while ( !SteamUtils()->GetAPICallResult( hCall, &param, sizeof( param ), param.k_iCallback, &bFailed ) )
 	{
 		ThreadSleep( 10 );
 		SteamAPI_RunCallbacks();
 	}
+	#else
+	while ( !SteamUtils()->GetAPICallResult( hCall, &param, sizeof( param ), param.k_iCallback, &bFailed ) )
+	{
+		ThreadSleep( 10 );
+		SteamAPI_RunCallbacks();
+	}
+	#endif
 
 	if ( bFailed )
 	{
@@ -223,12 +275,32 @@ CON_COMMAND_F( rd_load_all_inventory_defs, "load data and icons for all defined 
 	}
 
 	DefIDs.Purge();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	DefIDs.EnsureCapacity( pInventory->GetNumItemsWithPrices() );
+#else
+	DefIDs.EnsureCapacity( pInventory->GetNumItemsWithPrices() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CUtlMemory<uint64_t> CurrentPrices{ 0, int( pInventory->GetNumItemsWithPrices() ) };
+#else
+	CUtlMemory<uint64_t> CurrentPrices{ 0, int( pInventory->GetNumItemsWithPrices() ) };
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CUtlMemory<uint64_t> BasePrices{ 0, int( pInventory->GetNumItemsWithPrices() ) };
+#else
+	CUtlMemory<uint64_t> BasePrices{ 0, int( pInventory->GetNumItemsWithPrices() ) };
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pInventory->GetItemsWithPrices( DefIDs.Base(), CurrentPrices.Base(), BasePrices.Base(), pInventory->GetNumItemsWithPrices() );
+#else
+	pInventory->GetItemsWithPrices( DefIDs.Base(), CurrentPrices.Base(), BasePrices.Base(), pInventory->GetNumItemsWithPrices() );
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Msg( "Checking %d store item defs...\n", pInventory->GetNumItemsWithPrices() );
+#else
+	Msg( "Checking %d store item defs...\n", pInventory->GetNumItemsWithPrices() );
+#endif
 	FOR_EACH_VEC( DefIDs, i )
 	{
 		const ReactiveDropInventory::ItemDef_t *pDef = ReactiveDropInventory::GetItemDef( DefIDs[i] );
@@ -253,7 +325,11 @@ CON_COMMAND_F( rd_load_all_inventory_defs, "load data and icons for all defined 
 	for ( SteamItemDef_t id = 900000000; ; id++ )
 	{
 		uint32_t count{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetItemDefinitionProperty( id, NULL, NULL, &count );
+#else
+		pInventory->GetItemDefinitionProperty( id, NULL, NULL, &count );
+#endif
 		if ( !count )
 		{
 			Msg( "Number of unique item defs: %d\n", id - 900000000 );

--- a/src/game/client/swarm/rd_player_reporting.cpp
+++ b/src/game/client/swarm/rd_player_reporting.cpp
@@ -243,10 +243,18 @@ bool CRD_Player_Reporting::RecentlyReportedPlayer( const char *szCategory, CStea
 {
 	if ( m_pRecentReports == NULL )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamUser() )
+#else
+		if ( !SteamUser() )
+#endif
 			return false;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		CFmtStr szFileName{ "cfg/clientrqpr_%llu.dat", SteamUser()->GetSteamID().ConvertToUint64() };
+#else
+		CFmtStr szFileName{ "cfg/clientrqpr_%llu.dat", SteamUser()->GetSteamID().ConvertToUint64() };
+#endif
 		CUtlBuffer buf;
 
 		m_pRecentReports.Assign( new KeyValues{ "RQPR" } );
@@ -257,12 +265,20 @@ bool CRD_Player_Reporting::RecentlyReportedPlayer( const char *szCategory, CStea
 	}
 
 	CFmtStr szKey{ "%s/%llu", szCategory, player.ConvertToUint64() };
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	return SteamUtils() && uint64_t( SteamUtils()->GetServerRealTime() ) - REPORTING_QUICK_TIMEOUT < m_pRecentReports->GetUint64( szKey );
+#else
+	return SteamUtils() && uint64_t( SteamUtils()->GetServerRealTime() ) - REPORTING_QUICK_TIMEOUT < m_pRecentReports->GetUint64( szKey );
+#endif
 }
 
 void CRD_Player_Reporting::GetRecentlyPlayedWith( CUtlVector<CSteamID> &players ) const
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CSteamID self = SteamUser() ? SteamUser()->GetSteamID() : k_steamIDNil;
+#else
+	CSteamID self = SteamUser() ? SteamUser()->GetSteamID() : k_steamIDNil;
+#endif
 	float flExpireTime = Plat_FloatTime() - REPORTING_SNAPSHOT_LIFETIME;
 
 	FOR_EACH_VEC_BACK( m_RecentData, i )
@@ -386,12 +402,24 @@ bool CRD_Player_Reporting::PrepareReportForSend( const char *szCategory, const c
 
 	V_strncpy( m_szLastCategory, szCategory, sizeof( m_szLastCategory ) );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUser *pSteamUser = SteamUser();
+#else
+	ISteamUser *pSteamUser = SteamUser();
+#endif
 	Assert( pSteamUser );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamHTTP() );
+#else
+	Assert( SteamHTTP() );
+#endif
 
 	// we need to be connected to a game and also Steam in order to send a player report.
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !pSteamUser || !SteamHTTP() )
+#else
+	if ( !pSteamUser || !SteamHTTP() )
+#endif
 	{
 		TryLocalize( "#rd_reporting_error_not_connected", m_wszLastMessage, sizeof( m_wszLastMessage ) );
 		LogProgressMessage();
@@ -408,7 +436,11 @@ bool CRD_Player_Reporting::PrepareReportForSend( const char *szCategory, const c
 		Assert( m_szQuickReport[0] == '\0' );
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_hTicket = pSteamUser->GetAuthTicketForWebApi( "playerreport" );
+#else
+	m_hTicket = pSteamUser->GetAuthTicketForWebApi( "playerreport" );
+#endif
 	TryLocalize( "#rd_reporting_wait_requesting_ticket", m_wszLastMessage, sizeof( m_wszLastMessage ) );
 	LogProgressMessage();
 
@@ -563,16 +595,33 @@ void CRD_Player_Reporting::OnGetTicketForWebApiResponse( GetTicketForWebApiRespo
 		WriteJSONHex( m_Buffer, CUtlBuffer{ pParam->m_rgubTicket, pParam->m_cubTicket, CUtlBuffer::READ_ONLY } );
 		WriteJSONRaw( m_Buffer, "}" );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamHTTP *pSteamHTTP = SteamHTTP();
+#else
+		ISteamHTTP *pSteamHTTP = SteamHTTP();
+#endif
 		Assert( pSteamHTTP );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		HTTPRequestHandle hRequest = pSteamHTTP->CreateHTTPRequest( k_EHTTPMethodPOST, "https://gamereport.reactivedrop.com/playerreport" );
+#else
+		HTTPRequestHandle hRequest = pSteamHTTP->CreateHTTPRequest( k_EHTTPMethodPOST, "https://gamereport.reactivedrop.com/playerreport" );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestUserAgentInfo( hRequest, "RDPlayerReporting" );
+#else
+		pSteamHTTP->SetHTTPRequestUserAgentInfo( hRequest, "RDPlayerReporting" );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamHTTP->SetHTTPRequestRawPostBody( hRequest, "application/json", static_cast< uint8 * >( m_Buffer.Base() ), m_Buffer.TellPut() );
+#else
+		pSteamHTTP->SetHTTPRequestRawPostBody( hRequest, "application/json", static_cast< uint8 * >( m_Buffer.Base() ), m_Buffer.TellPut() );
+#endif
 
 		m_Buffer.Purge();
 
 		SteamAPICall_t hCall = k_uAPICallInvalid;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pSteamHTTP->SendHTTPRequest( hRequest, &hCall ) )
 		{
 			// if we didn't get a valid request handle somehow, we'll end up here.
@@ -580,6 +629,15 @@ void CRD_Player_Reporting::OnGetTicketForWebApiResponse( GetTicketForWebApiRespo
 			LogProgressMessage();
 			return;
 		}
+#else
+		if ( !pSteamHTTP->SendHTTPRequest( hRequest, &hCall ) )
+		{
+			// if we didn't get a valid request handle somehow, we'll end up here.
+			TryLocalize( "#rd_reporting_error_sending_unknown", m_wszLastMessage, sizeof( m_wszLastMessage ) );
+			LogProgressMessage();
+			return;
+		}
+#endif
 
 		TryLocalize( "#rd_reporting_sending_report_to_server", m_wszLastMessage, sizeof( m_wszLastMessage ) );
 		m_HTTPRequestCompleted.Set( hCall, this, &CRD_Player_Reporting::OnHTTPRequestCompleted );
@@ -611,16 +669,28 @@ void CRD_Player_Reporting::OnHTTPRequestCompleted( HTTPRequestCompleted_t *pPara
 
 	if ( !pParam->m_bRequestSuccessful )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamHTTP()->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+		SteamHTTP()->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 		TryLocalize( "#rd_reporting_error_sending_network", m_wszLastMessage, sizeof( m_wszLastMessage ) );
 		LogProgressMessage();
 		return;
 	}
 
 	CUtlMemory<char> body{ 0, int( pParam->m_unBodySize ) + 1 };
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamHTTP()->GetHTTPResponseBodyData( pParam->m_hRequest, reinterpret_cast< uint8 * >( body.Base() ), body.Count() - 1 );
+#else
+	SteamHTTP()->GetHTTPResponseBodyData( pParam->m_hRequest, reinterpret_cast< uint8 * >( body.Base() ), body.Count() - 1 );
+#endif
 	body[pParam->m_unBodySize] = '\0';
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamHTTP()->ReleaseHTTPRequest( pParam->m_hRequest );
+#else
+	SteamHTTP()->ReleaseHTTPRequest( pParam->m_hRequest );
+#endif
 
 	Assert( pParam->m_eStatusCode == k_EHTTPStatusCode200OK );
 	( void )body; // potentially useful for debugging, not currently shown to user.
@@ -632,10 +702,22 @@ void CRD_Player_Reporting::OnHTTPRequestCompleted( HTTPRequestCompleted_t *pPara
 		{
 			RecentlyReportedPlayer( "", k_steamIDNil ); // call for side effect of initializing m_pRecentReports
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			Assert( SteamUtils() );
+#else
+			Assert( SteamUtils() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( m_pRecentReports != NULL && SteamUtils() )
+#else
+			if ( m_pRecentReports != NULL && SteamUtils() )
+#endif
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				uint64_t iNow = SteamUtils()->GetServerRealTime();
+#else
+				uint64_t iNow = SteamUtils()->GetServerRealTime();
+#endif
 				uint64_t iExpireBefore = iNow - REPORTING_QUICK_TIMEOUT;
 
 				FOR_EACH_SUBKEY( m_pRecentReports, pCategory )
@@ -657,7 +739,11 @@ void CRD_Player_Reporting::OnHTTPRequestCompleted( HTTPRequestCompleted_t *pPara
 				m_pRecentReports->SetUint64( m_szQuickReport, iNow );
 
 				CUtlBuffer buf;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				CFmtStr szFileName{ "cfg/clientrqpr_%llu.dat", SteamUser()->GetSteamID().ConvertToUint64() };
+#else
+				CFmtStr szFileName{ "cfg/clientrqpr_%llu.dat", SteamUser()->GetSteamID().ConvertToUint64() };
+#endif
 				if ( !m_pRecentReports->WriteAsBinary( buf ) )
 				{
 					Warning( "Failed to encode quick report cache\n" );
@@ -713,7 +799,11 @@ ReportingServerSnapshot_t *CRD_Player_Reporting::NewSnapshot() const
 	ReportingServerSnapshot_t *pSnapshot = new ReportingServerSnapshot_t();
 
 	pSnapshot->RecordedAt = Plat_FloatTime();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pSnapshot->SnapshotTaken = SteamUtils() ? SteamUtils()->GetServerRealTime() : 0;
+#else
+	pSnapshot->SnapshotTaken = SteamUtils() ? SteamUtils()->GetServerRealTime() : 0;
+#endif
 
 	extern ConVar rd_challenge;
 	char szChallengeFileName[MAX_PATH];

--- a/src/game/client/swarm/rd_player_reporting.h
+++ b/src/game/client/swarm/rd_player_reporting.h
@@ -67,8 +67,16 @@ private:
 	HAuthTicket m_hTicket{ k_HAuthTicketInvalid };
 	friend class BaseModUI::ReportProblem;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Player_Reporting, OnGetTicketForWebApiResponse, GetTicketForWebApiResponse_t );
+#else
+	STEAM_CALLBACK( CRD_Player_Reporting, OnGetTicketForWebApiResponse, GetTicketForWebApiResponse_t );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CRD_Player_Reporting, HTTPRequestCompleted_t> m_HTTPRequestCompleted;
+#else
+	CCallResult<CRD_Player_Reporting, HTTPRequestCompleted_t> m_HTTPRequestCompleted;
+#endif
 	void OnHTTPRequestCompleted( HTTPRequestCompleted_t *pParam, bool bIOFailure );
 
 	void LogProgressMessage();

--- a/src/game/client/swarm/rd_rich_presence.cpp
+++ b/src/game/client/swarm/rd_rich_presence.cpp
@@ -107,10 +107,18 @@ bool RD_Rich_Presence::Init()
 
 void RD_Rich_Presence::Shutdown()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pSteamFriends = SteamFriends();
+#else
+	ISteamFriends *pSteamFriends = SteamFriends();
+#endif
 	if ( pSteamFriends )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->ClearRichPresence();
+#else
+		pSteamFriends->ClearRichPresence();
+#endif
 	}
 
 #ifdef DISCORD_RICH_PRESENCE_ENABLED
@@ -134,7 +142,11 @@ void RD_Rich_Presence::Update( float frametime )
 
 void RD_Rich_Presence::UpdatePresence()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pSteamFriends = SteamFriends();
+#else
+	ISteamFriends *pSteamFriends = SteamFriends();
+#endif
 	if ( !pSteamFriends )
 		return;					// no friends, no fun
 
@@ -145,11 +157,31 @@ void RD_Rich_Presence::UpdatePresence()
 
 	if ( !engine->IsConnected() )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->SetRichPresence( "status", "Main Menu" );
+#else
+		pSteamFriends->SetRichPresence( "status", "Main Menu" );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->SetRichPresence( "connect", NULL );
+#else
+		pSteamFriends->SetRichPresence( "connect", NULL );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->SetRichPresence( "steam_display", "#Main_Menu" );
+#else
+		pSteamFriends->SetRichPresence( "steam_display", "#Main_Menu" );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->SetRichPresence( "steam_player_group", NULL );
+#else
+		pSteamFriends->SetRichPresence( "steam_player_group", NULL );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->SetRichPresence( "steam_player_group_size", NULL );
+#else
+		pSteamFriends->SetRichPresence( "steam_player_group_size", NULL );
+#endif
 
 #ifdef DISCORD_RICH_PRESENCE_ENABLED
 		discordPresence.largeImageKey = "default";
@@ -161,11 +193,31 @@ void RD_Rich_Presence::UpdatePresence()
 	}
 	else if ( engine->IsPlayingDemo() )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->SetRichPresence( "status", "Watching a Demo" );
+#else
+		pSteamFriends->SetRichPresence( "status", "Watching a Demo" );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->SetRichPresence( "connect", NULL );
+#else
+		pSteamFriends->SetRichPresence( "connect", NULL );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->SetRichPresence( "steam_display", "#Watching_a_Demo" );
+#else
+		pSteamFriends->SetRichPresence( "steam_display", "#Watching_a_Demo" );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->SetRichPresence( "steam_player_group", NULL );
+#else
+		pSteamFriends->SetRichPresence( "steam_player_group", NULL );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamFriends->SetRichPresence( "steam_player_group_size", NULL );
+#else
+		pSteamFriends->SetRichPresence( "steam_player_group_size", NULL );
+#endif
 
 #ifdef DISCORD_RICH_PRESENCE_ENABLED
 		discordPresence.largeImageKey = "default";
@@ -191,25 +243,53 @@ void RD_Rich_Presence::UpdatePresence()
 
 			static char szConnectString[40];
 			V_snprintf( szConnectString, sizeof( szConnectString ), "+connect_lobby %llu", currentLobby.ConvertToUint64() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamFriends->SetRichPresence( "steam_player_group", szCurrentLobbyID );
+#else
+			pSteamFriends->SetRichPresence( "steam_player_group", szCurrentLobbyID );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamFriends->SetRichPresence( "connect", szConnectString );
+#else
+			pSteamFriends->SetRichPresence( "connect", szConnectString );
+#endif
 #ifdef DISCORD_RICH_PRESENCE_ENABLED
 			discordPresence.partyId = szCurrentLobbyID;
 #endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			ISteamMatchmaking *pSteamMatchmaking = SteamMatchmaking();
+#else
+			ISteamMatchmaking *pSteamMatchmaking = SteamMatchmaking();
+#endif
 			if ( pSteamMatchmaking )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				int memberCount = pSteamMatchmaking->GetNumLobbyMembers( currentLobby );
+#else
+				int memberCount = pSteamMatchmaking->GetNumLobbyMembers( currentLobby );
+#endif
 				if ( pSteamFriends )
 				{
 					static char szGroupSize[4];
 					V_snprintf( szGroupSize, sizeof( szGroupSize ), "%d", memberCount );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pSteamFriends->SetRichPresence( "steam_player_group_size", szGroupSize );
+#else
+					pSteamFriends->SetRichPresence( "steam_player_group_size", szGroupSize );
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pSteamFriends->SetRichPresence( "num_players", szGroupSize );
+#else
+					pSteamFriends->SetRichPresence( "num_players", szGroupSize );
+#endif
 					V_snprintf( szGroupSize, sizeof( szGroupSize ), "%d", gpGlobals->maxClients );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pSteamFriends->SetRichPresence( "max_players", szGroupSize );
+#else
+					pSteamFriends->SetRichPresence( "max_players", szGroupSize );
+#endif
 				}
 #ifdef DISCORD_RICH_PRESENCE_ENABLED
 				discordPresence.partySize = memberCount;
@@ -224,7 +304,11 @@ void RD_Rich_Presence::UpdatePresence()
 			}
 			else if ( pSteamFriends )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "steam_player_group_size", NULL );
+#else
+				pSteamFriends->SetRichPresence( "steam_player_group_size", NULL );
+#endif
 			}
 		}
 		else if ( engine->IsConnected() && ASWGameResource() && ASWGameResource()->IsOfflineGame() )
@@ -239,11 +323,31 @@ void RD_Rich_Presence::UpdatePresence()
 
 			if ( pSteamFriends )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "connect", NULL );
+#else
+				pSteamFriends->SetRichPresence( "connect", NULL );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "steam_player_group", NULL );
+#else
+				pSteamFriends->SetRichPresence( "steam_player_group", NULL );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "steam_player_group_size", NULL );
+#else
+				pSteamFriends->SetRichPresence( "steam_player_group_size", NULL );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "num_players", "1" );
+#else
+				pSteamFriends->SetRichPresence( "num_players", "1" );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "max_players", "1" );
+#else
+				pSteamFriends->SetRichPresence( "max_players", "1" );
+#endif
 			}
 		}
 		else if ( engine->IsConnected() )
@@ -265,24 +369,44 @@ void RD_Rich_Presence::UpdatePresence()
 						static char szHostAdress[32];
 						V_strncpy( szHostAdress, pAddr, sizeof( szHostAdress ) );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 						pSteamFriends->SetRichPresence( "steam_player_group", szHostAdress );
+#else
+						pSteamFriends->SetRichPresence( "steam_player_group", szHostAdress );
+#endif
 #ifdef DISCORD_RICH_PRESENCE_ENABLED
 						discordPresence.partyId = szHostAdress;
 #endif 
 
 						static char szConnectString[40];
 						V_snprintf( szConnectString, sizeof( szConnectString ), "+connect %s", pAddr );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 						pSteamFriends->SetRichPresence( "connect", szConnectString );
+#else
+						pSteamFriends->SetRichPresence( "connect", szConnectString );
+#endif
 					}
 				}
 
 				static char szGroupSize[4];
 				V_snprintf( szGroupSize, sizeof( szGroupSize ), "%d", UTIL_ASW_GetNumPlayers() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "steam_player_group_size", szGroupSize );
+#else
+				pSteamFriends->SetRichPresence( "steam_player_group_size", szGroupSize );
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "num_players", szGroupSize );
+#else
+				pSteamFriends->SetRichPresence( "num_players", szGroupSize );
+#endif
 				V_snprintf( szGroupSize, sizeof( szGroupSize ), "%d", gpGlobals->maxClients );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "max_players", szGroupSize );
+#else
+				pSteamFriends->SetRichPresence( "max_players", szGroupSize );
+#endif
 			}
 		}
 
@@ -359,7 +483,11 @@ void RD_Rich_Presence::UpdatePresence()
 				{
 					V_strncpy( szMissionTranslationKey, "community_mission", sizeof( szMissionTranslationKey ) );
 				}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "rd_mission_key", szMissionTranslationKey );
+#else
+				pSteamFriends->SetRichPresence( "rd_mission_key", szMissionTranslationKey );
+#endif
 
 				static char szMissionName[128];
 				if ( wchar_t *pwszTranslatedMissionName = g_pLocalize->Find( STRING( pMission->MissionTitle ) ) )
@@ -370,7 +498,11 @@ void RD_Rich_Presence::UpdatePresence()
 				{
 					V_strncpy( szMissionName, STRING( pMission->MissionTitle ), sizeof( szMissionName ) );
 				}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamFriends->SetRichPresence( "rd_mission", szMissionName );
+#else
+				pSteamFriends->SetRichPresence( "rd_mission", szMissionName );
+#endif
 				V_strncpy( szLargeImageText, szMissionName, sizeof( szLargeImageText ) );
 
 				if ( !ASWDeathmatchMode() )
@@ -387,7 +519,11 @@ void RD_Rich_Presence::UpdatePresence()
 					case 4: szDifficulty = "Insane"; break;
 					case 5: szDifficulty = "Brutal"; break;
 					}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pSteamFriends->SetRichPresence( "rd_difficulty", szDifficulty );
+#else
+					pSteamFriends->SetRichPresence( "rd_difficulty", szDifficulty );
+#endif
 
 					// set challenge
 					if ( V_strcmp( rd_challenge.GetString(), "0" ) )
@@ -402,7 +538,11 @@ void RD_Rich_Presence::UpdatePresence()
 						{
 							V_strncpy( szChallengeTranslationKey, "community_challenge", sizeof( szChallengeTranslationKey ) );
 						}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 						pSteamFriends->SetRichPresence( "rd_challenge_key", szChallengeTranslationKey );
+#else
+						pSteamFriends->SetRichPresence( "rd_challenge_key", szChallengeTranslationKey );
+#endif
 
 						static char szChallengeName[128];
 						if ( wchar_t *pwszTranslatedChallengeName = g_pLocalize->Find( pszDisplayName ) )
@@ -413,7 +553,11 @@ void RD_Rich_Presence::UpdatePresence()
 						{
 							V_strncpy( szChallengeName, pszDisplayName, sizeof( szChallengeName ) );
 						}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 						pSteamFriends->SetRichPresence( "rd_challenge", szChallengeName );
+#else
+						pSteamFriends->SetRichPresence( "rd_challenge", szChallengeName );
+#endif
 						V_strncpy( szDetails, szChallengeName, sizeof( szDetails ) );
 						V_strcat( szDetails, " (", sizeof( szDetails ) );
 						V_strcat( szDetails, szDifficulty, sizeof( szDetails ) );
@@ -483,8 +627,16 @@ void RD_Rich_Presence::UpdatePresence()
 				discordPresence.largeImageKey = "default";
 			}
 #endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamFriends->SetRichPresence( "status", szDetails );
+#else
+			pSteamFriends->SetRichPresence( "status", szDetails );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamFriends->SetRichPresence( "steam_display", szSteamDisplay );
+#else
+			pSteamFriends->SetRichPresence( "steam_display", szSteamDisplay );
+#endif
 
 			CASW_Marine_Profile *pProfile = NULL;
 			if ( C_ASW_Marine *pMarine = C_ASW_Marine::AsMarine( pPlayer->GetNPC() ) )

--- a/src/game/client/swarm/rd_steam_input.cpp
+++ b/src/game/client/swarm/rd_steam_input.cpp
@@ -82,12 +82,20 @@ void CRD_Steam_Input::PostInit()
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInput *pSteamInput = SteamInput();
+#else
+	ISteamInput *pSteamInput = SteamInput();
+#endif
 	Assert( pSteamInput );
 	if ( !pSteamInput )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	bool bSuccess = pSteamInput->Init( true );
+#else
+	bool bSuccess = pSteamInput->Init( true );
+#endif
 	Assert( bSuccess );
 	if ( !bSuccess )
 		Warning( "ISteamInput::Init returned failure status\n" );
@@ -96,17 +104,41 @@ void CRD_Steam_Input::PostInit()
 	char szCWD[MAX_PATH];
 	V_GetCurrentDirectory( szCWD, sizeof( szCWD ) );
 	CUtlString szInputActionManifest = CUtlString::PathJoin( szCWD, "steam_input/steam_input_manifest.vdf" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	bSuccess = pSteamInput->SetInputActionManifestFilePath( szInputActionManifest );
+#else
+	bSuccess = pSteamInput->SetInputActionManifestFilePath( szInputActionManifest );
+#endif
 	if ( !bSuccess )
 		Warning( "ISteamInput::SetInputActionManifestFilePath returned failure status\n" );
 #endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pSteamInput->EnableDeviceCallbacks();
+#else
+	pSteamInput->EnableDeviceCallbacks();
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pSteamInput->EnableActionEventCallbacks( &OnActionEvent );
+#else
+	pSteamInput->EnableActionEventCallbacks( &OnActionEvent );
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 #define INIT_ACTION_SET( name ) { m_ActionSets.name = pSteamInput->GetActionSetHandle( #name ); Assert( !m_Controllers.Count() || m_ActionSets.name ); if ( m_Controllers.Count() && !m_ActionSets.name ) Warning( "Could not find Steam Input action set '%s'\n", #name ); }
+#else
+#define INIT_ACTION_SET( name ) { m_ActionSets.name = pSteamInput->GetActionSetHandle( #name ); Assert( !m_Controllers.Count() || m_ActionSets.name ); if ( m_Controllers.Count() && !m_ActionSets.name ) Warning( "Could not find Steam Input action set '%s'\n", #name ); }
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 #define INIT_ACTION_SET_LAYER( name ) { m_ActionSetLayers.name = pSteamInput->GetActionSetHandle( #name ); Assert( !m_Controllers.Count() || m_ActionSetLayers.name ); if ( m_Controllers.Count() && !m_ActionSetLayers.name ) Warning( "Could not find Steam Input action layer '%s'\n", #name ); }
+#else
+#define INIT_ACTION_SET_LAYER( name ) { m_ActionSetLayers.name = pSteamInput->GetActionSetHandle( #name ); Assert( !m_Controllers.Count() || m_ActionSetLayers.name ); if ( m_Controllers.Count() && !m_ActionSetLayers.name ) Warning( "Could not find Steam Input action layer '%s'\n", #name ); }
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 #define INIT_ANALOG_ACTION( name ) { m_AnalogActions.name = pSteamInput->GetAnalogActionHandle( #name ); Assert( !m_Controllers.Count() || m_AnalogActions.name ); if ( m_Controllers.Count() && !m_AnalogActions.name ) Warning( "Could not find Steam Input analog action '%s'\n", #name ); }
+#else
+#define INIT_ANALOG_ACTION( name ) { m_AnalogActions.name = pSteamInput->GetAnalogActionHandle( #name ); Assert( !m_Controllers.Count() || m_AnalogActions.name ); if ( m_Controllers.Count() && !m_AnalogActions.name ) Warning( "Could not find Steam Input analog action '%s'\n", #name ); }
+#endif
 
 	// Action Sets
 	INIT_ACTION_SET( InGame );
@@ -118,7 +150,11 @@ void CRD_Steam_Input::PostInit()
 	// Digital Actions
 	for ( CRD_Steam_Input_Bind *pBind = CRD_Steam_Input_Bind::s_pBinds; pBind; pBind = pBind->m_pNext )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pBind->m_hAction = pSteamInput->GetDigitalActionHandle( pBind->m_szActionName );
+#else
+		pBind->m_hAction = pSteamInput->GetDigitalActionHandle( pBind->m_szActionName );
+#endif
 		AssertMsg1( !m_Controllers.Count() || pBind->m_hAction, "could not find digital action '%s'", pBind->m_szActionName );
 		if ( m_Controllers.Count() && !pBind->m_hAction )
 			Warning( "Could not find Steam Input digital action '%s'\n", pBind->m_szActionName );
@@ -126,7 +162,11 @@ void CRD_Steam_Input::PostInit()
 		pBind->m_hForceActionSet = NULL;
 		if ( pBind->m_szForceActionSet )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pBind->m_hForceActionSet = pSteamInput->GetActionSetHandle( pBind->m_szForceActionSet );
+#else
+			pBind->m_hForceActionSet = pSteamInput->GetActionSetHandle( pBind->m_szForceActionSet );
+#endif
 			AssertMsg2( !m_Controllers.Count() || pBind->m_hForceActionSet, "could not find action set '%s' for digital action '%s'", pBind->m_szForceActionSet, pBind->m_szActionName );
 		}
 	}
@@ -146,12 +186,20 @@ void CRD_Steam_Input::Shutdown()
 	if ( !m_bInitialized )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInput *pSteamInput = SteamInput();
+#else
+	ISteamInput *pSteamInput = SteamInput();
+#endif
 	Assert( pSteamInput );
 	if ( !pSteamInput )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	bool bSuccess = pSteamInput->Shutdown();
+#else
+	bool bSuccess = pSteamInput->Shutdown();
+#endif
 	Assert( bSuccess );
 	if ( !bSuccess )
 		Warning( "ISteamInput::Shutdown returned failure status\n" );
@@ -188,7 +236,11 @@ void CRD_Steam_Input::Update( float frametime )
 		{
 			s_hTextEntryFocus = pTextEntry;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			ISteamUtils *pSteamUtils = SteamUtils();
+#else
+			ISteamUtils *pSteamUtils = SteamUtils();
+#endif
 			Assert( pSteamUtils );
 			if ( pSteamUtils )
 			{
@@ -197,11 +249,19 @@ void CRD_Steam_Input::Update( float frametime )
 					int x, y, w, t;
 					vgui::ipanel()->GetAbsPos( pTextEntry->GetVPanel(), x, y );
 					pTextEntry->GetSize( w, t );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pSteamUtils->ShowFloatingGamepadTextInput( pTextEntry->IsMultiline() ? k_EFloatingGamepadTextInputModeModeMultipleLines : k_EFloatingGamepadTextInputModeModeSingleLine, x, y, w, t );
+#else
+					pSteamUtils->ShowFloatingGamepadTextInput( pTextEntry->IsMultiline() ? k_EFloatingGamepadTextInputModeModeMultipleLines : k_EFloatingGamepadTextInputModeModeSingleLine, x, y, w, t );
+#endif
 				}
 				else
 				{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pSteamUtils->DismissFloatingGamepadTextInput();
+#else
+					pSteamUtils->DismissFloatingGamepadTextInput();
+#endif
 				}
 			}
 		}
@@ -210,12 +270,20 @@ void CRD_Steam_Input::Update( float frametime )
 	if ( !m_bInitialized )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInput *pSteamInput = SteamInput();
+#else
+	ISteamInput *pSteamInput = SteamInput();
+#endif
 	Assert( pSteamInput );
 	if ( !pSteamInput )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pSteamInput->RunFrame();
+#else
+	pSteamInput->RunFrame();
+#endif
 
 	FOR_EACH_VEC( m_Controllers, i )
 	{
@@ -305,7 +373,11 @@ public:
 		char szDebugName[256];
 		V_snprintf( szDebugName, sizeof( szDebugName ), "steam input glyph for action origin %d", eOrigin );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInput *pSteamInput = SteamInput();
+#else
+		ISteamInput *pSteamInput = SteamInput();
+#endif
 		Assert( pSteamInput );
 		if ( !pSteamInput )
 		{
@@ -313,10 +385,19 @@ public:
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( const char *szOrigin = pSteamInput->GetStringForActionOrigin( eOrigin ) )
 			V_snprintf( szDebugName, sizeof( szDebugName ), "steam input glyph for %d %s", eOrigin, szOrigin );
+#else
+		if ( const char *szOrigin = pSteamInput->GetStringForActionOrigin( eOrigin ) )
+			V_snprintf( szDebugName, sizeof( szDebugName ), "steam input glyph for %d %s", eOrigin, szOrigin );
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		const char *szGlyphPath = pSteamInput->GetGlyphPNGForActionOrigin( eOrigin, RD_INPUT_GLYPH_SIZE, RD_INPUT_GLYPH_STYLE );
+#else
+		const char *szGlyphPath = pSteamInput->GetGlyphPNGForActionOrigin( eOrigin, RD_INPUT_GLYPH_SIZE, RD_INPUT_GLYPH_STYLE );
+#endif
 		Assert( szGlyphPath );
 		if ( !szGlyphPath )
 		{
@@ -337,14 +418,22 @@ public:
 
 vgui::IImage *CRD_Steam_Input::GlyphImageForOrigin( EInputActionOrigin eOrigin )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInput *pSteamInput = SteamInput();
+#else
+	ISteamInput *pSteamInput = SteamInput();
+#endif
 	Assert( pSteamInput );
 	if ( !pSteamInput )
 		return NULL;
 
 	if ( rd_force_controller_glyph_set.GetInt() >= 0 )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		eOrigin = pSteamInput->TranslateActionOrigin( static_cast< ESteamInputType >( rd_force_controller_glyph_set.GetInt() ), eOrigin );
+#else
+		eOrigin = pSteamInput->TranslateActionOrigin( static_cast< ESteamInputType >( rd_force_controller_glyph_set.GetInt() ), eOrigin );
+#endif
 	}
 
 	ushort index = m_GlyphTextures.Find( eOrigin );
@@ -384,7 +473,11 @@ const char *CRD_Steam_Input::Key_LookupBindingEx( const char *pBinding, int iUse
 {
 	int iRealUserId = iUserId == -1 ? GET_ACTIVE_SPLITSCREEN_SLOT() : iUserId;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInput *pSteamInput = SteamInput();
+#else
+	ISteamInput *pSteamInput = SteamInput();
+#endif
 	Assert( pSteamInput );
 	if ( iAllowJoystick != 0 && pSteamInput )
 	{
@@ -410,7 +503,11 @@ const char *CRD_Steam_Input::Key_LookupBindingEx( const char *pBinding, int iUse
 				bAny = true;
 
 				EInputActionOrigin origins[STEAM_INPUT_MAX_ORIGINS]{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				int count = pSteamInput->GetAnalogActionOrigins( m_Controllers[i]->m_hController, m_ActionSets.InGame, hAnalogAction, origins );
+#else
+				int count = pSteamInput->GetAnalogActionOrigins( m_Controllers[i]->m_hController, m_ActionSets.InGame, hAnalogAction, origins );
+#endif
 				if ( count > iStartCount )
 				{
 					return OriginPlaceholderString( origins[iStartCount] );
@@ -434,8 +531,16 @@ const char *CRD_Steam_Input::Key_LookupBindingEx( const char *pBinding, int iUse
 					bAny = true;
 
 					EInputActionOrigin origins[STEAM_INPUT_MAX_ORIGINS]{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					InputActionSetHandle_t hActionSet = pBind->m_hForceActionSet ? pBind->m_hForceActionSet : pSteamInput->GetCurrentActionSet( m_Controllers[i]->m_hController );
+#else
+					InputActionSetHandle_t hActionSet = pBind->m_hForceActionSet ? pBind->m_hForceActionSet : pSteamInput->GetCurrentActionSet( m_Controllers[i]->m_hController );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					int count = pSteamInput->GetDigitalActionOrigins( m_Controllers[i]->m_hController, hActionSet, pBind->m_hAction, origins );
+#else
+					int count = pSteamInput->GetDigitalActionOrigins( m_Controllers[i]->m_hController, hActionSet, pBind->m_hAction, origins );
+#endif
 					if ( count > iStartCount )
 					{
 						return OriginPlaceholderString( origins[iStartCount] );
@@ -482,7 +587,11 @@ const char *CRD_Steam_Input::Key_LookupBindingEx( const char *pBinding, int iUse
 				if ( !m_Controllers[j]->m_bConnected || m_Controllers[j]->m_SplitScreenPlayerIndex != iRealUserId )
 					continue;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				return OriginPlaceholderString( pSteamInput->GetActionOriginFromXboxOrigin( m_Controllers[j]->m_hController, s_XInputTable[i].XBoxOrigin ) );
+#else
+				return OriginPlaceholderString( pSteamInput->GetActionOriginFromXboxOrigin( m_Controllers[j]->m_hController, s_XInputTable[i].XBoxOrigin ) );
+#endif
 			}
 		}
 	}
@@ -510,9 +619,17 @@ bool CRD_Steam_Input::IsOriginPlaceholderString( const char *szKey )
 
 const char *CRD_Steam_Input::NameForOrigin( EInputActionOrigin eOrigin )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInput *pSteamInput = SteamInput();
+#else
+	ISteamInput *pSteamInput = SteamInput();
+#endif
 	Assert( pSteamInput );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	return pSteamInput ? pSteamInput->GetStringForActionOrigin( eOrigin ) : NULL;
+#else
+	return pSteamInput ? pSteamInput->GetStringForActionOrigin( eOrigin ) : NULL;
+#endif
 }
 
 const char *CRD_Steam_Input::NameForOrigin( const char *szKey )
@@ -544,7 +661,11 @@ void CRD_Steam_Input::DrawLegacyControllerGlyph( const char *szKey, int x, int y
 	if ( iCenterY )
 		y -= tall * iCenterY / 2;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInput *pSteamInput = SteamInput();
+#else
+	ISteamInput *pSteamInput = SteamInput();
+#endif
 	Assert( pSteamInput );
 	if ( pSteamInput && eOrigin != k_EInputActionOrigin_None )
 	{
@@ -569,7 +690,11 @@ void CRD_Steam_Input::DrawLegacyControllerGlyph( const char *szKey, int x, int y
 				continue;
 			}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			eOrigin = pSteamInput->GetActionOriginFromXboxOrigin( m_Controllers[i]->m_hController, eXboxOrigin );
+#else
+			eOrigin = pSteamInput->GetActionOriginFromXboxOrigin( m_Controllers[i]->m_hController, eXboxOrigin );
+#endif
 			vgui::HTexture hTexture = GlyphForOrigin( eOrigin );
 			if ( hTexture )
 			{
@@ -590,7 +715,11 @@ void CRD_Steam_Input::DrawLegacyControllerGlyph( const char *szKey, int x, int y
 
 bool CRD_Steam_Input::GetGameAxes( int nSlot, float *flMoveX, float *flMoveY, float *flLookX, float *flLookY )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInput *pSteamInput = SteamInput();
+#else
+	ISteamInput *pSteamInput = SteamInput();
+#endif
 	Assert( pSteamInput );
 	if ( !pSteamInput )
 		return false;
@@ -604,7 +733,11 @@ bool CRD_Steam_Input::GetGameAxes( int nSlot, float *flMoveX, float *flMoveY, fl
 			continue;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		InputAnalogActionData_t data = pSteamInput->GetAnalogActionData( m_Controllers[i]->m_hController, m_AnalogActions.Move );
+#else
+		InputAnalogActionData_t data = pSteamInput->GetAnalogActionData( m_Controllers[i]->m_hController, m_AnalogActions.Move );
+#endif
 		if ( data.bActive )
 		{
 			if ( !bFoundMove )
@@ -618,7 +751,11 @@ bool CRD_Steam_Input::GetGameAxes( int nSlot, float *flMoveX, float *flMoveY, fl
 			*flMoveY -= data.y * MAX_BUTTONSAMPLE;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		data = pSteamInput->GetAnalogActionData( m_Controllers[i]->m_hController, m_AnalogActions.Look );
+#else
+		data = pSteamInput->GetAnalogActionData( m_Controllers[i]->m_hController, m_AnalogActions.Look );
+#endif
 		if ( data.bActive )
 		{
 			if ( !bFoundLook )
@@ -651,7 +788,11 @@ bool CRD_Steam_Input::GetGameAxes( int nSlot, float *flMoveX, float *flMoveY, fl
 
 bool CRD_Steam_Input::GetMenuNavigateOffset( int nSlot, float *flMenuNavigateX, float *flMenuNavigateY )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInput *pSteamInput = SteamInput();
+#else
+	ISteamInput *pSteamInput = SteamInput();
+#endif
 	Assert( pSteamInput );
 	if ( !pSteamInput )
 		return false;
@@ -665,7 +806,11 @@ bool CRD_Steam_Input::GetMenuNavigateOffset( int nSlot, float *flMenuNavigateX, 
 			continue;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		InputAnalogActionData_t data = pSteamInput->GetAnalogActionData( m_Controllers[i]->m_hController, m_AnalogActions.MenuNavigate );
+#else
+		InputAnalogActionData_t data = pSteamInput->GetAnalogActionData( m_Controllers[i]->m_hController, m_AnalogActions.MenuNavigate );
+#endif
 		if ( data.bActive )
 		{
 			if ( !bFoundMenuNavigate )
@@ -708,7 +853,11 @@ InputActionSetHandle_t CRD_Steam_Input::DetermineActionSet( CUtlVector<InputActi
 
 void CRD_Steam_Input::SetRumble( float fLeftMotor, float fRightMotor, int userId )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInput *pSteamInput = SteamInput();
+#else
+	ISteamInput *pSteamInput = SteamInput();
+#endif
 	Assert( pSteamInput );
 	if ( !pSteamInput )
 		return;
@@ -717,7 +866,11 @@ void CRD_Steam_Input::SetRumble( float fLeftMotor, float fRightMotor, int userId
 	{
 		if ( m_Controllers[i]->m_bConnected && m_Controllers[i]->m_SplitScreenPlayerIndex == userId )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamInput->TriggerVibration( m_Controllers[i]->m_hController, clamp( fLeftMotor, 0.0f, 1.0f ) * UINT16_MAX, clamp( fRightMotor, 0.0f, 1.0f ) * UINT16_MAX );
+#else
+			pSteamInput->TriggerVibration( m_Controllers[i]->m_hController, clamp( fLeftMotor, 0.0f, 1.0f ) * UINT16_MAX, clamp( fRightMotor, 0.0f, 1.0f ) * UINT16_MAX );
+#endif
 		}
 	}
 }
@@ -856,9 +1009,17 @@ void CRD_Steam_Controller::OnFrame( ISteamInput *pSteamInput )
 
 	C_ASW_Player *pPlayer = m_SplitScreenPlayerIndex == -1 ? NULL : C_ASW_Player::GetLocalASWPlayer( m_SplitScreenPlayerIndex );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	InputActionSetHandle_t hLastActionSet = pSteamInput->GetCurrentActionSet( m_hController );
+#else
+	InputActionSetHandle_t hLastActionSet = pSteamInput->GetCurrentActionSet( m_hController );
+#endif
 	InputActionSetHandle_t ActiveLayers[STEAM_INPUT_MAX_ACTIVE_LAYERS];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	int nActiveLayers = pSteamInput->GetActiveActionSetLayers( m_hController, ActiveLayers );
+#else
+	int nActiveLayers = pSteamInput->GetActiveActionSetLayers( m_hController, ActiveLayers );
+#endif
 
 	CUtlVector<InputActionSetHandle_t> RequestedLayers;
 	InputActionSetHandle_t hSet = g_RD_Steam_Input.DetermineActionSet( &RequestedLayers, m_SplitScreenPlayerIndex );
@@ -866,11 +1027,23 @@ void CRD_Steam_Controller::OnFrame( ISteamInput *pSteamInput )
 
 	if ( m_bJustChangedActionSet || RequestedLayers.Count() != nActiveLayers || V_memcmp( RequestedLayers.Base(), ActiveLayers, nActiveLayers * sizeof( ActiveLayers[0] ) ) )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamInput->DeactivateAllActionSetLayers( m_hController );
+#else
+		pSteamInput->DeactivateAllActionSetLayers( m_hController );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamInput->ActivateActionSet( m_hController, hSet );
+#else
+		pSteamInput->ActivateActionSet( m_hController, hSet );
+#endif
 		FOR_EACH_VEC( RequestedLayers, i )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamInput->ActivateActionSetLayer( m_hController, RequestedLayers[i] );
+#else
+			pSteamInput->ActivateActionSetLayer( m_hController, RequestedLayers[i] );
+#endif
 		}
 	}
 
@@ -885,7 +1058,11 @@ void CRD_Steam_Controller::OnFrame( ISteamInput *pSteamInput )
 		if ( PlayerColor != m_LastPlayerColor )
 		{
 			m_LastPlayerColor = PlayerColor;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamInput->SetLEDColor( m_hController, PlayerColor.r(), PlayerColor.g(), PlayerColor.b(), PlayerColor == Color{} ? k_ESteamInputLEDFlag_RestoreUserDefault : k_ESteamInputLEDFlag_SetColor );
+#else
+			pSteamInput->SetLEDColor( m_hController, PlayerColor.r(), PlayerColor.g(), PlayerColor.b(), PlayerColor == Color{} ? k_ESteamInputLEDFlag_RestoreUserDefault : k_ESteamInputLEDFlag_SetColor );
+#endif
 		}
 	}
 }

--- a/src/game/client/swarm/rd_steam_input.h
+++ b/src/game/client/swarm/rd_steam_input.h
@@ -39,9 +39,21 @@ public:
 	void SetRumble( float fLeftMotor, float fRightMotor, int userId = INVALID_USER_ID );
 	void StopRumble( int userId = INVALID_USER_ID );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Steam_Input, OnSteamInputDeviceConnected, SteamInputDeviceConnected_t );
+#else
+	STEAM_CALLBACK( CRD_Steam_Input, OnSteamInputDeviceConnected, SteamInputDeviceConnected_t );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Steam_Input, OnSteamInputDeviceDisconnected, SteamInputDeviceDisconnected_t );
+#else
+	STEAM_CALLBACK( CRD_Steam_Input, OnSteamInputDeviceDisconnected, SteamInputDeviceDisconnected_t );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Steam_Input, OnSteamInputConfigurationLoaded, SteamInputConfigurationLoaded_t );
+#else
+	STEAM_CALLBACK( CRD_Steam_Input, OnSteamInputConfigurationLoaded, SteamInputConfigurationLoaded_t );
+#endif
 	static void OnActionEvent( SteamInputActionEvent_t *pEvent );
 
 	bool m_bInitialized;

--- a/src/game/client/swarm/rd_swarmopedia.cpp
+++ b/src/game/client/swarm/rd_swarmopedia.cpp
@@ -363,7 +363,11 @@ float Requirement::GetProgress() const
 		FOR_EACH_VEC( StatNames, i )
 		{
 			int iStat{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( !SteamUserStats() || !SteamUserStats()->GetStat( StatNames[i], &iStat ) )
+#else
+			if ( !SteamUserStats() || !SteamUserStats()->GetStat( StatNames[i], &iStat ) )
+#endif
 			{
 				DevWarning( "Failed to retrieve stat '%s' for Swarmopedia\n", StatNames[i] );
 			}
@@ -1575,7 +1579,11 @@ void WeaponFact::Merge( const WeaponFact *pWeaponFact )
 
 void RD_Swarmopedia::CheckArticleUnlock( const char *szStatName, int iStatBefore, int iStatAfter )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUserStats *pStats = SteamUserStats();
+#else
+	ISteamUserStats *pStats = SteamUserStats();
+#endif
 	Assert( pStats );
 	if ( !pStats )
 	{
@@ -1613,7 +1621,11 @@ void RD_Swarmopedia::CheckArticleUnlock( const char *szStatName, int iStatBefore
 				if ( V_stricmp( pReq->StatNames[k], szStatName ) )
 				{
 					int32 iStat;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					if ( pStats->GetStat( pReq->StatNames[k], &iStat ) )
+#else
+					if ( pStats->GetStat( pReq->StatNames[k], &iStat ) )
+#endif
 					{
 						iProgressExceptStat -= iStat;
 					}

--- a/src/game/client/swarm/rd_swarmopedia_content_log.cpp
+++ b/src/game/client/swarm/rd_swarmopedia_content_log.cpp
@@ -16,12 +16,28 @@ static void LoadSeenContent()
 	if ( s_bLoadedSeenContent )
 		return;
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+	#else
+	ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+	#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( pRemoteStorage && pRemoteStorage->IsCloudEnabledForApp() && pRemoteStorage->FileExists( "reactivedrop/cfg/swarmopedia_found.txt" ) )
+	#else
+	if ( pRemoteStorage && pRemoteStorage->IsCloudEnabledForApp() && pRemoteStorage->FileExists( "reactivedrop/cfg/swarmopedia_found.txt" ) )
+	#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		int nSize = pRemoteStorage->GetFileSize( "reactivedrop/cfg/swarmopedia_found.txt" );
+#else
+		int nSize = pRemoteStorage->GetFileSize( "reactivedrop/cfg/swarmopedia_found.txt" );
+#endif
 		CUtlBuffer buf;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pRemoteStorage->FileRead( "reactivedrop/cfg/swarmopedia_found.txt", buf.AccessForDirectRead( nSize ), nSize );
+#else
+		pRemoteStorage->FileRead( "reactivedrop/cfg/swarmopedia_found.txt", buf.AccessForDirectRead( nSize ), nSize );
+#endif
 		g_pFullFileSystem->WriteFile( "cfg/swarmopedia_found.txt", "MOD", buf );
 	}
 
@@ -34,12 +50,24 @@ static void SaveSeenContent()
 {
 	s_pSwarmopediaSeenContent->SaveToFile( g_pFullFileSystem, "cfg/swarmopedia_found.txt", "MOD" );
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+	#else
+	ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+	#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( pRemoteStorage && pRemoteStorage->IsCloudEnabledForApp() )
+	#else
+	if ( pRemoteStorage && pRemoteStorage->IsCloudEnabledForApp() )
+	#endif
 	{
 		CUtlBuffer buf;
 		g_pFullFileSystem->ReadFile( "cfg/swarmopedia_found.txt", "MOD", buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pRemoteStorage->FileWrite( "reactivedrop/cfg/swarmopedia_found.txt", buf.Base(), buf.TellMaxPut() );
+#else
+		pRemoteStorage->FileWrite( "reactivedrop/cfg/swarmopedia_found.txt", buf.Base(), buf.TellMaxPut() );
+#endif
 
 		DevMsg( "Saved reactivedrop/cfg/swarmopedia_found.txt to cloud.\n" );
 	}

--- a/src/game/client/swarm/rd_text_filtering.cpp
+++ b/src/game/client/swarm/rd_text_filtering.cpp
@@ -18,13 +18,21 @@ CRD_Text_Filtering::CRD_Text_Filtering() : CAutoGameSystem( "CRD_Text_Filtering"
 
 void CRD_Text_Filtering::PostInit()
 {
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUtils() )
+	#else
+	if ( !SteamUtils() )
+	#endif
 	{
 		Warning( "RD_Text_Filtering: SteamUtils() returned NULL!\n" );
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUtils()->InitFilterText() )
+#else
+	if ( !SteamUtils()->InitFilterText() )
+#endif
 	{
 		DevMsg( "RD_Text_Filtering: filtering unavailable for this language.\n" );
 	}
@@ -32,7 +40,11 @@ void CRD_Text_Filtering::PostInit()
 
 CSteamID CRD_Text_Filtering::GetClientSteamID( int client )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUtils() )
+#else
+	if ( !SteamUtils() )
+#endif
 	{
 		return k_steamIDNil;
 	}
@@ -43,19 +55,31 @@ CSteamID CRD_Text_Filtering::GetClientSteamID( int client )
 		return k_steamIDNil;
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	return CSteamID( playerInfo.friendsID, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+	#else
+	return CSteamID( playerInfo.friendsID, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+	#endif
 }
 
 static void DoFilterText( ETextFilteringContext eContext, CSteamID sourceSteamID, char *szText, size_t bufSizeInBytes )
 {
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !rd_text_filtering.GetBool() || !SteamUtils() )
+	#else
+	if ( !rd_text_filtering.GetBool() || !SteamUtils() )
+	#endif
 		return;
 
 	if ( rd_text_filtering_debug_no_steamid.GetBool() )
 		sourceSteamID = k_steamIDNil;
 
 	char *szDest = (char *)stackalloc( bufSizeInBytes );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUtils()->FilterText( eContext, sourceSteamID, szText, szDest, bufSizeInBytes );
+#else
+	SteamUtils()->FilterText( eContext, sourceSteamID, szText, szDest, bufSizeInBytes );
+#endif
 	V_strncpy( szText, szDest, bufSizeInBytes );
 }
 

--- a/src/game/client/swarm/vgui/asw_hud_chat.cpp
+++ b/src/game/client/swarm/vgui/asw_hud_chat.cpp
@@ -568,21 +568,38 @@ void CHudChat::StartMessageMode( int iMessageModeType )
 {
 	BaseClass::StartMessageMode( iMessageModeType );
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUtils() )
 	{
 		int x, y, w, t;
 		GetBounds( x, y, w, t );
 		SteamUtils()->ShowFloatingGamepadTextInput( k_EFloatingGamepadTextInputModeModeSingleLine, x, y, w, t );
 	}
+	#else
+	if ( SteamUtils() )
+	{
+		int x, y, w, t;
+		GetBounds( x, y, w, t );
+		SteamUtils()->ShowFloatingGamepadTextInput( k_EFloatingGamepadTextInputModeModeSingleLine, x, y, w, t );
+	}
+	#endif
 }
 
 void CHudChat::StopMessageMode( bool bFade )
 {
 	BaseClass::StopMessageMode( bFade );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUtils() )
+#else
+	if ( SteamUtils() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUtils()->DismissFloatingGamepadTextInput();
+#else
+		SteamUtils()->DismissFloatingGamepadTextInput();
+#endif
 	}
 }
 

--- a/src/game/client/swarm/vgui/asw_hud_chat.h
+++ b/src/game/client/swarm/vgui/asw_hud_chat.h
@@ -53,7 +53,11 @@ public:
 	vgui::Panel *m_pSwarmBackground;
 	vgui::Panel *m_pSwarmBackgroundInner;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CHudChat, OnFloatingGamepadTextInputDismissed, FloatingGamepadTextInputDismissed_t )
+#else
+	STEAM_CALLBACK( CHudChat, OnFloatingGamepadTextInputDismissed, FloatingGamepadTextInputDismissed_t )
+#endif
 	{
 		StopMessageMode();
 	}

--- a/src/game/client/swarm/vgui/asw_mission_chooser_frame.cpp
+++ b/src/game/client/swarm/vgui/asw_mission_chooser_frame.cpp
@@ -914,9 +914,17 @@ void CASW_Mission_Chooser_Entry::ApplyEntry()
 	if ( m_WorkshopChooserType != ASW_CHOOSER_TYPE::NUM_TYPES )
 	{
 		CFmtStr szWorkshopURL( VarArgs( "https://steamcommunity.com/workshop/browse/?appid=563560&requiredtags[]=%s&browsesort=playtime_trend", s_WorkshopChooserTypeTag[( int )m_WorkshopChooserType] ) );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamFriends() && SteamUtils() && SteamUtils()->IsOverlayEnabled() )
+#else
+		if ( SteamFriends() && SteamUtils() && SteamUtils()->IsOverlayEnabled() )
+#endif
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamFriends()->ActivateGameOverlayToWebPage( szWorkshopURL, k_EActivateGameOverlayToWebPageMode_Modal );
+#else
+			SteamFriends()->ActivateGameOverlayToWebPage( szWorkshopURL, k_EActivateGameOverlayToWebPageMode_Modal );
+#endif
 		}
 		else
 		{

--- a/src/game/client/swarm/vgui/asw_scalable_text.cpp
+++ b/src/game/client/swarm/vgui/asw_scalable_text.cpp
@@ -1,4 +1,4 @@
-﻿#include "cbase.h"
+#include "cbase.h"
 #include <vgui_controls/Panel.h>
 #include "asw_scalable_text.h"
 #include <vgui/isurface.h>
@@ -14,14 +14,26 @@ static bool IsAlphabet( char category )
 	if ( !s_chAlphabet )
 	{
 		// Only compute this once. If the user changes their language during a game session, we might precache the wrong materials, but otherwise no issue.
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		Assert( SteamApps() );
+		#else
+		Assert( SteamApps() );
+		#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamApps() )
+#else
+		if ( !SteamApps() )
+#endif
 		{
 			s_chAlphabet = 'e'; // error
 			return false;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		const char *szLang = SteamApps()->GetCurrentGameLanguage();
+#else
+		const char *szLang = SteamApps()->GetCurrentGameLanguage();
+#endif
 		if ( !V_strcmp( szLang, "english" ) || !V_strcmp( szLang, "german" ) || !V_strcmp( szLang, "italian" ) || !V_strcmp( szLang, "vietnamese" ) )
 		{
 			s_chAlphabet = 'L'; // Latin

--- a/src/game/client/swarm/vgui/asw_vgui_computer_mail.cpp
+++ b/src/game/client/swarm/vgui/asw_vgui_computer_mail.cpp
@@ -220,9 +220,17 @@ void CASW_VGUI_Computer_Mail::SetLabelsFromMailFile()
 	if ( pArea->m_MailFile == NULL_STRING )
 		return;
 	engine->GetUILanguage( uilanguage, sizeof( uilanguage ) );
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamApps() )
+	#else
+	if ( SteamApps() )
+	#endif
 	{
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		V_strncpy( uilanguage, SteamApps()->GetCurrentGameLanguage(), sizeof( uilanguage ) );
+	#else
+		V_strncpy( uilanguage, SteamApps()->GetCurrentGameLanguage(), sizeof( uilanguage ) );
+	#endif
 	}
 
 	V_snprintf( buffer, sizeof( buffer ), "resource/mail/%s_%s.txt", pszMailFile, uilanguage );

--- a/src/game/client/swarm/vgui/asw_vgui_computer_news.cpp
+++ b/src/game/client/swarm/vgui/asw_vgui_computer_news.cpp
@@ -110,10 +110,17 @@ void CASW_VGUI_Computer_News::SetLabelsFromFile()
 		return;
 
 	engine->GetUILanguage( uilanguage, sizeof( uilanguage ) );
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamApps() )
 	{
 		V_strncpy( uilanguage, SteamApps()->GetCurrentGameLanguage(), sizeof( uilanguage ) );
 	}
+	#else
+	if ( SteamApps() )
+	{
+		V_strncpy( uilanguage, SteamApps()->GetCurrentGameLanguage(), sizeof( uilanguage ) );
+	}
+	#endif
 
 	V_snprintf( buffer, sizeof( buffer ), "resource/news/%s_%s.txt", pszNewsFile, uilanguage );
 	if ( m_pKeyValues )

--- a/src/game/client/swarm/vgui/campaignpanel.cpp
+++ b/src/game/client/swarm/vgui/campaignpanel.cpp
@@ -327,8 +327,16 @@ void CampaignPanel::OnThink()
 	if ( !Briefing() )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pSteamFriends = SteamFriends();
+#else
+	ISteamFriends *pSteamFriends = SteamFriends();
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_pFriendsButton->SetVisible( ( pSteamFriends && pSteamFriends->GetFriendCount( k_EFriendFlagImmediate ) > 0 ) && !( ASWGameResource() && ASWGameResource()->IsOfflineGame() ) );
+#else
+	m_pFriendsButton->SetVisible( ( pSteamFriends && pSteamFriends->GetFriendCount( k_EFriendFlagImmediate ) > 0 ) && !( ASWGameResource() && ASWGameResource()->IsOfflineGame() ) );
+#endif
 	m_pChangeMissionButton->SetVisible( Briefing()->IsLocalPlayerLeader() || gpGlobals->maxClients == 1 );
 
 	const char *pszLeaderName = Briefing()->GetLeaderName();

--- a/src/game/client/swarm/vgui/creditspanel.cpp
+++ b/src/game/client/swarm/vgui/creditspanel.cpp
@@ -37,9 +37,17 @@ CreditsPanel::CreditsPanel(vgui::Panel *parent, const char *name) : vgui::Panel(
 		szCreditsPrefix = STRING( pMission->CustomCreditsFile );
 
 	char szCreditsPath[512];
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamApps() )
+	#else
+	if ( SteamApps() )
+	#endif
 	{
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		V_snprintf( szCreditsPath, sizeof( szCreditsPath ), "%s_%s.txt", szCreditsPrefix, SteamApps()->GetCurrentGameLanguage() );
+	#else
+		V_snprintf( szCreditsPath, sizeof( szCreditsPath ), "%s_%s.txt", szCreditsPrefix, SteamApps()->GetCurrentGameLanguage() );
+	#endif
 
 		if ( !filesystem->FileExists( szCreditsPath, "GAME" ) )
 		{

--- a/src/game/client/swarm/vgui/missioncompletepanel.cpp
+++ b/src/game/client/swarm/vgui/missioncompletepanel.cpp
@@ -216,7 +216,11 @@ MissionCompletePanel::~MissionCompletePanel()
 static void CheckPvPFest2026()
 {
 	// during Steam PvP Fest 2026
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUtils() || !SteamUser() || SteamUtils()->GetServerRealTime() < 1770660000u || SteamUtils()->GetServerRealTime() > 1771264800u )
+	#else
+	if ( !SteamUtils() || !SteamUser() || SteamUtils()->GetServerRealTime() < 1770660000u || SteamUtils()->GetServerRealTime() > 1771264800u )
+	#endif
 		return;
 
 	if ( engine->IsPlayingDemo() || !C_ASW_Player::GetLocalASWPlayer() )
@@ -763,11 +767,19 @@ void MissionCompletePanel::OnSuggestDifficulty( bool bIncrease )
 void MissionCompletePanel::OnLeaderboardFound( SteamLeaderboard_t id )
 {
 	m_hLeaderboard = id;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_pExperienceReport->m_pLeaderboard->SetDisplayType( SteamUserStats()->GetLeaderboardDisplayType( id ) );
+#else
+	m_pExperienceReport->m_pLeaderboard->SetDisplayType( SteamUserStats()->GetLeaderboardDisplayType( id ) );
+#endif
 
 	if ( m_bLeaderboardReady )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hAPICall = SteamUserStats()->DownloadLeaderboardEntries( id, k_ELeaderboardDataRequestFriends, 0, 0 );
+#else
+		SteamAPICall_t hAPICall = SteamUserStats()->DownloadLeaderboardEntries( id, k_ELeaderboardDataRequestFriends, 0, 0 );
+#endif
 		m_LeaderboardDownloadedCallback.Set( hAPICall, this, &MissionCompletePanel::LeaderboardDownloadedCallback );
 	}
 }
@@ -782,7 +794,11 @@ void MissionCompletePanel::LeaderboardReady()
 	m_bLeaderboardReady = true;
 	if ( m_hLeaderboard != 0 )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hAPICall = SteamUserStats()->DownloadLeaderboardEntries( m_hLeaderboard, k_ELeaderboardDataRequestFriends, 0, 0 );
+#else
+		SteamAPICall_t hAPICall = SteamUserStats()->DownloadLeaderboardEntries( m_hLeaderboard, k_ELeaderboardDataRequestFriends, 0, 0 );
+#endif
 		m_LeaderboardDownloadedCallback.Set( hAPICall, this, &MissionCompletePanel::LeaderboardDownloadedCallback );
 	}
 }

--- a/src/game/client/swarm/vgui/missioncompletepanel.h
+++ b/src/game/client/swarm/vgui/missioncompletepanel.h
@@ -51,7 +51,11 @@ public:
 	void OnLeaderboardScoreUploaded( const RD_LeaderboardEntry_t & entry, int nGlobalRankPrevious );
 	void LeaderboardReady();
 	void LeaderboardDownloadedCallback( LeaderboardScoresDownloaded_t *pResult, bool bIOFailure );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<MissionCompletePanel, LeaderboardScoresDownloaded_t> m_LeaderboardDownloadedCallback;
+#else
+	CCallResult<MissionCompletePanel, LeaderboardScoresDownloaded_t> m_LeaderboardDownloadedCallback;
+#endif
 	SteamLeaderboard_t m_hLeaderboard;
 	bool m_bLeaderboardReady;
 

--- a/src/game/client/swarm/vgui/nb_leaderboard_panel.cpp
+++ b/src/game/client/swarm/vgui/nb_leaderboard_panel.cpp
@@ -74,7 +74,11 @@ CNB_Leaderboard_Panel::CNB_Leaderboard_Panel( vgui::Panel *parent, const char *n
 		m_pLeaderboard->SetTitle( UTIL_RD_GetCurrentLobbyData( "game:missioninfo:displaytitle" ) );
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hCall = SteamUserStats()->FindLeaderboard( szLeaderboardName );
+#else
+	SteamAPICall_t hCall = SteamUserStats()->FindLeaderboard( szLeaderboardName );
+#endif
 	m_LeaderboardFind.Set( hCall, this, &CNB_Leaderboard_Panel::LeaderboardFind );
 }
 
@@ -113,9 +117,17 @@ void CNB_Leaderboard_Panel::LeaderboardFind( LeaderboardFindResult_t *pResult, b
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_pLeaderboard->SetDisplayType( SteamUserStats()->GetLeaderboardDisplayType( pResult->m_hSteamLeaderboard ) );
+#else
+	m_pLeaderboard->SetDisplayType( SteamUserStats()->GetLeaderboardDisplayType( pResult->m_hSteamLeaderboard ) );
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hCall = SteamUserStats()->DownloadLeaderboardEntries( pResult->m_hSteamLeaderboard, k_ELeaderboardDataRequestFriends, 0, 0 );
+#else
+	SteamAPICall_t hCall = SteamUserStats()->DownloadLeaderboardEntries( pResult->m_hSteamLeaderboard, k_ELeaderboardDataRequestFriends, 0, 0 );
+#endif
 	m_LeaderboardDownload.Set( hCall, this, &CNB_Leaderboard_Panel::LeaderboardDownload );
 }
 

--- a/src/game/client/swarm/vgui/nb_leaderboard_panel.h
+++ b/src/game/client/swarm/vgui/nb_leaderboard_panel.h
@@ -27,8 +27,16 @@ public:
 	vgui::Label *m_pErrorLabel;
 	vgui::Label *m_pNotFoundLabel;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CNB_Leaderboard_Panel, LeaderboardFindResult_t> m_LeaderboardFind;
+#else
+	CCallResult<CNB_Leaderboard_Panel, LeaderboardFindResult_t> m_LeaderboardFind;
+#endif
 	void LeaderboardFind( LeaderboardFindResult_t *pResult, bool bIOError );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CNB_Leaderboard_Panel, LeaderboardScoresDownloaded_t> m_LeaderboardDownload;
+#else
+	CCallResult<CNB_Leaderboard_Panel, LeaderboardScoresDownloaded_t> m_LeaderboardDownload;
+#endif
 	void LeaderboardDownload( LeaderboardScoresDownloaded_t *pResult, bool bIOError );
 };

--- a/src/game/client/swarm/vgui/nb_lobby_row.cpp
+++ b/src/game/client/swarm/vgui/nb_lobby_row.cpp
@@ -505,17 +505,31 @@ void CNB_Lobby_Row::OnCommand( const char *command )
 	else if ( !Q_stricmp( command, "#L4D360UI_ViewSteamStats" ) )
 	{
 #if !defined( _X360 ) && !defined( NO_STEAM )
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUser() )
+#else
+		if ( SteamUser() )
+#endif
 		{
 			if ( developer.GetBool() )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				Msg( "Local player SteamID = %I64u\n", SteamUser()->GetSteamID().ConvertToUint64() );
+#else
+				Msg( "Local player SteamID = %I64u\n", SteamUser()->GetSteamID().ConvertToUint64() );
+#endif
 				Msg( "Activating stats for SteamID = %I64u\n", Briefing()->GetCommanderSteamID( m_nLobbySlot ).ConvertToUint64() );
 			}
 			char statsWeb[256];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			Q_snprintf( statsWeb, sizeof( statsWeb ), "https://stats.reactivedrop.com/profiles/%I64u?lang=%s&utm_source=briefing",
 				Briefing()->GetCommanderSteamID( m_nLobbySlot ).ConvertToUint64(),
 				SteamApps()->GetCurrentGameLanguage() );
+#else
+			Q_snprintf( statsWeb, sizeof( statsWeb ), "https://stats.reactivedrop.com/profiles/%I64u?lang=%s&utm_source=briefing",
+				Briefing()->GetCommanderSteamID( m_nLobbySlot ).ConvertToUint64(),
+				SteamApps()->GetCurrentGameLanguage() );
+#endif
 			BaseModUI::CUIGameData::Get()->ExecuteOverlayUrl( statsWeb );
 		}
 #endif

--- a/src/game/client/swarm/vgui/rd_vgui_commander_mini_profile.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_commander_mini_profile.cpp
@@ -162,12 +162,20 @@ void CRD_VGUI_Commander_Mini_Profile::OnKeyCodePressed( vgui::KeyCode code )
 
 void CRD_VGUI_Commander_Mini_Profile::InitForLocalPlayer()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUser *pSteamUser = SteamUser();
+#else
+	ISteamUser *pSteamUser = SteamUser();
+#endif
 	Assert( pSteamUser );
 	if ( !pSteamUser )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CSteamID localPlayerID = pSteamUser->GetSteamID();
+#else
+	CSteamID localPlayerID = pSteamUser->GetSteamID();
+#endif
 
 	InitShared( localPlayerID );
 
@@ -209,7 +217,11 @@ void CRD_VGUI_Commander_Mini_Profile::InitShared( CSteamID steamID )
 
 	m_SteamID = steamID;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pSteamFriends = SteamFriends();
+#else
+	ISteamFriends *pSteamFriends = SteamFriends();
+#endif
 	Assert( pSteamFriends );
 	if ( !pSteamFriends )
 		return;
@@ -217,14 +229,26 @@ void CRD_VGUI_Commander_Mini_Profile::InitShared( CSteamID steamID )
 	m_pImgAvatar->SetAvatarBySteamID( &steamID );
 
 	wchar_t wszName[k_cwchPersonaNameMax + 1];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	V_UTF8ToUnicode( pSteamFriends->GetFriendPersonaName( steamID ), wszName, sizeof( wszName ) );
+#else
+	V_UTF8ToUnicode( pSteamFriends->GetFriendPersonaName( steamID ), wszName, sizeof( wszName ) );
+#endif
 	m_pLblPlayerName->SetText( wszName );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUserStats *pUserStats = SteamUserStats();
+#else
+	ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 	Assert( pUserStats );
 	if ( pUserStats )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hCall = pUserStats->DownloadLeaderboardEntriesForUsers( STEAM_LEADERBOARD_HOIAF_CURRENT_SEASON, &steamID, 1 );
+#else
+		SteamAPICall_t hCall = pUserStats->DownloadLeaderboardEntriesForUsers( STEAM_LEADERBOARD_HOIAF_CURRENT_SEASON, &steamID, 1 );
+#endif
 		m_LeaderboardScoresDownloaded.Set( hCall, this, &CRD_VGUI_Commander_Mini_Profile::OnLeaderboardScoresDownloaded );
 	}
 	else
@@ -344,12 +368,20 @@ void CRD_VGUI_Commander_Mini_Profile::ClearHoIAFData()
 
 void CRD_VGUI_Commander_Mini_Profile::OnPersonaStateChange( PersonaStateChange_t *pParam )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pSteamFriends = SteamFriends();
+#else
+	ISteamFriends *pSteamFriends = SteamFriends();
+#endif
 	Assert( pSteamFriends );
 	if ( pSteamFriends && m_SteamID.ConvertToUint64() == pParam->m_ulSteamID )
 	{
 		wchar_t wszName[k_cwchPersonaNameMax + 1];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		V_UTF8ToUnicode( pSteamFriends->GetFriendPersonaName( m_SteamID ), wszName, sizeof( wszName ) );
+#else
+		V_UTF8ToUnicode( pSteamFriends->GetFriendPersonaName( m_SteamID ), wszName, sizeof( wszName ) );
+#endif
 		m_pLblPlayerName->SetText( wszName );
 	}
 }
@@ -367,7 +399,11 @@ void CRD_VGUI_Commander_Mini_Profile::OnLeaderboardScoresDownloaded( Leaderboard
 		Assert( pParam->m_cEntryCount == 1 );
 		LeaderboardEntry_t entry;
 		LeaderboardScoreDetails_Points_t details;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bool bOK = SteamUserStats()->GetDownloadedLeaderboardEntry( pParam->m_hSteamLeaderboardEntries, 0, &entry, reinterpret_cast< int32 * >( &details ), sizeof( details ) / sizeof( int32 ) );
+#else
+		bool bOK = SteamUserStats()->GetDownloadedLeaderboardEntry( pParam->m_hSteamLeaderboardEntries, 0, &entry, reinterpret_cast< int32 * >( &details ), sizeof( details ) / sizeof( int32 ) );
+#endif
 		Assert( bOK );
 		if ( bOK )
 		{

--- a/src/game/client/swarm/vgui/rd_vgui_commander_mini_profile.h
+++ b/src/game/client/swarm/vgui/rd_vgui_commander_mini_profile.h
@@ -53,7 +53,15 @@ public:
 	bool m_bEmbedded{ false };
 	bool m_bHoIAFError{ false };
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_VGUI_Commander_Mini_Profile, OnPersonaStateChange, PersonaStateChange_t );
+#else
+	STEAM_CALLBACK( CRD_VGUI_Commander_Mini_Profile, OnPersonaStateChange, PersonaStateChange_t );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CRD_VGUI_Commander_Mini_Profile, LeaderboardScoresDownloaded_t> m_LeaderboardScoresDownloaded;
+#else
+	CCallResult<CRD_VGUI_Commander_Mini_Profile, LeaderboardScoresDownloaded_t> m_LeaderboardScoresDownloaded;
+#endif
 	void OnLeaderboardScoresDownloaded( LeaderboardScoresDownloaded_t *pParam, bool bIOFailure );
 };

--- a/src/game/client/swarm/vgui/rd_vgui_leaderboard_panel.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_leaderboard_panel.cpp
@@ -44,7 +44,11 @@ void CReactiveDrop_VGUI_Leaderboard_Panel::SetTitle( const wchar_t *wszTitle )
 
 void CReactiveDrop_VGUI_Leaderboard_Panel::SetEntries( const CUtlVector<RD_LeaderboardEntry_t> & entries )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CSteamID localUserID = SteamUser()->GetSteamID();
+#else
+	CSteamID localUserID = SteamUser()->GetSteamID();
+#endif
 
 	m_gplLeaderboard->RemoveAllPanelItems();
 
@@ -174,7 +178,11 @@ void CReactiveDrop_VGUI_Leaderboard_Entry::SetEntry( const RD_LeaderboardEntry_t
 	m_imgAvatar->SetAvatarBySteamID( &steamIDCopy );
 
 	wchar_t wszName[k_cwchPersonaNameMax];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Q_UTF8ToUnicode( SteamFriends()->GetFriendPersonaName( entry.entry.m_steamIDUser ), wszName, sizeof( wszName ) );
+#else
+	Q_UTF8ToUnicode( SteamFriends()->GetFriendPersonaName( entry.entry.m_steamIDUser ), wszName, sizeof( wszName ) );
+#endif
 	g_RDTextFiltering.FilterTextName( wszName, entry.entry.m_steamIDUser );
 	m_lblName->SetText( wszName );
 

--- a/src/game/client/swarm/vgui/rd_vgui_main_menu_hoiaf_leaderboard_entry.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_main_menu_hoiaf_leaderboard_entry.cpp
@@ -78,12 +78,20 @@ void CRD_VGUI_Main_Menu_HoIAF_Leaderboard_Entry::SetFromEntry( const Leaderboard
 {
 	m_SteamID = entry.m_steamIDUser;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pFriends = SteamFriends();
+#else
+	ISteamFriends *pFriends = SteamFriends();
+#endif
 	Assert( pFriends );
 	if ( pFriends )
 	{
 		wchar_t wszName[k_cwchPersonaNameMax];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		V_UTF8ToUnicode( pFriends->GetFriendPersonaName( m_SteamID ), wszName, sizeof( wszName ) );
+#else
+		V_UTF8ToUnicode( pFriends->GetFriendPersonaName( m_SteamID ), wszName, sizeof( wszName ) );
+#endif
 		SetText( wszName );
 	}
 

--- a/src/game/client/swarm/vgui/rd_vgui_main_menu_top_bar.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_main_menu_top_bar.cpp
@@ -38,10 +38,17 @@ CRD_VGUI_Main_Menu_Top_Bar::CRD_VGUI_Main_Menu_Top_Bar( vgui::Panel *parent, con
 
 	g_RD_HUD_Sheets.VidInit();
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !s_nMainMenuTopBarCount && SteamUtils() )
 	{
 		SteamUtils()->SetOverlayNotificationInset( 0, YRES( 24 ) );
 	}
+	#else
+	if ( !s_nMainMenuTopBarCount && SteamUtils() )
+	{
+		SteamUtils()->SetOverlayNotificationInset( 0, YRES( 24 ) );
+	}
+	#endif
 	s_nMainMenuTopBarCount++;
 }
 
@@ -49,9 +56,17 @@ CRD_VGUI_Main_Menu_Top_Bar::~CRD_VGUI_Main_Menu_Top_Bar()
 {
 	Assert( s_nMainMenuTopBarCount > 0 );
 	s_nMainMenuTopBarCount--;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !s_nMainMenuTopBarCount && SteamUtils() )
+#else
+	if ( !s_nMainMenuTopBarCount && SteamUtils() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUtils()->SetOverlayNotificationInset( 0, 0 );
+#else
+		SteamUtils()->SetOverlayNotificationInset( 0, 0 );
+#endif
 	}
 }
 

--- a/src/game/client/swarm/vgui/rd_vgui_notifications.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_notifications.cpp
@@ -325,7 +325,11 @@ void CRD_VGUI_Notifications_List::OnThink()
 {
 	BaseClass::OnThink();
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	int64_t iNow = SteamUtils() ? SteamUtils()->GetServerRealTime() : 0;
+#else
+	int64_t iNow = SteamUtils() ? SteamUtils()->GetServerRealTime() : 0;
+#endif
 	if ( iNow == m_iLastTimerUpdate )
 	{
 		// only update timers once per second to save some CPU cycles

--- a/src/game/client/swarm/vgui/rd_vgui_quick_report_panel.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_quick_report_panel.cpp
@@ -91,10 +91,18 @@ void CRD_VGUI_Quick_Report_Panel::ApplySchemeSettings( vgui::IScheme *pScheme )
 
 	m_pImgPlayerAvatar->SetAvatarBySteamID( &m_PlayerID );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( ISteamFriends *pFriends = SteamFriends() )
+#else
+	if ( ISteamFriends *pFriends = SteamFriends() )
+#endif
 	{
 		wchar_t wszPlayerName[k_cwchPersonaNameMax];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		V_UTF8ToUnicode( pFriends->GetFriendPersonaName( m_PlayerID ), wszPlayerName, sizeof( wszPlayerName ) );
+#else
+		V_UTF8ToUnicode( pFriends->GetFriendPersonaName( m_PlayerID ), wszPlayerName, sizeof( wszPlayerName ) );
+#endif
 		m_pLblPlayerName->SetText( wszPlayerName );
 	}
 }
@@ -180,9 +188,17 @@ void CRD_VGUI_Quick_Report_Panel::ConfirmAndSendQuickReport( const char *szTitle
 
 	static wchar_t s_wszMessage[1024];
 	wchar_t wszPlayerName[k_cwchPersonaNameMax];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( ISteamFriends *pFriends = SteamFriends() )
+#else
+	if ( ISteamFriends *pFriends = SteamFriends() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		V_UTF8ToUnicode( pFriends->GetFriendPersonaName( player ), wszPlayerName, sizeof( wszPlayerName ) );
+#else
+		V_UTF8ToUnicode( pFriends->GetFriendPersonaName( player ), wszPlayerName, sizeof( wszPlayerName ) );
+#endif
 	}
 	else
 	{

--- a/src/game/client/swarm/vgui/rd_vgui_settings_about.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_settings_about.cpp
@@ -46,7 +46,11 @@ CRD_VGUI_Settings_About::CRD_VGUI_Settings_About( vgui::Panel *parent, const cha
 
 void CRD_VGUI_Settings_About::Activate()
 {
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamApps *pApps = SteamApps();
+	#else
+	ISteamApps *pApps = SteamApps();
+	#endif
 	Assert( pApps );
 
 	wchar_t wszBuf[256];
@@ -58,7 +62,11 @@ void CRD_VGUI_Settings_About::Activate()
 	}
 	else
 	{
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		V_snwprintf( wszParam, NELEMS( wszParam ), L"%d", pApps->GetAppBuildId() );
+	#else
+		V_snwprintf( wszParam, NELEMS( wszParam ), L"%d", pApps->GetAppBuildId() );
+	#endif
 	}
 	g_pVGuiLocalize->ConstructString( wszBuf, sizeof( wszBuf ), g_pVGuiLocalize->Find( "#rd_about_build_id" ), 1, wszParam );
 	m_pLblBuildID->SetText( wszBuf );
@@ -72,7 +80,11 @@ void CRD_VGUI_Settings_About::Activate()
 	{
 		V_wcsncpy( wszParam, L"?", sizeof( wszParam ) );
 	}
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	else if ( pApps->GetCurrentBetaName( szBranch, sizeof( szBranch ) ) || szBranch[0] != '\0' )
+	#else
+	else if ( pApps->GetCurrentBetaName( szBranch, sizeof( szBranch ) ) || szBranch[0] != '\0' )
+	#endif
 	{
 		V_UTF8ToUnicode( szBranch, wszParam, sizeof( wszParam ) );
 	}

--- a/src/game/client/swarm/vgui/rd_vgui_settings_controls.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_settings_controls.cpp
@@ -104,7 +104,11 @@ void CRD_VGUI_Bind::OnKeyCodeTyped( vgui::KeyCode keycode )
 	switch ( code )
 	{
 	case KEY_XBUTTON_A:
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamInput() || !SteamInput()->ShowBindingPanel( g_RD_Steam_Input.m_hLastControllerWithEvent ) )
+#else
+		if ( !SteamInput() || !SteamInput()->ShowBindingPanel( g_RD_Steam_Input.m_hLastControllerWithEvent ) )
+#endif
 		{
 			CBaseModPanel::GetSingleton().PlayUISound( UISOUND_INVALID );
 		}
@@ -129,7 +133,11 @@ void CRD_VGUI_Bind::OnMouseReleased( vgui::MouseCode code )
 
 		if ( m_pPnlControllerIcon->IsCursorOver() && g_RD_Steam_Input.Key_LookupBindingEx( m_szBind, -1, 0, 1 ) )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( !SteamInput() || !SteamInput()->ShowBindingPanel( g_RD_Steam_Input.m_hLastControllerWithEvent ) )
+#else
+			if ( !SteamInput() || !SteamInput()->ShowBindingPanel( g_RD_Steam_Input.m_hLastControllerWithEvent ) )
+#endif
 			{
 				CBaseModPanel::GetSingleton().PlayUISound( UISOUND_INVALID );
 			}
@@ -423,15 +431,27 @@ void CRD_VGUI_Settings_Controls::OnThink()
 	EInputActionOrigin eMove = g_RD_Steam_Input.OriginFromPlaceholderString( g_RD_Steam_Input.Key_LookupBindingEx( "xmove", -1, 0, 1 ) );
 	EInputActionOrigin eLook = g_RD_Steam_Input.OriginFromPlaceholderString( g_RD_Steam_Input.Key_LookupBindingEx( "xlook", -1, 0, 1 ) );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamInput() || ( eMove == k_EInputActionOrigin_None && eLook == k_EInputActionOrigin_None ) )
+#else
+	if ( !SteamInput() || ( eMove == k_EInputActionOrigin_None && eLook == k_EInputActionOrigin_None ) )
+#endif
 	{
 		m_pLblLeftStickAction->SetVisible( false );
 		m_pLblRightStickAction->SetVisible( false );
 	}
 	else
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		EInputActionOrigin eDeckMove = SteamInput()->TranslateActionOrigin( k_ESteamInputType_SteamDeckController, eMove );
+#else
+		EInputActionOrigin eDeckMove = SteamInput()->TranslateActionOrigin( k_ESteamInputType_SteamDeckController, eMove );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		EInputActionOrigin eDeckLook = SteamInput()->TranslateActionOrigin( k_ESteamInputType_SteamDeckController, eLook );
+#else
+		EInputActionOrigin eDeckLook = SteamInput()->TranslateActionOrigin( k_ESteamInputType_SteamDeckController, eLook );
+#endif
 
 		m_bMoveStickLeft = eDeckMove == k_EInputActionOrigin_SteamDeck_LeftStick_Move || eDeckMove == k_EInputActionOrigin_SteamDeck_LeftPad_Swipe;
 		m_bMoveStickRight = eDeckMove == k_EInputActionOrigin_SteamDeck_RightStick_Move || eDeckMove == k_EInputActionOrigin_SteamDeck_RightPad_Swipe;

--- a/src/game/client/swarm/vgui/rd_vgui_settings_options_2.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_settings_options_2.cpp
@@ -136,14 +136,26 @@ void CRD_VGUI_Settings_Options_2::Activate()
 
 	m_pSettingSpeedTimerColor->SetEnabled( rd_draw_timer.GetBool() );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUserStats *pUserStats = SteamUserStats();
+#else
+	ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 	Assert( pUserStats );
 	int32_t iStatsOptOut = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !m_pSettingLeaderboardPrivateStats->IsEnabled() && pUserStats && pUserStats->GetStat( "stats_display_opt_out", &iStatsOptOut ) )
 	{
 		m_pSettingLeaderboardPrivateStats->SetCurrentSliderValue( iStatsOptOut );
 		m_pSettingLeaderboardPrivateStats->SetEnabled( true );
 	}
+#else
+	if ( !m_pSettingLeaderboardPrivateStats->IsEnabled() && pUserStats && pUserStats->GetStat( "stats_display_opt_out", &iStatsOptOut ) )
+	{
+		m_pSettingLeaderboardPrivateStats->SetCurrentSliderValue( iStatsOptOut );
+		m_pSettingLeaderboardPrivateStats->SetEnabled( true );
+	}
+#endif
 
 	// not ready yet
 	m_pSettingStrangeRankUp->SetVisible( false );
@@ -153,12 +165,17 @@ void CRD_VGUI_Settings_Options_2::OnCurrentOptionChanged( vgui::Panel *panel )
 {
 	if ( panel == m_pSettingLeaderboardPrivateStats )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUserStats *pUserStats = SteamUserStats();
+#else
+		ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 		Assert( pUserStats );
 		if ( pUserStats )
 		{
 			int32_t iStatsOptOutNew = int32_t( m_pSettingLeaderboardPrivateStats->GetCurrentSliderValue() );
 			int32_t iStatsOptOutOld = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( pUserStats->GetStat( "stats_display_opt_out", &iStatsOptOutOld ) && iStatsOptOutOld != iStatsOptOutNew )
 			{
 				Msg( "Setting stats_display_opt_out to %d\n", iStatsOptOutNew );
@@ -166,6 +183,15 @@ void CRD_VGUI_Settings_Options_2::OnCurrentOptionChanged( vgui::Panel *panel )
 				pUserStats->StoreStats();
 				m_pSettingLeaderboardPrivateStats->SetEnabled( false );
 			}
+#else
+			if ( pUserStats->GetStat( "stats_display_opt_out", &iStatsOptOutOld ) && iStatsOptOutOld != iStatsOptOutNew )
+			{
+				Msg( "Setting stats_display_opt_out to %d\n", iStatsOptOutNew );
+				pUserStats->SetStat( "stats_display_opt_out", iStatsOptOutNew );
+				pUserStats->StoreStats();
+				m_pSettingLeaderboardPrivateStats->SetEnabled( false );
+			}
+#endif
 		}
 	}
 

--- a/src/game/client/swarm/vgui/rd_vgui_stock_ticker.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_stock_ticker.cpp
@@ -492,7 +492,11 @@ void CRD_VGUI_Stock_Ticker::GenerateTickerText( KeyValues *pDef, wchar_t *&wszTe
 		int iDays = pDef->GetInt( "days", 30 );
 		Assert( iDays <= 60 );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUserStats *pUserStats = SteamUserStats();
+#else
+		ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 		if ( !pUserStats )
 		{
 			delete[] wszText;
@@ -508,7 +512,11 @@ void CRD_VGUI_Stock_Ticker::GenerateTickerText( KeyValues *pDef, wchar_t *&wszTe
 				continue;
 
 			int64 iStatHistory[60];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			int iDaysRetrieved = pUserStats->GetGlobalStatHistory( pValue->GetString(), iStatHistory, sizeof( iStatHistory ) );
+#else
+			int iDaysRetrieved = pUserStats->GetGlobalStatHistory( pValue->GetString(), iStatHistory, sizeof( iStatHistory ) );
+#endif
 			if ( iDaysRetrieved < iDays )
 			{
 				// failed to retrieve stats; will try again next time this comes up

--- a/src/game/client/swarm/vgui/rd_vgui_workshop_download_progress.cpp
+++ b/src/game/client/swarm/vgui/rd_vgui_workshop_download_progress.cpp
@@ -58,7 +58,11 @@ void CRD_VGUI_Workshop_Download_Progress::OnThink()
 
 	BaseClass::OnThink();
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pUGC = SteamUGC();
+#else
+	ISteamUGC *pUGC = SteamUGC();
+#endif
 	AssertOnce( pUGC );
 	if ( !pUGC )
 	{
@@ -81,7 +85,11 @@ void CRD_VGUI_Workshop_Download_Progress::OnThink()
 		{
 			const auto &addon = g_ReactiveDropWorkshop.m_EnabledAddons[i];
 			PublishedFileId_t nPublishedFileID = addon.details.m_nPublishedFileId;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			uint32 itemState = pUGC->GetItemState( nPublishedFileID );
+#else
+			uint32 itemState = pUGC->GetItemState( nPublishedFileID );
+#endif
 
 			if ( itemState & k_EItemStateDownloadPending )
 			{
@@ -92,7 +100,11 @@ void CRD_VGUI_Workshop_Download_Progress::OnThink()
 			if ( !s_bFoundDownloadWithProgress && ( itemState & k_EItemStateDownloading ) )
 			{
 				uint64 nBytesDownloaded, nBytesTotal;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				if ( pUGC->GetItemDownloadInfo( nPublishedFileID, &nBytesDownloaded, &nBytesTotal ) && nBytesDownloaded > 0 )
+#else
+				if ( pUGC->GetItemDownloadInfo( nPublishedFileID, &nBytesDownloaded, &nBytesTotal ) && nBytesDownloaded > 0 )
+#endif
 				{
 					s_iBestAddonIndex = i;
 					s_nBestBytesDownloaded = nBytesDownloaded;
@@ -155,7 +167,11 @@ void CRD_VGUI_Workshop_Download_Progress::OnThink()
 	if ( !s_bFoundDownloadWithProgress )
 	{
 		// Only query if not already found in the loop
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetItemDownloadInfo( nPublishedFileID, &nBytesDownloaded, &nBytesTotal );
+#else
+		pUGC->GetItemDownloadInfo( nPublishedFileID, &nBytesDownloaded, &nBytesTotal );
+#endif
 
 		// We are busy, reset s_nLastAddonCount to force a re-scan
 		s_nLastAddonCount = -1;

--- a/src/game/client/swarm/vgui/stats_report.cpp
+++ b/src/game/client/swarm/vgui/stats_report.cpp
@@ -424,7 +424,11 @@ void StatsReport::SetPlayerNames( void )
 					{
 						if ( pi.friendsID )
 						{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 							CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+#else
+							CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+#endif
 							steamID = steamIDForPlayer;
 						}
 					}

--- a/src/game/client/vgui_avatarimage.cpp
+++ b/src/game/client/vgui_avatarimage.cpp
@@ -60,27 +60,47 @@ bool CAvatarImage::SetAvatarSteamID( CSteamID steamIDUser, bool bFetch )
 	ClearAvatarSteamID();
 	m_steamIDUser = steamIDUser;
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamFriends() && SteamUtils() )
+#else
+	if ( SteamFriends() && SteamUtils() )
+#endif
 	{
 		m_SteamID = steamIDUser;
 
 		// if this goes through we'll get a callback
 		if ( bFetch )
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamFriends()->RequestUserInformation( m_SteamID, false );
+#else
+			SteamFriends()->RequestUserInformation( m_SteamID, false );
+#endif
 
 		int iAvatar;
 
 		switch ( m_SourceArtSize )
 		{
 		case k_EAvatarSize32x32:
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			iAvatar = SteamFriends()->GetSmallFriendAvatar( steamIDUser );
+#else
+			iAvatar = SteamFriends()->GetSmallFriendAvatar( steamIDUser );
+#endif
 			break;
 		case k_EAvatarSize64x64:
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			iAvatar = SteamFriends()->GetMediumFriendAvatar( steamIDUser );
+#else
+			iAvatar = SteamFriends()->GetMediumFriendAvatar( steamIDUser );
+#endif
 			break;
 		case k_EAvatarSize184x184:
 		default:
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			iAvatar = SteamFriends()->GetLargeFriendAvatar( steamIDUser );
+#else
+			iAvatar = SteamFriends()->GetLargeFriendAvatar( steamIDUser );
+#endif
 			break;
 		}
 
@@ -89,11 +109,19 @@ bool CAvatarImage::SetAvatarSteamID( CSteamID steamIDUser, bool bFetch )
 		*/
 
 		uint32 wide, tall;
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUtils()->GetImageSize( iAvatar, &wide, &tall ) )
+		#else
+		if ( SteamUtils()->GetImageSize( iAvatar, &wide, &tall ) )
+		#endif
 		{
 			int cubImage = wide * tall * 4;
 			byte *rgubDest = new byte[cubImage];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamUtils()->GetImageRGBA( iAvatar, rgubDest, cubImage );
+#else
+			SteamUtils()->GetImageRGBA( iAvatar, rgubDest, cubImage );
+#endif
 			InitFromRGBA( rgubDest, wide, tall );
 			delete[] rgubDest;
 		}
@@ -112,9 +140,17 @@ void CAvatarImage::UpdateFriendStatus( void )
 	if ( !m_SteamID.IsValid() )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamFriends() && SteamUtils() )
+#else
+	if ( SteamFriends() && SteamUtils() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_bFriend = SteamFriends()->HasFriend( m_SteamID, k_EFriendFlagImmediate );
+#else
+		m_bFriend = SteamFriends()->HasFriend( m_SteamID, k_EFriendFlagImmediate );
+#endif
 		if ( m_bFriend && !m_pFriendIcon )
 		{
 			m_pFriendIcon = HudIcons().GetIcon( "ico_friend_indicator_avatar" );
@@ -217,14 +253,22 @@ void CAvatarImagePanel::SetPlayer( C_BasePlayer *pPlayer )
 //-----------------------------------------------------------------------------
 void CAvatarImagePanel::SetPlayerByIndex( int iIndex )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( iIndex && SteamUtils() )
+#else
+	if ( iIndex && SteamUtils() )
+#endif
 	{
 		player_info_t pi;
 		if ( engine->GetPlayerInfo(iIndex, &pi) )
 		{
 			if ( pi.friendsID )
 			{
+				#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+				#else
+				CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+				#endif
 				SetAvatarBySteamID( &steamIDForPlayer );
 			}
 		}

--- a/src/game/client/vgui_avatarimage.h
+++ b/src/game/client/vgui_avatarimage.h
@@ -121,7 +121,11 @@ private:
 	CSteamID	m_SteamID;
 	EAvatarSize m_SourceArtSize;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CAvatarImage, OnPersonaStateChange, PersonaStateChange_t );
+#else
+	STEAM_CALLBACK( CAvatarImage, OnPersonaStateChange, PersonaStateChange_t );
+#endif
 };
 
 //-----------------------------------------------------------------------------

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -614,6 +614,12 @@ static bool InitGameSystems( CreateInterfaceFn appSystemFactory )
 CServerGameDLL g_ServerGameDLL;
 EXPOSE_SINGLE_INTERFACE_GLOBALVAR(CServerGameDLL, IServerGameDLL, INTERFACEVERSION_SERVERGAMEDLL, g_ServerGameDLL);
 
+#ifndef STEAMAPPS_INTERFACE_VERSION008
+#ifndef CLIENT_DLL
+static bool s_bSteamGameServerInitialized = false;
+#endif
+#endif
+
 bool CServerGameDLL::DLLInit( CreateInterfaceFn appSystemFactory, 
 		CreateInterfaceFn physicsFactory, CreateInterfaceFn fileSystemFactory, 
 		CGlobalVars *pGlobals)
@@ -624,8 +630,15 @@ bool CServerGameDLL::DLLInit( CreateInterfaceFn appSystemFactory,
 
 	// initialize a game server. this call was in engine before, but not anymore. we need to call it from somewhere
 	// initialize the gameserver, srcds already binds to the correct ip and ports, so we can just pass 0 here to all parameters
-	bool r = SteamGameServer_Init(0, 0, 0, eServerModeAuthenticationAndSecure, "7149");
-	ConMsg("StartGameServer_Init resulted in %d\n", r);
+	if ( !s_bSteamGameServerInitialized )
+	{
+		bool r = SteamGameServer_Init(0, 0, 0, eServerModeAuthenticationAndSecure, "7149");
+		ConMsg("StartGameServer_Init resulted in %d\n", r);
+		if ( !r )
+			return false;
+
+		s_bSteamGameServerInitialized = true;
+	}
 #endif
 #endif
 
@@ -900,6 +913,16 @@ void CServerGameDLL::DLLShutdown( void )
 		delete TheNavMesh;
 		TheNavMesh = NULL;
 	}
+
+#ifndef STEAMAPPS_INTERFACE_VERSION008
+#ifndef CLIENT_DLL
+	if ( s_bSteamGameServerInitialized )
+	{
+		SteamGameServer_Shutdown();
+		s_bSteamGameServerInitialized = false;
+	}
+#endif
+#endif
 
 	DisconnectTier3Libraries();
 	DisconnectTier2Libraries();
@@ -1294,7 +1317,11 @@ void CServerGameDLL::GameFrame( bool simulating )
 #ifndef NO_STEAM
 	// All the calls to us from the engine prior to gameframe (like LevelInit & ServerActivate)
 	// are done before the engine has got the Steam API connected, so we have to wait until now to connect ourselves.
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamGameServerStats() )
+#else
+	if ( SteamGameServerStats() )
+#endif
 	{
 		GameRules()->UpdateGameplayStatsFromSteam();
 	}
@@ -1469,6 +1496,7 @@ void CServerGameDLL::Think( bool finalTick )
 {
 	// this is normally done in engine, but not anymore
 	// we need to put this here
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if (SteamGameServer()) {
 		bool bLoggedIn = SteamGameServer()->BLoggedOn();
 		if (!bLoggedIn) {
@@ -1477,6 +1505,16 @@ void CServerGameDLL::Think( bool finalTick )
 	}
 
 	SteamGameServer_RunCallbacks();
+#else
+	if (SteamGameServer()) {
+		bool bLoggedIn = SteamGameServer()->BLoggedOn();
+		if (!bLoggedIn) {
+			SteamGameServer()->LogOnAnonymous();
+		}
+	}
+
+	SteamGameServer_RunCallbacks();
+#endif
 
 	// because steam_api and engine are disagreeing, sv_lan is set to 1
 	// this is not because they are incompatible, but because the init in engine is gone

--- a/src/game/server/swarm/asw_player.h
+++ b/src/game/server/swarm/asw_player.h
@@ -313,7 +313,11 @@ public:
 	int   m_iKillingSpree;
 
 #if !defined(NO_STEAM)
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult< CASW_Player, UserStatsReceived_t > m_CallbackUserStatsReceived;
+#else
+	CCallResult< CASW_Player, UserStatsReceived_t > m_CallbackUserStatsReceived;
+#endif
 	void Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsReceived, bool bError );
 #endif
 	CNetworkVar( unsigned, m_iScreenWidthHeight );

--- a/src/game/shared/achievementmgr.cpp
+++ b/src/game/shared/achievementmgr.cpp
@@ -56,10 +56,17 @@ static CDllDemandLoader g_GameUI( "gameui" );	// FIXME: This is duplicated!
 
 #ifdef DEDICATED
 // Hack this for now until we get steam_api recompiling in the Steam codebase.
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 ISteamUserStats *SteamUserStats()
 {
 	return NULL;
 }
+#else
+ISteamUserStats *SteamUserStats()
+{
+	return NULL;
+}
+#endif
 #endif
 
 #if defined( XBX_GetPrimaryUserId )
@@ -535,7 +542,11 @@ void CAchievementMgr::UserConnected( int nUserSlot )
 		// ASSERT( STEAM_PLAYER_SLOT == nUserSlot )
 
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUserStats() )
+#else
+		if ( SteamUserStats() )
+#endif
 		{
 			// request stat download; will get called back at OnUserStatsReceived when complete
 
@@ -543,7 +554,7 @@ void CAchievementMgr::UserConnected( int nUserSlot )
 		// This call is no longer required as it is managed by the Steam client. The game stats and achievements
 		// will be synchronized with Steam before the game process begins.
 		// [Obsolete("No longer required. Automatically handled by the Steam client.", false)]
-#if defined(STEAMAPPS_INTERFACE_VERSION008)
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamUserStats()->RequestCurrentStats();
 #else
 			SteamUserStats()->RequestUserStats(SteamUser()->GetSteamID());
@@ -645,7 +656,11 @@ void CAchievementMgr::UploadUserData( int nUserSlot )
 #ifdef CLIENT_DLL
 	if ( IsPC() && ( nUserSlot == STEAM_PLAYER_SLOT ) )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUserStats() )
+#else
+		if ( SteamUserStats() )
+#endif
 		{
 			if ( m_flWaitingForStoreStatsCallback > 0.0f )
 			{
@@ -654,7 +669,11 @@ void CAchievementMgr::UploadUserData( int nUserSlot )
 			}
 			// Upload current Steam client achievements & stats state to Steam.  Will get called back at OnUserStatsStored when complete.
 			// Only values previously set via SteamUserStats() get uploaded
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( SteamUserStats()->StoreStats() )
+#else
+			if ( SteamUserStats()->StoreStats() )
+#endif
 			{
 				m_flWaitingForStoreStatsCallback = gpGlobals->curtime;
 			}
@@ -780,11 +799,19 @@ void CAchievementMgr::AwardAchievement( int iAchievementID, int nUserSlot )
 
 	if ( IsPC() )
 	{		
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUserStats() )
+#else
+		if ( SteamUserStats() )
+#endif
 		{
 			VPROF_BUDGET( "AwardAchievement", VPROF_BUDGETGROUP_STEAM );
 			// set this achieved in the Steam client
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			bool bRet = SteamUserStats()->SetAchievement( pAchievement->GetName() );
+#else
+			bool bRet = SteamUserStats()->SetAchievement( pAchievement->GetName() );
+#endif
 			//		Assert( bRet );
 			if ( bRet )
 			{
@@ -938,7 +965,11 @@ bool CAchievementMgr::CheckAchievementsEnabled( )
 			// Cheats get turned on automatically if you run with -dev which many people do internally, so allow cheats if developer is turned on and we're not running
 			// on Steam public
 #ifdef CLIENT_DLL
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( ( developer.GetInt() == 0 ) || !SteamUtils() || ( k_EUniversePublic == SteamUtils()->GetConnectedUniverse() ) )
+			#else
+			if ( ( developer.GetInt() == 0 ) || !SteamUtils() || ( k_EUniversePublic == SteamUtils()->GetConnectedUniverse() ) )
+			#endif
 #else
 			if ( developer.GetInt() == 0 )
 #endif
@@ -992,7 +1023,11 @@ bool CalcPlayersOnFriendsList( int iMinFriends )
 
 	if ( IsPC() )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamFriends() || !SteamUtils() || !g_pGameRules->IsMultiplayer() )
+#else
+		if ( !SteamFriends() || !SteamUtils() || !g_pGameRules->IsMultiplayer() )
+#endif
 			return false;
 	}
 	else if ( IsX360() )
@@ -1023,8 +1058,16 @@ bool CalcPlayersOnFriendsList( int iMinFriends )
 					continue;
 
 				// check and see if they're on the local player's friends list
+				#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				CSteamID steamID( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+				#else
+				CSteamID steamID( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+				#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				if ( !SteamFriends()->HasFriend( steamID, /*k_EFriendFlagImmediate*/ 0x04 ) )
+#else
+				if ( !SteamFriends()->HasFriend( steamID, /*k_EFriendFlagImmediate*/ 0x04 ) )
+#endif
 					continue;
 			}
 			else if ( IsX360() )
@@ -1065,16 +1108,28 @@ bool CalcHasNumClanPlayers( int iClanTeammates )
 		if ( CalcPlayerCount()-1 < iClanTeammates )
 			return false;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamFriends() || !SteamUtils() || !g_pGameRules->IsMultiplayer() )
+#else
+		if ( !SteamFriends() || !SteamUtils() || !g_pGameRules->IsMultiplayer() )
+#endif
 			return false;
 
 		// determine local player team
 		int iLocalPlayerIndex =  GetLocalPlayerIndex();
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		for ( int iClan = 0; iClan < SteamFriends()->GetClanCount(); iClan++ )
+#else
+		for ( int iClan = 0; iClan < SteamFriends()->GetClanCount(); iClan++ )
+#endif
 		{
 			int iClanMembersOnTeam = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			CSteamID clanID = SteamFriends()->GetClanByIndex( iClan );
+#else
+			CSteamID clanID = SteamFriends()->GetClanByIndex( iClan );
+#endif
 			// enumerate all players
 			for( int iPlayerIndex = 1 ; iPlayerIndex <= MAX_PLAYERS; iPlayerIndex++ )
 			{
@@ -1084,8 +1139,16 @@ bool CalcHasNumClanPlayers( int iClanTeammates )
 					if ( engine->GetPlayerInfo( iPlayerIndex, &pi ) && ( pi.friendsID ) )
 					{	
 						// check and see if they're on the local player's friends list
+						#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 						CSteamID steamID( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+						#else
+						CSteamID steamID( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+						#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 						if ( SteamFriends()->IsUserInSource( steamID, clanID ) )
+#else
+						if ( SteamFriends()->IsUserInSource( steamID, clanID ) )
+#endif
 						{
 							iClanMembersOnTeam++;
 							if ( iClanMembersOnTeam == iClanTeammates )
@@ -1561,8 +1624,16 @@ void CAchievementMgr::OnEvent( KeyValues *pEvent )
 void CAchievementMgr::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsReceived )
 {
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamUserStats() );
+#else
+	Assert( SteamUserStats() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUserStats() )
+#else
+	if ( !SteamUserStats() )
+#endif
 		return;
 
 	if ( pUserStatsReceived->m_eResult != k_EResultOK )
@@ -1581,17 +1652,29 @@ void CAchievementMgr::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStats
 		int nCount = 0;
 		int nComponentBits = 0;
 		bool bAchieved = false;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bool bRet1 = SteamUserStats()->GetAchievement( pAchievement->GetName(), &bAchieved );
+#else
+		bool bRet1 = SteamUserStats()->GetAchievement( pAchievement->GetName(), &bAchieved );
+#endif
 
 #ifdef INFESTED_DLL
 		if ( bRet1 )
 #else
 		// TODO: these look hardcoded for L4D2 - remove?
 		Q_snprintf( szFieldName, sizeof( szFieldName ), "TD2.Achievements.Count.%02d", i );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bool bRet2 = SteamUserStats()->GetStat( szFieldName, &nCount );
+#else
+		bool bRet2 = SteamUserStats()->GetStat( szFieldName, &nCount );
+#endif
 
 		Q_snprintf( szFieldName, sizeof( szFieldName ), "TD2.Achievements.Comp.%02d", i );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bool bRet3 = SteamUserStats()->GetStat( szFieldName, &nComponentBits );
+#else
+		bool bRet3 = SteamUserStats()->GetStat( szFieldName, &nComponentBits );
+#endif
 
 		if ( bRet1 && bRet2 && bRet3 )
 #endif
@@ -1617,7 +1700,11 @@ void CAchievementMgr::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStats
 			int iValue;
 			char pszProgressName[1024];
 			Q_snprintf( pszProgressName, 1024, "%s_STAT", pAchievement->GetName() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( SteamUserStats()->GetStat( pszProgressName, &iValue ) )
+#else
+			if ( SteamUserStats()->GetStat( pszProgressName, &iValue ) )
+#endif
 			{
 				pAchievement->SetCount( iValue );
 			}
@@ -1629,7 +1716,11 @@ void CAchievementMgr::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStats
 			if ( pAchievement->HasComponents() )
 			{
 				Q_snprintf( pszProgressName, 1024, "%s_COMP", pAchievement->GetName() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				if ( SteamUserStats()->GetStat( pszProgressName, &iValue ) )
+#else
+				if ( SteamUserStats()->GetStat( pszProgressName, &iValue ) )
+#endif
 				{
 					pAchievement->SetComponentBits( iValue );
 				}
@@ -1717,9 +1808,17 @@ void CAchievementMgr::ResetAchievement_Internal( CBaseAchievement *pAchievement 
 #ifdef CLIENT_DLL
 	Assert( pAchievement );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUserStats() )
+#else
+	if ( SteamUserStats() )
+#endif
 	{
-		SteamUserStats()->ClearAchievement( pAchievement->GetName() );		
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
+		SteamUserStats()->ClearAchievement( pAchievement->GetName() );
+#else
+		SteamUserStats()->ClearAchievement( pAchievement->GetName() );
+#endif
 	}
 
 	pAchievement->SetAchieved( false );
@@ -1935,4 +2034,3 @@ void CAchievementMgr::ClearAchievementData( int nUserSlot )
 		m_mapAchievement[nUserSlot][i]->ClearAchievementData();
 	}
 }
-

--- a/src/game/shared/achievementmgr.h
+++ b/src/game/shared/achievementmgr.h
@@ -71,7 +71,11 @@ public:
 	virtual void OnEvent( KeyValues *pEvent );
 
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	bool LoggedIntoSteam() { return ( SteamUser() && SteamUserStats() && SteamUser()->BLoggedOn() ); }
+#else
+	bool LoggedIntoSteam() { return ( SteamUser() && SteamUserStats() && SteamUser()->BLoggedOn() ); }
+#endif
 #else
 	bool LoggedIntoSteam() { return false; }
 #endif
@@ -80,8 +84,16 @@ public:
 	bool WereCheatsEverOn( void ) { return m_bCheatsEverOn; }
 
 #if !defined(NO_STEAM)
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CAchievementMgr, Steam_OnUserStatsReceived, UserStatsReceived_t );
+#else
+	STEAM_CALLBACK( CAchievementMgr, Steam_OnUserStatsReceived, UserStatsReceived_t );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CAchievementMgr, Steam_OnUserStatsStored, UserStatsStored_t );
+#else
+	STEAM_CALLBACK( CAchievementMgr, Steam_OnUserStatsStored, UserStatsStored_t );
+#endif
 #endif
 	const CUtlVector<int>& GetAchievedDuringCurrentGame( int nPlayerSlot );
 	void ResetAchievedDuringCurrentGame( int nPlayerSlot );

--- a/src/game/shared/baseachievement.cpp
+++ b/src/game/shared/baseachievement.cpp
@@ -241,7 +241,11 @@ void CBaseAchievement::IncrementCount()
 
 #if !defined( NO_STEAM )
 		// if this achievement's progress should be stored in Steam, set the steam stat for it
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( StoreProgressInSteam() && SteamUserStats() )
+#else
+		if ( StoreProgressInSteam() && SteamUserStats() )
+#endif
 		{
 			// Set the Steam stat with the same name as the achievement.  Only cached locally until we upload it.
 			char pszProgressName[1024];
@@ -249,7 +253,11 @@ void CBaseAchievement::IncrementCount()
 #if defined( INFESTED_DLL ) && defined( CLIENT_DLL )
 			RD_Swarmopedia::CheckArticleUnlock( pszProgressName, m_iCount - 1, m_iCount );
 #endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			bool bRet = SteamUserStats()->SetStat( pszProgressName, m_iCount );
+#else
+			bool bRet = SteamUserStats()->SetStat( pszProgressName, m_iCount );
+#endif
 			if ( !bRet )
 			{
 				DevMsg( "ISteamUserStats::GetStat failed to set progress value in Steam for achievement %s\n", pszProgressName );
@@ -259,7 +267,11 @@ void CBaseAchievement::IncrementCount()
 			{
 				Q_snprintf( pszProgressName, 1024, "%s_COMP", GetName() );
 				int32 bits = (int32) GetComponentBits();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				bRet = SteamUserStats()->SetStat( pszProgressName, bits );
+#else
+				bRet = SteamUserStats()->SetStat( pszProgressName, bits );
+#endif
 				if ( !bRet )
 				{
 					DevMsg( "ISteamUserStats::GetStat failed to set component value in Steam for achievement %s\n", pszProgressName );
@@ -468,12 +480,20 @@ void CBaseAchievement::EnsureComponentBitSetAndEvaluate( int iBitNumber )
 
 #if !defined( NO_STEAM )
 		// if this achievement's progress should be stored in Steam, set the steam stat for it
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( StoreProgressInSteam() && SteamUserStats() )
+#else
+		if ( StoreProgressInSteam() && SteamUserStats() )
+#endif
 		{
 			// Set the Steam stat with the same name as the achievement.  Only cached locally until we upload it.
 			char pszProgressName[1024];
 			Q_snprintf( pszProgressName, 1024, "%s_STAT", GetName() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			bool bRet = SteamUserStats()->SetStat( pszProgressName, m_iCount );
+#else
+			bool bRet = SteamUserStats()->SetStat( pszProgressName, m_iCount );
+#endif
 			if ( !bRet )
 			{
 				DevMsg( "ISteamUserStats::GetStat failed to set progress value in Steam for achievement %s\n", pszProgressName );
@@ -483,7 +503,11 @@ void CBaseAchievement::EnsureComponentBitSetAndEvaluate( int iBitNumber )
 			{
 				Q_snprintf( pszProgressName, 1024, "%s_COMP", GetName() );
 				int32 bits = (int32) GetComponentBits();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				bRet = SteamUserStats()->SetStat( pszProgressName, bits );
+#else
+				bRet = SteamUserStats()->SetStat( pszProgressName, bits );
+#endif
 				if ( !bRet )
 				{
 					DevMsg( "ISteamUserStats::GetStat failed to set component value in Steam for achievement %s\n", pszProgressName );

--- a/src/game/shared/swarm/asw_achievements.cpp
+++ b/src/game/shared/swarm/asw_achievements.cpp
@@ -1187,7 +1187,11 @@ class CAchievement_Die_In_Many_Ways : public CASW_Achievement
 
 	void CheckDeathTypeCount()
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUserStats *pSteamUserStats = SteamUserStats();
+#else
+		ISteamUserStats *pSteamUserStats = SteamUserStats();
+#endif
 		if ( !pSteamUserStats )
 			return;
 
@@ -1195,6 +1199,7 @@ class CAchievement_Die_In_Many_Ways : public CASW_Achievement
 		int nDeathTypes = 0;
 		for ( int i = 0; i < DEATHCAUSE_COUNT && !IsAchieved(); i++ )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( pSteamUserStats->GetStat( g_szDeathCauseStatName[i], &nCount ) && nCount )
 			{
 				nDeathTypes++;
@@ -1203,6 +1208,16 @@ class CAchievement_Die_In_Many_Ways : public CASW_Achievement
 					IncrementCount();
 				}
 			}
+#else
+			if ( pSteamUserStats->GetStat( g_szDeathCauseStatName[i], &nCount ) && nCount )
+			{
+				nDeathTypes++;
+				if ( nDeathTypes > GetCount() )
+				{
+					IncrementCount();
+				}
+			}
+#endif
 		}
 	}
 

--- a/src/game/shared/swarm/asw_fx_shared.cpp
+++ b/src/game/shared/swarm/asw_fx_shared.cpp
@@ -276,7 +276,11 @@ public:
 		if ( engine->IsPlayingDemo() || !pMarine || !pMarine->IsInhabited() || !pMarine->GetCommander() || !pMarine->GetCommander()->IsLocalPlayer() || !ASWGameRules() || ASWGameRules()->m_bCheated )
 			return false;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pSteamInventory = SteamInventory();
+#else
+		ISteamInventory *pSteamInventory = SteamInventory();
+#endif
 		if ( !pSteamInventory )
 			return false;
 
@@ -284,9 +288,17 @@ public:
 		if ( pMarine->m_bOnFire && pMarine->IsInfested() )
 		{
 			SteamInventoryResult_t hResult;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( pSteamInventory->AddPromoItem( &hResult, 28 ) )
+#else
+			if ( pSteamInventory->AddPromoItem( &hResult, 28 ) )
+#endif
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pSteamInventory->DestroyResult( hResult );
+#else
+				pSteamInventory->DestroyResult( hResult );
+#endif
 			}
 		}
 
@@ -333,5 +345,4 @@ BEGIN_NETWORK_TABLE( CPointToiletFlushable, DT_PointToiletFlushable )
 	RecvPropTime( RECVINFO( m_flNextUse ) ),
 #endif
 END_NETWORK_TABLE()
-
 

--- a/src/game/shared/swarm/asw_gamerules.cpp
+++ b/src/game/shared/swarm/asw_gamerules.cpp
@@ -381,7 +381,11 @@ static void UpdateMatchmakingTagsCallback( IConVar *pConVar, const char *pOldVal
 	}
 
 	// mm_max_players gets updated after it's read for the lobby, so we need to update the slot count here as well.
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamMatchmaking()->SetLobbyMemberLimit( UTIL_RD_GetCurrentLobbyID(), gpGlobals->maxClients );
+#else
+	SteamMatchmaking()->SetLobbyMemberLimit( UTIL_RD_GetCurrentLobbyID(), gpGlobals->maxClients );
+#endif
 	UTIL_RD_UpdateCurrentLobbyData( "members:numSlots", gpGlobals->maxClients );
 
 	{
@@ -419,17 +423,34 @@ static void UpdateMatchmakingTagsCallback( IConVar *pConVar, const char *pOldVal
 	UTIL_RD_UpdateCurrentLobbyData( "system:map_version", GetClientWorldEntity()->m_nMapVersion );
 	UTIL_RD_UpdateCurrentLobbyData( "system:server_version", uint64_t( pAlienSwarm->m_iServerVersion ) );
 	UTIL_RD_UpdateCurrentLobbyData( "system:pure", sv_consistency.GetInt() );
-	if ( ISteamApps *pSteamApps = SteamApps() )
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
+	ISteamApps *pSteamApps = SteamApps();
+	#else
+	ISteamApps *pSteamApps = SteamApps();
+	#endif
+	if ( pSteamApps )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		UTIL_RD_UpdateCurrentLobbyData( "system:game_build", pSteamApps->GetAppBuildId() );
+		#else
+		UTIL_RD_UpdateCurrentLobbyData( "system:game_build", pSteamApps->GetAppBuildId() );
+		#endif
 		char szBranch[256]{};
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pSteamApps->GetCurrentBetaName( szBranch, sizeof( szBranch ) );
+		#else
+		pSteamApps->GetCurrentBetaName( szBranch, sizeof( szBranch ) );
+		#endif
 		UTIL_RD_UpdateCurrentLobbyData( "system:game_branch", szBranch );
 
 		KeyValues::AutoDelete pUpdate( "update" );
 		pUpdate->SetString( "update/system/game_version", engine->GetProductVersionString() );
 		pUpdate->SetInt( "update/system/map_version", GetClientWorldEntity()->m_nMapVersion );
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUpdate->SetInt( "update/system/game_build", pSteamApps->GetAppBuildId() );
+		#else
+		pUpdate->SetInt( "update/system/game_build", pSteamApps->GetAppBuildId() );
+		#endif
 		pUpdate->SetString( "update/system/game_branch", szBranch );
 		g_pMatchFramework->GetMatchSession()->UpdateSessionSettings( pUpdate );
 	}
@@ -3947,7 +3968,11 @@ void CAlienSwarm::OnSteamRelayNetworkStatusChanged( SteamRelayNetworkStatus_t *p
 	if ( !pParam->m_bPingMeasurementInProgress )
 	{
 		SteamNetworkPingLocation_t location;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		float flAge = SteamNetworkingUtils()->GetLocalPingLocation( location );
+#else
+		float flAge = SteamNetworkingUtils()->GetLocalPingLocation( location );
+#endif
 		if ( flAge >= 0 )
 		{
 			DevMsg( 2, "Updated server ping location. New age: %f\n", flAge );
@@ -3960,10 +3985,18 @@ void CAlienSwarm::Think()
 {
 	if ( m_bShuttingDown ) return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !m_bObtainedPingLocation && SteamNetworkingUtils() )
+#else
+	if ( !m_bObtainedPingLocation && SteamNetworkingUtils() )
+#endif
 	{
 		SteamNetworkPingLocation_t location;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		float flAge = SteamNetworkingUtils()->GetLocalPingLocation( location );
+#else
+		float flAge = SteamNetworkingUtils()->GetLocalPingLocation( location );
+#endif
 		if ( flAge >= 0 )
 		{
 			SetPingLocation( location );
@@ -8990,10 +9023,18 @@ bool CAlienSwarm::IsOfflineGame()
 
 bool CAlienSwarm::IsAnniversaryWeek()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUtils *pUtils = SteamUtils();
+#else
+	ISteamUtils *pUtils = SteamUtils();
+#endif
 #ifdef GAME_DLL
 	if ( !pUtils )
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUtils = SteamGameServerUtils();
+	#else
+		pUtils = SteamGameServerUtils();
+	#endif
 #endif
 	Assert( pUtils );
 	if ( !pUtils )
@@ -9011,7 +9052,11 @@ bool CAlienSwarm::IsAnniversaryWeek()
 	// Therefore, we are moving it to GMT and extending the week by 1 day to compensate.
 	// The anniversary week now takes place from the 20th to the 27th.
 	tm curtime;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Plat_gmtime( pUtils->GetServerRealTime(), &curtime );
+#else
+	Plat_gmtime( pUtils->GetServerRealTime(), &curtime );
+#endif
 	return ( curtime.tm_mday >= 20 && curtime.tm_mday <= 27 ) && curtime.tm_mon == 3;
 }
 
@@ -10389,7 +10434,11 @@ bool CAlienSwarm::ShouldAllowMarineStrafePush(void)
 void CAlienSwarm::SetPingLocation( const SteamNetworkPingLocation_t & location )
 {
 	char szLocation[k_cchMaxSteamNetworkingPingLocationString];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamNetworkingUtils()->ConvertPingLocationToString( location, szLocation, sizeof( szLocation ) );
+#else
+	SteamNetworkingUtils()->ConvertPingLocationToString( location, szLocation, sizeof( szLocation ) );
+#endif
 	m_bObtainedPingLocation = true;
 	Assert( V_strlen( szLocation ) < sizeof( m_szApproximatePingLocation ) );
 	if ( V_strlen( szLocation ) < sizeof( m_szApproximatePingLocation ) )

--- a/src/game/shared/swarm/asw_gamerules.h
+++ b/src/game/shared/swarm/asw_gamerules.h
@@ -613,7 +613,11 @@ private:
 
 #ifndef CLIENT_DLL
 	IASW_Map_Builder *m_pMapBuilder;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CAlienSwarm, OnSteamRelayNetworkStatusChanged, SteamRelayNetworkStatus_t );
+#else
+	STEAM_CALLBACK( CAlienSwarm, OnSteamRelayNetworkStatusChanged, SteamRelayNetworkStatus_t );
+#endif
 #endif
 };
 

--- a/src/game/shared/swarm/asw_player_experience.cpp
+++ b/src/game/shared/swarm/asw_player_experience.cpp
@@ -425,15 +425,27 @@ void CASW_Player::RequestExperience()
 
 #ifdef CLIENT_DLL
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( engine->IsPlayingDemo() && SteamFriends() )
+#else
+	if ( engine->IsPlayingDemo() && SteamFriends() )
+#endif
 	{
 		player_info_t pi;
 		if ( engine->GetPlayerInfo( entindex(), &pi ) && pi.friendsID )
 		{
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			CSteamID steamID( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+			#else
+			CSteamID steamID( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+			#endif
 
 			// grab the player's avatar (otherwise we'll only have it if they're friends with us)
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamFriends()->RequestUserInformation( steamID, false );
+#else
+			SteamFriends()->RequestUserInformation( steamID, false );
+#endif
 		}
 	}
 
@@ -444,8 +456,16 @@ void CASW_Player::RequestExperience()
 		return;
 #endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamUserStats() );
+#else
+	Assert( SteamUserStats() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUserStats() )
+#else
+	if ( SteamUserStats() )
+#endif
 	{
 		if ( IsLocalPlayer( this ) )
 		{
@@ -453,7 +473,7 @@ void CASW_Player::RequestExperience()
 			// This call is no longer required as it is managed by the Steam client. The game stats and achievements
 			// will be synchronized with Steam before the game process begins.
 			// [Obsolete("No longer required. Automatically handled by the Steam client.", false)]
-#if defined(STEAMAPPS_INTERFACE_VERSION008)
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamUserStats()->RequestCurrentStats();
 #else
 			SteamUserStats()->RequestUserStats(SteamUser()->GetSteamID());
@@ -464,9 +484,17 @@ void CASW_Player::RequestExperience()
 			player_info_t pi;
 			if ( engine->GetPlayerInfo( entindex(), &pi ) && pi.friendsID )
 			{
+				#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				CSteamID steamID( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+				#else
+				CSteamID steamID( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+				#endif
 				Msg( "Requesting Steam stats for %s (%s)\n", pi.name ? pi.name : "NULL", pi.friendsName ? pi.friendsName : "NULL" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				SteamUserStats()->RequestUserStats( steamID );
+#else
+				SteamUserStats()->RequestUserStats( steamID );
+#endif
 			}
 		}
 		m_bPendingSteamStats = true;
@@ -475,13 +503,25 @@ void CASW_Player::RequestExperience()
 #else
 	if ( engine->IsDedicatedServer() )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		Assert( SteamGameServerStats() );
+#else
+		Assert( SteamGameServerStats() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamGameServerStats() )
+#else
+		if ( SteamGameServerStats() )
+#endif
 		{
 			CSteamID steamID;
 			if ( GetSteamID( &steamID ) )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				SteamAPICall_t hSteamAPICall = SteamGameServerStats()->RequestUserStats( steamID );
+#else
+				SteamAPICall_t hSteamAPICall = SteamGameServerStats()->RequestUserStats( steamID );
+#endif
 				if ( hSteamAPICall != 0 )
 				{
 					m_CallbackUserStatsReceived.Set( hSteamAPICall, this, &CASW_Player::Steam_OnUserStatsReceived );
@@ -493,13 +533,25 @@ void CASW_Player::RequestExperience()
 	}
 	else
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		Assert( SteamUserStats() );
+#else
+		Assert( SteamUserStats() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUserStats() )
+#else
+		if ( SteamUserStats() )
+#endif
 		{
 			CSteamID steamID;
 			if ( GetSteamID( &steamID ) )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				SteamAPICall_t hSteamAPICall = SteamUserStats()->RequestUserStats( steamID );
+#else
+				SteamAPICall_t hSteamAPICall = SteamUserStats()->RequestUserStats( steamID );
+#endif
 				if ( hSteamAPICall != 0 )
 				{
 					m_CallbackUserStatsReceived.Set( hSteamAPICall, this, &CASW_Player::Steam_OnUserStatsReceived );
@@ -546,13 +598,21 @@ void CASW_Player::AwardExperience()
 #ifdef CLIENT_DLL
 	if ( IsLocalPlayer() && !engine->IsPlayingDemo() )
 	{
-		#if !defined(NO_STEAM)
-		// only upload if Steam is running
-		if ( SteamUserStats() )
-		{
+#if !defined(NO_STEAM)
+	// only upload if Steam is running
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
+	if ( SteamUserStats() )
+#else
+	if ( SteamUserStats() )
+#endif
+	{
 			if( GetLocalASWPlayer() == this )
 				g_ASW_Steamstats.PrepStatsForSend( this );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamUserStats()->SetStat( "experience", m_iExperience );
+#else
+			SteamUserStats()->SetStat( "experience", m_iExperience );
+#endif
 			g_ASW_AchievementMgr.UploadUserData( GetSplitScreenPlayerSlot() );
 
 			if ( GetMedalStore() )
@@ -653,10 +713,26 @@ const char *CASW_Player::GetWeaponUnlockedAtLevel( int nLevel )
 //-----------------------------------------------------------------------------
 void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsReceived )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamUserStats() );
+#else
+	Assert( SteamUserStats() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamUser() );
+#else
+	Assert( SteamUser() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamUtils() );
+#else
+	Assert( SteamUtils() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUserStats() || !SteamUser() || !SteamUtils() )
+#else
+	if ( !SteamUserStats() || !SteamUser() || !SteamUtils() )
+#endif
 		return;
 
 	if ( pUserStatsReceived->m_eResult != k_EResultOK )
@@ -671,7 +747,11 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 	CSteamID steamID;
 	if ( IsLocalPlayer() )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		steamID = SteamUser()->GetSteamID();
+#else
+		steamID = SteamUser()->GetSteamID();
+#endif
 	}
 	else
 	{
@@ -682,7 +762,11 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 		if ( !pi.friendsID )
 			return;
 			
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+		#else
+		CSteamID steamIDForPlayer( pi.friendsID, 1, SteamUtils()->GetConnectedUniverse(), k_EAccountTypeIndividual );
+		#endif
 		steamID = steamIDForPlayer;
 
 		DevMsg( "Steam_OnUserStatsReceived for non local player %s (%s)\n", pi.name ? pi.name : "NULL", pi.friendsName ? pi.friendsName : "NULL" );
@@ -691,7 +775,11 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 		return;
 
 #ifdef USE_XP_FROM_STEAM
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUserStats()->GetUserStat( steamID, "experience", &m_iExperience ) )
+#else
+	if ( SteamUserStats()->GetUserStat( steamID, "experience", &m_iExperience ) )
+#endif
 	{
 		m_bPendingSteamStats = false;
 	}
@@ -704,7 +792,11 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 		}
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUserStats()->GetUserStat( steamID, "promotion", &m_iPromotion ) )
+#else
+	if ( !SteamUserStats()->GetUserStat( steamID, "promotion", &m_iPromotion ) )
+#endif
 	{
 		Msg( "Error retrieving promotion stat for player %s.\n", GetPlayerName() );
 		if ( !IsLocalPlayer() )
@@ -719,7 +811,11 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 		{
 			if ( !GetMedalStore()->m_bFoundNewClientDat )		// if we failed to find the new client dat, then take steam numbers
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				if ( SteamUserStats()->GetUserStat( steamID, "experience", &m_iExperience ) )
+#else
+				if ( SteamUserStats()->GetUserStat( steamID, "experience", &m_iExperience ) )
+#endif
 				{
 					m_bPendingSteamStats = false;
 				}
@@ -728,7 +824,11 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 					Msg( "Error retrieving experience stat for player %s.\n", GetPlayerName() );
 				}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				if ( !SteamUserStats()->GetUserStat( steamID, "promotion", &m_iPromotion ) )
+#else
+				if ( !SteamUserStats()->GetUserStat( steamID, "promotion", &m_iPromotion ) )
+#endif
 				{
 					Msg( "Error retrieving promotion stat for player %s.\n", GetPlayerName() );
 				}
@@ -761,14 +861,26 @@ void CASW_Player::Steam_OnUserStatsStored( UserStatsStored_t *pUserStatsStored )
 	if ( !IsLocalPlayer( this ) )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CSteamID steamID = SteamUser()->GetSteamID();
+#else
+	CSteamID steamID = SteamUser()->GetSteamID();
+#endif
 
 	if ( k_EResultOK != pUserStatsStored->m_eResult )
 	{
 		DevMsg( "CASW_Player: failed to upload stats to Steam, EResult %d (%s)\n", pUserStatsStored->m_eResult, UTIL_RD_EResultToString( pUserStatsStored->m_eResult ) );
 #ifdef USE_XP_FROM_STEAM
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->GetStat( "experience", &m_iExperience );
+#else
+		SteamUserStats()->GetStat( "experience", &m_iExperience );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->GetStat( "promotion", &m_iPromotion );
+#else
+		SteamUserStats()->GetStat( "promotion", &m_iPromotion );
+#endif
 #endif
 
 		// Set stats to whatever is stored on steam
@@ -809,12 +921,32 @@ void CASW_Player::AcceptPromotion()
 
 #if !defined(NO_STEAM)
 	// only upload if Steam is running
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUserStats() )
+#else
+	if ( SteamUserStats() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->SetStat( "experience", m_iExperience );
+#else
+		SteamUserStats()->SetStat( "experience", m_iExperience );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->SetStat( "promotion", m_iPromotion );
+#else
+		SteamUserStats()->SetStat( "promotion", m_iPromotion );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->SetStat( "level", 1 );
+#else
+		SteamUserStats()->SetStat( "level", 1 );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->SetStat( "level.xprequired", 0 );
+#else
+		SteamUserStats()->SetStat( "level.xprequired", 0 );
+#endif
 		g_ASW_AchievementMgr.UploadUserData( GetSplitScreenPlayerSlot() );
 
 		if ( GetMedalStore() )
@@ -845,15 +977,31 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 #if GAME_DLL
 	if ( engine->IsDedicatedServer() )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		Assert( SteamGameServerStats() );
-		if ( !SteamGameServerStats() )
+#else
+		Assert( SteamGameServerStats() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
+	if ( !SteamGameServerStats() )
+#else
+	if ( !SteamGameServerStats() )
+#endif
 			return;
 	}
 	else
 #endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		Assert( SteamUserStats() );
+#else
+		Assert( SteamUserStats() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamUserStats() )
+#else
+		if ( !SteamUserStats() )
+#endif
 			return;
 	}
 
@@ -882,7 +1030,11 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 #if GAME_DLL
 	if ( engine->IsDedicatedServer() )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamGameServerStats()->GetUserStat( steamIDForPlayer, "experience", &m_iExperience ) )
+#else
+		if ( SteamGameServerStats()->GetUserStat( steamIDForPlayer, "experience", &m_iExperience ) )
+#endif
 		{
 			m_bPendingSteamStats = false;
 		}
@@ -890,12 +1042,20 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 		{
 			Msg( "Server error retrieving experience stat for player %s.\n", GetPlayerName() );
 		}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamGameServerStats()->GetUserStat( steamIDForPlayer, "promotion", &m_iPromotion );
+#else
+		SteamGameServerStats()->GetUserStat( steamIDForPlayer, "promotion", &m_iPromotion );
+#endif
 	}
 	else
 #endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUserStats()->GetUserStat( steamIDForPlayer, "experience", &m_iExperience ) )
+#else
+		if ( SteamUserStats()->GetUserStat( steamIDForPlayer, "experience", &m_iExperience ) )
+#endif
 		{
 			m_bPendingSteamStats = false;
 		}
@@ -903,7 +1063,11 @@ void CASW_Player::Steam_OnUserStatsReceived( UserStatsReceived_t *pUserStatsRece
 		{
 			Msg( "Server error retrieving experience stat for player %s.\n", GetPlayerName() );
 		}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUserStats()->GetUserStat( steamIDForPlayer, "promotion", &m_iPromotion );
+#else
+		SteamUserStats()->GetUserStat( steamIDForPlayer, "promotion", &m_iPromotion );
+#endif
 	}
 #endif
 }

--- a/src/game/shared/swarm/asw_util_shared.cpp
+++ b/src/game/shared/swarm/asw_util_shared.cpp
@@ -2485,9 +2485,17 @@ bool UTIL_RD_AddLocalizeFile( const char *fileName, const char *pPathID, bool bI
 		{
 			pszLanguageReplacement = CommandLine()->ParmValue( "-language", "english" );
 		}
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		else if ( SteamApps() )
+		#else
+		else if ( SteamApps() )
+		#endif
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pszLanguageReplacement = SteamApps()->GetCurrentGameLanguage();
+#else
+			pszLanguageReplacement = SteamApps()->GetCurrentGameLanguage();
+#endif
 		}
 #ifdef GAME_DLL
 		else if ( engine->IsDedicatedServer() )
@@ -3557,7 +3565,11 @@ void UTIL_RD_BinToHex( const byte *in, int inputbytes, char *out, int outsize )
 int UTIL_RD_GetCurrentHoIAFSeason( int *pDaysRemaining, int *pHoursRemaining )
 {
 	struct tm tm;
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Plat_gmtime( SteamUtils() ? SteamUtils()->GetServerRealTime() : std::time( NULL ), &tm );
+	#else
+	Plat_gmtime( SteamUtils() ? SteamUtils()->GetServerRealTime() : std::time( NULL ), &tm );
+	#endif
 
 	if ( pHoursRemaining )
 		*pHoursRemaining = 23 - tm.tm_hour;

--- a/src/game/shared/swarm/rd_crafting_defs.cpp
+++ b/src/game/shared/swarm/rd_crafting_defs.cpp
@@ -783,10 +783,18 @@ static int __cdecl CompareItemIDs( const SteamItemDef_t *a, const SteamItemDef_t
 
 void ValidateCraftingDefs( const CUtlVector<SteamItemDef_t> &AllItemDefs )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInventory *pInventory = SteamInventory();
+#else
+	ISteamInventory *pInventory = SteamInventory();
+#endif
 #ifdef GAME_DLL
 	if ( engine->IsDedicatedServer() )
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory = SteamGameServerInventory();
+#else
+		pInventory = SteamGameServerInventory();
+#endif
 #endif
 	Assert( pInventory );
 	if ( !pInventory )
@@ -800,7 +808,11 @@ void ValidateCraftingDefs( const CUtlVector<SteamItemDef_t> &AllItemDefs )
 	FOR_EACH_VEC( AllItemDefs, i )
 	{
 		uint32 nExchangeSize = sizeof( szExchange );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pInventory->GetItemDefinitionProperty( AllItemDefs[i], "exchange", szExchange, &nExchangeSize ) )
+#else
+		if ( !pInventory->GetItemDefinitionProperty( AllItemDefs[i], "exchange", szExchange, &nExchangeSize ) )
+#endif
 			continue;
 
 		// this code assumes that each item is in at most one contains_any list and isn't exchangable from anything else

--- a/src/game/shared/swarm/rd_hoiaf_utils.cpp
+++ b/src/game/shared/swarm/rd_hoiaf_utils.cpp
@@ -137,7 +137,11 @@ int CRD_HoIAF_System::CountEventTimers() const
 
 bool CRD_HoIAF_System::IsEventTimerActive( int index ) const
 {
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	int64_t iCurrentTime = SteamUtils() ? SteamUtils()->GetServerRealTime() : 0;
+	#else
+	int64_t iCurrentTime = SteamUtils() ? SteamUtils()->GetServerRealTime() : 0;
+	#endif
 	return GetEventStartTime( index ) <= iCurrentTime && GetEventEndTime( index ) >= iCurrentTime;
 }
 
@@ -176,7 +180,11 @@ int64_t CRD_HoIAF_System::GetEventEndTime( int index ) const
 #ifdef CLIENT_DLL
 void CRD_HoIAF_System::InsertChatMessages( CBaseHudChat *pChat )
 {
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	int64_t iCurrentTime = SteamUtils() ? SteamUtils()->GetServerRealTime() : 0;
+	#else
+	int64_t iCurrentTime = SteamUtils() ? SteamUtils()->GetServerRealTime() : 0;
+	#endif
 	FOR_EACH_VEC( m_ChatAnnouncements, i )
 	{
 		if ( m_ChatAnnouncements[i]->NotBefore > iCurrentTime )
@@ -381,7 +389,11 @@ bool CRD_HoIAF_System::AreResearchProjectsActive() const
 
 bool CRD_HoIAF_System::IsCraftingBlueprintHidden( SteamItemDef_t iItemDef ) const
 {
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	RTime32 currentTime = SteamUtils() ? SteamUtils()->GetServerRealTime() : 0;
+	#else
+	RTime32 currentTime = SteamUtils() ? SteamUtils()->GetServerRealTime() : 0;
+	#endif
 
 	FOR_EACH_VEC( m_HideCraftingBlueprint, i )
 	{
@@ -792,13 +804,29 @@ void CRD_HoIAF_System::ParseIAFIntel()
 				pNews->TextureHandle = vgui::surface()->CreateNewTextureID();
 				vgui::surface()->DrawSetTextureFile( pNews->TextureHandle, &szTextureName[strlen( "materials/" )], 1, false );
 			}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			else if ( ISteamHTTP *pHTTP = SteamHTTP() )
+#else
+			else if ( ISteamHTTP *pHTTP = SteamHTTP() )
+#endif
 			{
+				#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pNews->m_hTextureRequest = pHTTP->CreateHTTPRequest( k_EHTTPMethodGET, szTextureURL );
+				#else
+				pNews->m_hTextureRequest = pHTTP->CreateHTTPRequest( k_EHTTPMethodGET, szTextureURL );
+				#endif
+				#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pHTTP->SetHTTPRequestUserAgentInfo( pNews->m_hTextureRequest, "Reactive Drop News Showcase Icon Fetch" );
+				#else
+				pHTTP->SetHTTPRequestUserAgentInfo( pNews->m_hTextureRequest, "Reactive Drop News Showcase Icon Fetch" );
+				#endif
 
 				SteamAPICall_t hCall = k_uAPICallInvalid;
+				#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				if ( pHTTP->SendHTTPRequest( pNews->m_hTextureRequest, &hCall ) )
+				#else
+				if ( pHTTP->SendHTTPRequest( pNews->m_hTextureRequest, &hCall ) )
+				#endif
 				{
 					pNews->m_TextureRequestFinished.Set( hCall, pNews, &CRD_HoIAF_System::FeaturedNews_t::OnHTTPRequestCompleted );
 				}
@@ -916,11 +944,27 @@ void CRD_HoIAF_System::LoadCachedIAFIntel()
 bool CRD_HoIAF_System::RefreshIAFIntel( bool bOnlyIfExpired, bool bForceNewRequest )
 {
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUtils *pUtils = SteamUtils();
+#else
+	ISteamUtils *pUtils = SteamUtils();
+#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamHTTP *pHTTP = SteamHTTP();
+	#else
+	ISteamHTTP *pHTTP = SteamHTTP();
+	#endif
+#else
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
+	ISteamUtils *pUtils = engine->IsDedicatedServer() ? SteamGameServerUtils() : SteamUtils();
 #else
 	ISteamUtils *pUtils = engine->IsDedicatedServer() ? SteamGameServerUtils() : SteamUtils();
+#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamHTTP *pHTTP = engine->IsDedicatedServer() ? SteamGameServerHTTP() : SteamHTTP();
+	#else
+	ISteamHTTP *pHTTP = engine->IsDedicatedServer() ? SteamGameServerHTTP() : SteamHTTP();
+	#endif
 #endif
 	Assert( pUtils );
 	Assert( pHTTP );
@@ -929,14 +973,22 @@ bool CRD_HoIAF_System::RefreshIAFIntel( bool bOnlyIfExpired, bool bForceNewReque
 		return false;
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	int64_t iNow = pUtils->GetServerRealTime();
+	#else
+	int64_t iNow = pUtils->GetServerRealTime();
+	#endif
 	if ( bOnlyIfExpired && iNow < m_iExpireAt )
 	{
 		return true;
 	}
 
 	// Call PrioritizeHTTPRequest again to check if the request still exists and didn't magically disappear.
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !bForceNewRequest && m_hIAFIntelRefreshRequest != INVALID_HTTPREQUEST_HANDLE && pHTTP->PrioritizeHTTPRequest( m_hIAFIntelRefreshRequest ) )
+	#else
+	if ( !bForceNewRequest && m_hIAFIntelRefreshRequest != INVALID_HTTPREQUEST_HANDLE && pHTTP->PrioritizeHTTPRequest( m_hIAFIntelRefreshRequest ) )
+	#endif
 	{
 		return false;
 	}
@@ -951,26 +1003,46 @@ bool CRD_HoIAF_System::RefreshIAFIntel( bool bOnlyIfExpired, bool bForceNewReque
 
 	if ( m_hIAFIntelRefreshRequest != INVALID_HTTPREQUEST_HANDLE )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pHTTP->ReleaseHTTPRequest( m_hIAFIntelRefreshRequest );
+#else
+		pHTTP->ReleaseHTTPRequest( m_hIAFIntelRefreshRequest );
+#endif
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_hIAFIntelRefreshRequest = pHTTP->CreateHTTPRequest( k_EHTTPMethodGET, "https://stats.reactivedrop.com/game_dynamic_state.bin" );
+	#else
+	m_hIAFIntelRefreshRequest = pHTTP->CreateHTTPRequest( k_EHTTPMethodGET, "https://stats.reactivedrop.com/game_dynamic_state.bin" );
+	#endif
 	if ( m_hIAFIntelRefreshRequest == INVALID_HTTPREQUEST_HANDLE )
 	{
 		Warning( "[HoIAF:%c] Game global state update request: CreateHTTPRequest failed!\n", IsClientDll() ? 'C' : 'S' );
 		return false;
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->SetHTTPRequestUserAgentInfo( m_hIAFIntelRefreshRequest, IsClientDll() ? "Reactive Drop Client" : "Reactive Drop Server" );
+	#else
+	pHTTP->SetHTTPRequestUserAgentInfo( m_hIAFIntelRefreshRequest, IsClientDll() ? "Reactive Drop Client" : "Reactive Drop Server" );
+	#endif
 	SteamAPICall_t hCall = k_uAPICallInvalid;
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !pHTTP->SendHTTPRequest( m_hIAFIntelRefreshRequest, &hCall ) )
+	#else
+	if ( !pHTTP->SendHTTPRequest( m_hIAFIntelRefreshRequest, &hCall ) )
+	#endif
 	{
 		Warning( "[HoIAF:%c] Game global state update request: SendHTTPRequest failed!\n", IsClientDll() ? 'C' : 'S' );
 		return false;
 	}
 
 	// We want this before any of the optional things we might be downloading.
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->PrioritizeHTTPRequest( m_hIAFIntelRefreshRequest );
+	#else
+	pHTTP->PrioritizeHTTPRequest( m_hIAFIntelRefreshRequest );
+	#endif
 
 	m_IAFIntelRefresh.Set( hCall, this, &CRD_HoIAF_System::OnHTTPRequestCompleted );
 
@@ -990,11 +1062,27 @@ void CRD_HoIAF_System::OnHTTPRequestCompleted( HTTPRequestCompleted_t *pParam, b
 	Assert( pParam && pParam->m_hRequest == m_hIAFIntelRefreshRequest );
 
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUtils *pUtils = SteamUtils();
+#else
+	ISteamUtils *pUtils = SteamUtils();
+#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamHTTP *pHTTP = SteamHTTP();
+	#else
+	ISteamHTTP *pHTTP = SteamHTTP();
+	#endif
+#else
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
+	ISteamUtils *pUtils = engine->IsDedicatedServer() ? SteamGameServerUtils() : SteamUtils();
 #else
 	ISteamUtils *pUtils = engine->IsDedicatedServer() ? SteamGameServerUtils() : SteamUtils();
+#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamHTTP *pHTTP = engine->IsDedicatedServer() ? SteamGameServerHTTP() : SteamHTTP();
+	#else
+	ISteamHTTP *pHTTP = engine->IsDedicatedServer() ? SteamGameServerHTTP() : SteamHTTP();
+	#endif
 #endif
 	Assert( pUtils );
 	Assert( pHTTP );
@@ -1017,7 +1105,11 @@ void CRD_HoIAF_System::OnHTTPRequestCompleted( HTTPRequestCompleted_t *pParam, b
 	{
 		CUtlBuffer body{ 0, int( pParam->m_unBodySize ) };
 		body.SeekPut( CUtlBuffer::SEEK_HEAD, pParam->m_unBodySize );
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pHTTP->GetHTTPResponseBodyData( pParam->m_hRequest, ( uint8 * )body.Base(), pParam->m_unBodySize ) )
+		#else
+		if ( !pHTTP->GetHTTPResponseBodyData( pParam->m_hRequest, ( uint8 * )body.Base(), pParam->m_unBodySize ) )
+		#endif
 		{
 			Warning( "[HoIAF:%c] Game global state update request: GetHTTPResponseBodyData failed!\n", IsClientDll() ? 'C' : 'S' );
 			OnRequestFailed();
@@ -1051,7 +1143,11 @@ void CRD_HoIAF_System::OnHTTPRequestCompleted( HTTPRequestCompleted_t *pParam, b
 
 		ParseIAFIntel();
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		int64_t iNow = pUtils ? pUtils->GetServerRealTime() : 0;
+		#else
+		int64_t iNow = pUtils ? pUtils->GetServerRealTime() : 0;
+		#endif
 		Assert( m_iExpireAt > iNow );
 		if ( m_iExpireAt > iNow )
 		{
@@ -1066,16 +1162,28 @@ void CRD_HoIAF_System::OnHTTPRequestCompleted( HTTPRequestCompleted_t *pParam, b
 	}
 
 cleanup:
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+	#else
+	pHTTP->ReleaseHTTPRequest( pParam->m_hRequest );
+	#endif
 	m_hIAFIntelRefreshRequest = INVALID_HTTPREQUEST_HANDLE;
 }
 
 void CRD_HoIAF_System::OnRequestFailed()
 {
 #ifdef CLIENT_DLL
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUtils *pUtils = SteamUtils();
+	#else
+	ISteamUtils *pUtils = SteamUtils();
+	#endif
 #else
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUtils *pUtils = engine->IsDedicatedServer() ? SteamGameServerUtils() : SteamUtils();
+	#else
+	ISteamUtils *pUtils = engine->IsDedicatedServer() ? SteamGameServerUtils() : SteamUtils();
+	#endif
 #endif
 	Assert( pUtils );
 
@@ -1084,7 +1192,11 @@ void CRD_HoIAF_System::OnRequestFailed()
 		m_iExponentialBackoff = 12; // cap at just over an hour
 
 	// if we can't get the current time, give up until the game is restarted
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_iBackoffUntil = pUtils ? ( pUtils->GetServerRealTime() + ( 1 << m_iExponentialBackoff ) ) : ~0u;
+	#else
+	m_iBackoffUntil = pUtils ? ( pUtils->GetServerRealTime() + ( 1 << m_iExponentialBackoff ) ) : ~0u;
+	#endif
 }
 
 void CRD_HoIAF_System::OnNewIntelReceived()
@@ -1112,7 +1224,11 @@ void CRD_HoIAF_System::OnNewIntelReceived()
 void CRD_HoIAF_System::LoadTranslatedString( CUtlString &str, KeyValues *pKV, const char *szTemplate )
 {
 	char szLocalized[256], szEnglish[256];
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	V_snprintf( szLocalized, sizeof( szLocalized ), szTemplate, SteamApps() ? SteamApps()->GetCurrentGameLanguage() : "" );
+	#else
+	V_snprintf( szLocalized, sizeof( szLocalized ), szTemplate, SteamApps() ? SteamApps()->GetCurrentGameLanguage() : "" );
+	#endif
 	V_snprintf( szEnglish, sizeof( szEnglish ), szTemplate, "english" );
 	str = pKV->GetString( szLocalized, pKV->GetString( szEnglish ) );
 }
@@ -1127,9 +1243,17 @@ CRD_HoIAF_System::FeaturedNews_t::~FeaturedNews_t()
 		TextureHandle = NULL;
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( m_hTextureRequest != INVALID_HTTPREQUEST_HANDLE && SteamHTTP() )
+	#else
+	if ( m_hTextureRequest != INVALID_HTTPREQUEST_HANDLE && SteamHTTP() )
+	#endif
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamHTTP()->ReleaseHTTPRequest( m_hTextureRequest );
+		#else
+		SteamHTTP()->ReleaseHTTPRequest( m_hTextureRequest );
+		#endif
 		m_hTextureRequest = INVALID_HTTPREQUEST_HANDLE;
 	}
 #endif
@@ -1147,7 +1271,11 @@ void CRD_HoIAF_System::FeaturedNews_t::OnHTTPRequestCompleted( HTTPRequestComple
 
 	Assert( m_hTextureRequest == pParam->m_hRequest );
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamHTTP *pHTTP = SteamHTTP();
+	#else
+	ISteamHTTP *pHTTP = SteamHTTP();
+	#endif
 	Assert( pHTTP );
 	if ( !pHTTP )
 	{
@@ -1166,7 +1294,11 @@ void CRD_HoIAF_System::FeaturedNews_t::OnHTTPRequestCompleted( HTTPRequestComple
 	{
 		CUtlBuffer body{ 0, int( pParam->m_unBodySize ) };
 		body.SeekPut( CUtlBuffer::SEEK_HEAD, pParam->m_unBodySize );
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pHTTP->GetHTTPResponseBodyData( m_hTextureRequest, ( uint8 * )body.Base(), pParam->m_unBodySize ) )
+		#else
+		if ( !pHTTP->GetHTTPResponseBodyData( m_hTextureRequest, ( uint8 * )body.Base(), pParam->m_unBodySize ) )
+		#endif
 		{
 			Warning( "[HoIAF:%c] Failed to download icon for featured news item with URL %s (GetHTTPResponseBodyData failed)\n", IsClientDll() ? 'C' : 'S', URL.Get() );
 			goto cleanup;
@@ -1190,7 +1322,11 @@ void CRD_HoIAF_System::FeaturedNews_t::OnHTTPRequestCompleted( HTTPRequestComple
 	}
 
 cleanup:
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pHTTP->ReleaseHTTPRequest( m_hTextureRequest );
+	#else
+	pHTTP->ReleaseHTTPRequest( m_hTextureRequest );
+	#endif
 	m_hTextureRequest = INVALID_HTTPREQUEST_HANDLE;
 }
 #endif

--- a/src/game/shared/swarm/rd_hoiaf_utils.h
+++ b/src/game/shared/swarm/rd_hoiaf_utils.h
@@ -121,7 +121,11 @@ private:
 
 	KeyValues::AutoDelete m_pIAFIntel;
 	HTTPRequestHandle m_hIAFIntelRefreshRequest{ INVALID_HTTPREQUEST_HANDLE };
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CRD_HoIAF_System, HTTPRequestCompleted_t> m_IAFIntelRefresh;
+#else
+	CCallResult<CRD_HoIAF_System, HTTPRequestCompleted_t> m_IAFIntelRefresh;
+#endif
 	int m_iExponentialBackoff{};
 	uint32_t m_iBackoffUntil{};
 
@@ -143,7 +147,11 @@ private:
 		HTTPRequestHandle m_hTextureRequest{ INVALID_HTTPREQUEST_HANDLE };
 		void OnHTTPRequestCompleted( HTTPRequestCompleted_t *pParam, bool bIOFailure );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		CCallResult<FeaturedNews_t, HTTPRequestCompleted_t> m_TextureRequestFinished;
+#else
+		CCallResult<FeaturedNews_t, HTTPRequestCompleted_t> m_TextureRequestFinished;
+#endif
 #endif
 	};
 	CUtlVectorAutoPurge<FeaturedNews_t *> m_FeaturedNews;

--- a/src/game/shared/swarm/rd_inventory_command.cpp
+++ b/src/game/shared/swarm/rd_inventory_command.cpp
@@ -57,11 +57,19 @@ public:
 
 		m_PayloadChunks.Purge();
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( ISteamInventory *pInventory = SteamInventory())
+#else
+		if ( ISteamInventory *pInventory = SteamInventory())
+#endif
 		{
 			FOR_EACH_VEC( m_ItemIDQueue, i )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->DestroyResult( m_ItemIDQueue[i].m_hResult );
+#else
+				pInventory->DestroyResult( m_ItemIDQueue[i].m_hResult );
+#endif
 			}
 		}
 
@@ -193,7 +201,11 @@ int UTIL_RD_SendInventoryCommand( EInventoryCommand eCmd, const CUtlVector<int> 
 
 	if ( hResult != k_SteamInventoryResultInvalid )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
+#else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
 		Assert( pInventory );
 		if ( !pInventory )
 		{
@@ -201,7 +213,11 @@ int UTIL_RD_SendInventoryCommand( EInventoryCommand eCmd, const CUtlVector<int> 
 			return 0;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bool bOK = pInventory->SerializeResult( hResult, NULL, &nSize );
+#else
+		bool bOK = pInventory->SerializeResult( hResult, NULL, &nSize );
+#endif
 		Assert( bOK );
 		if ( !bOK )
 		{
@@ -210,7 +226,11 @@ int UTIL_RD_SendInventoryCommand( EInventoryCommand eCmd, const CUtlVector<int> 
 		}
 
 		buf.Init( 0, nSize );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bOK = pInventory->SerializeResult( hResult, buf.Base(), &nSize );
+#else
+		bOK = pInventory->SerializeResult( hResult, buf.Base(), &nSize );
+#endif
 		Assert( bOK );
 		if ( !bOK )
 		{
@@ -247,7 +267,11 @@ void UTIL_RD_SendInventoryCommandByIDs( EInventoryCommand eCmd, const CUtlVector
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInventory *pInventory = SteamInventory();
+#else
+	ISteamInventory *pInventory = SteamInventory();
+#endif
 	if ( !pInventory )
 	{
 		Warning( "Cannot send inventory command %d: no ISteamInventory\n", eCmd );
@@ -258,7 +282,11 @@ void UTIL_RD_SendInventoryCommandByIDs( EInventoryCommand eCmd, const CUtlVector
 	s_RD_Inventory_Command_Queue.m_ItemIDQueue[i].m_eCmd = eCmd;
 	s_RD_Inventory_Command_Queue.m_ItemIDQueue[i].m_Args.AddVectorToTail( args );
 	s_RD_Inventory_Command_Queue.m_ItemIDQueue[i].m_IDs.AddVectorToTail( ids );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pInventory->GetItemsByID( &s_RD_Inventory_Command_Queue.m_ItemIDQueue[i].m_hResult, realIDs.Base(), realIDs.Count() );
+#else
+	pInventory->GetItemsByID( &s_RD_Inventory_Command_Queue.m_ItemIDQueue[i].m_hResult, realIDs.Base(), realIDs.Count() );
+#endif
 }
 
 bool RDCheckForInventoryCommandResult( ISteamInventory *pInventory, SteamInventoryResult_t hResult )
@@ -277,9 +305,17 @@ bool RDCheckForInventoryCommandResult( ISteamInventory *pInventory, SteamInvento
 		}
 
 		uint32 nItems{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetResultItems( hResult, NULL, &nItems );
+#else
+		pInventory->GetResultItems( hResult, NULL, &nItems );
+#endif
 		CUtlMemory<SteamItemDetails_t> items{ 0, int( nItems ) };
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetResultItems( hResult, items.Base(), &nItems );
+#else
+		pInventory->GetResultItems( hResult, items.Base(), &nItems );
+#endif
 
 		FOR_EACH_VEC( cmd.m_IDs, j )
 		{
@@ -294,7 +330,11 @@ bool RDCheckForInventoryCommandResult( ISteamInventory *pInventory, SteamInvento
 		}
 
 		UTIL_RD_SendInventoryCommand( cmd.m_eCmd, args, hResult );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->DestroyResult( hResult );
+#else
+		pInventory->DestroyResult( hResult );
+#endif
 
 		s_RD_Inventory_Command_Queue.m_ItemIDQueue.Remove( i );
 		return true;
@@ -359,16 +399,28 @@ CASW_Player::InventoryCommandData_t::~InventoryCommandData_t()
 {
 	if ( m_hResult != k_SteamInventoryResultInvalid )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
+#else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
 		if ( !pInventory )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory = SteamGameServerInventory();
+#else
+			pInventory = SteamGameServerInventory();
+#endif
 		}
 		Assert( pInventory );
 
 		if ( pInventory )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->DestroyResult( m_hResult );
+#else
+			pInventory->DestroyResult( m_hResult );
+#endif
 		}
 	}
 }
@@ -561,13 +613,25 @@ static void UpdateAllEquipmentItemInstances( const ReactiveDropInventory::ItemIn
 
 static void ExecuteInventoryCommand( CASW_Player *pPlayer, EInventoryCommand eCmd, const CUtlVector<int> &args, const CUtlVector<ReactiveDropInventory::ItemInstance_t> &items )
 {
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUtils *pUtils = SteamUtils();
+	#else
+	ISteamUtils *pUtils = SteamUtils();
+	#endif
 #ifdef GAME_DLL
 	if ( engine->IsDedicatedServer() )
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUtils = SteamGameServerUtils();
+	#else
+		pUtils = SteamGameServerUtils();
+	#endif
 #endif
 	Assert( pUtils );
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	RTime32 iNow = pUtils ? pUtils->GetServerRealTime() : std::time( NULL );
+	#else
+	RTime32 iNow = pUtils ? pUtils->GetServerRealTime() : std::time( NULL );
+	#endif
 	RTime32 iFiveMinutesAgo = iNow - 300;
 
 	switch ( eCmd )
@@ -1113,10 +1177,18 @@ void CASW_Player::HandleInventoryCommand( KeyValues *pKeyValues )
 					return;
 				}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				ISteamInventory *pInventory = SteamInventory();
+#else
+				ISteamInventory *pInventory = SteamInventory();
+#endif
 				if ( !pInventory )
 				{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pInventory = SteamGameServerInventory();
+#else
+					pInventory = SteamGameServerInventory();
+#endif
 				}
 
 				Assert( pInventory );
@@ -1129,7 +1201,11 @@ void CASW_Player::HandleInventoryCommand( KeyValues *pKeyValues )
 				}
 
 				// send the serialized result off to be validated.
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->DeserializeResult( &m_InventoryCommands[i]->m_hResult, m_InventoryCommands[i]->m_Data.Base(), m_InventoryCommands[i]->m_Data.Count() );
+#else
+				pInventory->DeserializeResult( &m_InventoryCommands[i]->m_hResult, m_InventoryCommands[i]->m_Data.Base(), m_InventoryCommands[i]->m_Data.Count() );
+#endif
 				Assert( m_InventoryCommands[i]->m_hResult != k_SteamInventoryResultInvalid );
 				// throw away the serialized payload; we no longer need it in memory.
 				m_InventoryCommands[i]->m_Data.Purge();
@@ -1163,13 +1239,25 @@ void CASW_Player::HandleOfflineInventoryCommand( KeyValues *pKeyValues )
 {
 	Assert( !engine->IsDedicatedServer() );
 	Assert( gpGlobals->maxClients == 1 );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamUser() );
+#else
+	Assert( SteamUser() );
+#endif
 
 	// This only works in singleplayer, and we need access to our own Steam ID.
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( engine->IsDedicatedServer() || gpGlobals->maxClients != 1 || !SteamUser() )
+#else
+	if ( engine->IsDedicatedServer() || gpGlobals->maxClients != 1 || !SteamUser() )
+#endif
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CFmtStr szCacheFileName{ "cfg/clienti_%llu.dat", SteamUser()->GetSteamID().ConvertToUint64() };
+#else
+	CFmtStr szCacheFileName{ "cfg/clienti_%llu.dat", SteamUser()->GetSteamID().ConvertToUint64() };
+#endif
 	CUtlBuffer buf;
 
 	if ( !g_pFullFileSystem->ReadFile( szCacheFileName, "MOD", buf ) )
@@ -1233,10 +1321,18 @@ bool CASW_Player::OnSteamInventoryResultReady( SteamInventoryResultReady_t *pPar
 		return false;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamInventory *pInventory = SteamInventory();
+#else
+	ISteamInventory *pInventory = SteamInventory();
+#endif
 	if ( !pInventory )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory = SteamGameServerInventory();
+#else
+		pInventory = SteamGameServerInventory();
+#endif
 	}
 	Assert( pInventory );
 	if ( !pInventory )
@@ -1252,14 +1348,22 @@ bool CASW_Player::OnSteamInventoryResultReady( SteamInventoryResultReady_t *pPar
 			{
 				Warning( "Failure handling InvCmd from player %s: inventory result is %d (%s)\n", GetASWNetworkID(), pParam->m_result, UTIL_RD_EResultToString( pParam->m_result ) );
 			}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			else if ( !pInventory->CheckResultSteamID( m_InventoryCommands[i]->m_hResult, GetSteamID() ) )
+#else
+			else if ( !pInventory->CheckResultSteamID( m_InventoryCommands[i]->m_hResult, GetSteamID() ) )
+#endif
 			{
 				Warning( "Failure handling InvCmd from player %s: inventory result does not belong to Steam ID %llu\n", GetASWNetworkID(), GetSteamID().ConvertToUint64() );
 			}
 			else
 			{
 				uint32_t nItems = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetResultItems( m_InventoryCommands[i]->m_hResult, NULL, &nItems );
+#else
+				pInventory->GetResultItems( m_InventoryCommands[i]->m_hResult, NULL, &nItems );
+#endif
 
 				CUtlVector<ReactiveDropInventory::ItemInstance_t> items;
 				items.SetCount( nItems );

--- a/src/game/shared/swarm/rd_inventory_shared.cpp
+++ b/src/game/shared/swarm/rd_inventory_shared.cpp
@@ -67,22 +67,38 @@ COMPILE_TIME_ASSERT( ReactiveDropInventory::g_PlayerInventorySlotNames[RD_STEAM_
 
 #ifdef CLIENT_DLL
 ConVar rd_debug_inventory( "cl_debug_inventory", "0", FCVAR_NONE, "print debugging messages about inventory service calls" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 #define GET_INVENTORY_OR_BAIL \
 	ISteamInventory *pInventory = SteamInventory(); \
 	Assert( pInventory ); \
 	if ( !pInventory ) \
 		return
+#else
+#define GET_INVENTORY_OR_BAIL \
+	ISteamInventory *pInventory = SteamInventory(); \
+	Assert( pInventory ); \
+	if ( !pInventory ) \
+		return
+#endif
 
 extern ConVar rd_strange_device_tier_notifications;
 extern ConVar rd_equipped_medal[RD_STEAM_INVENTORY_NUM_MEDAL_SLOTS];
 ConVar rd_crafting_material_pickups( "rd_crafting_material_pickups", "1", FCVAR_ARCHIVE, "if set to 0, the game will pretend that no crafting material locations are available" );
 #else
 ConVar rd_debug_inventory( "sv_debug_inventory", "0", FCVAR_NONE, "print debugging messages about inventory service calls" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 #define GET_INVENTORY_OR_BAIL \
 	ISteamInventory *pInventory = engine->IsDedicatedServer() ? SteamGameServerInventory() : SteamInventory(); \
 	Assert( pInventory ); \
 	if ( !pInventory ) \
 		return
+#else
+#define GET_INVENTORY_OR_BAIL \
+	ISteamInventory *pInventory = engine->IsDedicatedServer() ? SteamGameServerInventory() : SteamInventory(); \
+	Assert( pInventory ); \
+	if ( !pInventory ) \
+		return
+#endif
 
 extern ConVar rd_dedicated_server_language;
 #endif
@@ -119,9 +135,17 @@ public:
 	void PostInit() override
 	{
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUser() )
+#else
+		if ( SteamUser() )
+#endif
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			CFmtStr szCacheFileName{ "cfg/clienti_%llu.dat", SteamUser()->GetSteamID().ConvertToUint64() };
+#else
+			CFmtStr szCacheFileName{ "cfg/clienti_%llu.dat", SteamUser()->GetSteamID().ConvertToUint64() };
+#endif
 			CUtlBuffer buf;
 			if ( g_pFullFileSystem->ReadFile( szCacheFileName, "MOD", buf ) )
 			{
@@ -144,11 +168,19 @@ public:
 		}
 #endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
+#else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
 #ifdef GAME_DLL
 		if ( engine->IsDedicatedServer() )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory = SteamGameServerInventory();
+#else
+			pInventory = SteamGameServerInventory();
+#endif
 		}
 #endif
 		if ( !pInventory )
@@ -157,7 +189,11 @@ public:
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pInventory->LoadItemDefinitions() )
+#else
+		if ( !pInventory->LoadItemDefinitions() )
+#endif
 		{
 			Warning( "Failed to load inventory item definitions!\n" );
 		}
@@ -173,7 +209,11 @@ public:
 		ListenForGameEvent( "rd_increment_strange_property" );
 
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetAllItems( &m_GetFullInventoryForCacheResult );
+#else
+		pInventory->GetAllItems( &m_GetFullInventoryForCacheResult );
+#endif
 
 		materials->AddReleaseFunc( &ResetAccessoryIconsOnMaterialsReleased );
 
@@ -183,11 +223,19 @@ public:
 
 	void LevelInitPreEntity() override
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
+#else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
 #ifdef GAME_DLL
 		if ( engine->IsDedicatedServer() )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory = SteamGameServerInventory();
+#else
+			pInventory = SteamGameServerInventory();
+#endif
 		}
 #endif
 		if ( !pInventory )
@@ -200,7 +248,11 @@ public:
 		{
 			m_flDefsUpdateTime = Plat_FloatTime();
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( !pInventory->LoadItemDefinitions() )
+#else
+			if ( !pInventory->LoadItemDefinitions() )
+#endif
 			{
 				Warning( "Failed to load inventory item definitions!\n" );
 			}
@@ -235,11 +287,19 @@ public:
 
 	void LevelShutdownPreEntity() override
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
+#else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
 #ifdef GAME_DLL
 		if ( engine->IsDedicatedServer() )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory = SteamGameServerInventory();
+#else
+			pInventory = SteamGameServerInventory();
+#endif
 		}
 #endif
 		if ( !pInventory )
@@ -257,15 +317,27 @@ public:
 #ifdef CLIENT_DLL
 	void CacheUserInventory( SteamInventoryResult_t hResult )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUtils *pUtils = SteamUtils();
+		#else
+		ISteamUtils *pUtils = SteamUtils();
+		#endif
 		Assert( pUtils );
 		// If we're not running as Alien Swarm: Reactive Drop (for example, if we're a mod or running through the SDK), don't update caches.
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pUtils || pUtils->GetAppID() != 563560 )
+		#else
+		if ( !pUtils || pUtils->GetAppID() != 563560 )
+		#endif
 		{
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
+#else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
 		if ( !pInventory )
 		{
 			Warning( "Failed to cache user inventory for offline play: no ISteamInventory\n" );
@@ -273,7 +345,11 @@ public:
 		}
 
 		uint32 nItems{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pInventory->GetResultItems( hResult, NULL, &nItems ) )
+#else
+		if ( !pInventory->GetResultItems( hResult, NULL, &nItems ) )
+#endif
 		{
 			Warning( "Failed to retrieve item count from inventory result for cache\n" );
 			return;
@@ -354,7 +430,11 @@ public:
 				Msg( "Have %d stacks of auto-stack item %d; merging\n", autoStackDefs[i].Count(), autoStackDefs.Key( i ) );
 			}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->TransferItemQuantity( AddCraftItemTask( CRAFT_AUTO_STACK, autoStackDefs.Key( i ) ), autoStackDefs[i][1], GetLocalItemCache( autoStackDefs[i][1] )->Quantity, autoStackDefs[i][0] );
+#else
+			pInventory->TransferItemQuantity( AddCraftItemTask( CRAFT_AUTO_STACK, autoStackDefs.Key( i ) ), autoStackDefs[i][1], GetLocalItemCache( autoStackDefs[i][1] )->Quantity, autoStackDefs[i][0] );
+#endif
 			if ( autoStackDefs[i].Count() > 2 )
 			{
 				m_CraftingQueue.Tail()->m_RetryItemList.AddVectorToTail( autoStackDefs[i] );
@@ -419,17 +499,29 @@ public:
 			}
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->ExchangeItems( AddCraftItemTask( CRAFT_AUTO_BACKGROUND ), output, outputqty, NELEMS( output ), input.Base(), inputqty.Base(), input.Count() );
+#else
+		pInventory->ExchangeItems( AddCraftItemTask( CRAFT_AUTO_BACKGROUND ), output, outputqty, NELEMS( output ), input.Base(), inputqty.Base(), input.Count() );
+#endif
 
 		return true;
 	}
 
 	void WriteInventoryCache()
 	{
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUtils *pUtils = SteamUtils();
+	#else
+		ISteamUtils *pUtils = SteamUtils();
+	#endif
 		Assert( pUtils );
 		// If we're not running as Alien Swarm: Reactive Drop (for example, if we're a mod or running through the SDK), don't update caches.
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pUtils || pUtils->GetAppID() != 563560 )
+		#else
+		if ( !pUtils || pUtils->GetAppID() != 563560 )
+		#endif
 		{
 			return;
 		}
@@ -450,14 +542,22 @@ public:
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUser *pUser = SteamUser();
+#else
+		ISteamUser *pUser = SteamUser();
+#endif
 		if ( !pUser )
 		{
 			Warning( "Failed to cache user inventory for offline play: no ISteamUser\n" );
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		CFmtStr szCacheFileName{ "cfg/clienti_%llu.dat", pUser->GetSteamID().ConvertToUint64() };
+#else
+		CFmtStr szCacheFileName{ "cfg/clienti_%llu.dat", pUser->GetSteamID().ConvertToUint64() };
+#endif
 		if ( !g_pFullFileSystem->WriteFile( szCacheFileName, "MOD", buf ) )
 		{
 			Warning( "Failed to write inventory cache\n" );
@@ -481,7 +581,11 @@ public:
 		ISteamUtils *pUtils = SteamUtils();
 		Assert( pUtils );
 		// If we're not running as Alien Swarm: Reactive Drop (for example, if we're a mod or running through the SDK), don't update caches.
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pUtils || pUtils->GetAppID() != 563560 )
+		#else
+		if ( !pUtils || pUtils->GetAppID() != 563560 )
+		#endif
 		{
 			return;
 		}
@@ -489,7 +593,11 @@ public:
 		CFastTimer timer;
 		timer.Start();
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
+#else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
 		if ( !pInventory )
 		{
 			Warning( "Failed to cache item schema for offline play: no ISteamInventory\n" );
@@ -499,10 +607,18 @@ public:
 		KeyValues::AutoDelete pCache{ "IS" };
 
 		uint32 nItemDefs{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetItemDefinitionIDs( NULL, &nItemDefs );
+#else
+		pInventory->GetItemDefinitionIDs( NULL, &nItemDefs );
+#endif
 		CUtlVector<SteamItemDef_t> ItemDefIDs;
 		ItemDefIDs.AddMultipleToTail( nItemDefs );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetItemDefinitionIDs( ItemDefIDs.Base(), &nItemDefs );
+#else
+		pInventory->GetItemDefinitionIDs( ItemDefIDs.Base(), &nItemDefs );
+#endif
 
 		ItemDefIDs.AddVectorToTail( m_HighOwnedInventoryDefIDs );
 
@@ -510,12 +626,20 @@ public:
 		uint32 size{};
 
 		uint32 nSkippedDefs = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		const char *szUserLanguage = SteamApps()->GetCurrentGameLanguage();
+#else
+		const char *szUserLanguage = SteamApps()->GetCurrentGameLanguage();
+#endif
 
 		FOR_EACH_VEC( ItemDefIDs, i )
 		{
 			size = szStringBuf.Count();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->GetItemDefinitionProperty( ItemDefIDs[i], "type", szStringBuf.Base(), &size );
+#else
+			pInventory->GetItemDefinitionProperty( ItemDefIDs[i], "type", szStringBuf.Base(), &size );
+#endif
 			if ( !V_strcmp( szStringBuf.Base(), "bundle" ) ||
 				!V_strcmp( szStringBuf.Base(), "generator" ) ||
 				!V_strcmp( szStringBuf.Base(), "playtimegenerator" ) )
@@ -527,10 +651,18 @@ public:
 
 			KeyValues *pDef = new KeyValues{ "d" };
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->GetItemDefinitionProperty( ItemDefIDs[i], NULL, NULL, &size );
+#else
+			pInventory->GetItemDefinitionProperty( ItemDefIDs[i], NULL, NULL, &size );
+#endif
 			szStringBuf.EnsureCapacity( size );
 			size = szStringBuf.Count();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->GetItemDefinitionProperty( ItemDefIDs[i], NULL, szStringBuf.Base(), &size );
+#else
+			pInventory->GetItemDefinitionProperty( ItemDefIDs[i], NULL, szStringBuf.Base(), &size );
+#endif
 
 			CSplitString PropertyNames{ szStringBuf.Base(), "," };
 			FOR_EACH_VEC( PropertyNames, j )
@@ -578,10 +710,18 @@ public:
 
 #undef CHECK_LANGUAGE_PREFIX
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetItemDefinitionProperty( ItemDefIDs[i], PropertyNames[j], NULL, &size );
+#else
+				pInventory->GetItemDefinitionProperty( ItemDefIDs[i], PropertyNames[j], NULL, &size );
+#endif
 				szStringBuf.EnsureCapacity( size );
 				size = szStringBuf.Count();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetItemDefinitionProperty( ItemDefIDs[i], PropertyNames[j], szStringBuf.Base(), &size );
+#else
+				pInventory->GetItemDefinitionProperty( ItemDefIDs[i], PropertyNames[j], szStringBuf.Base(), &size );
+#endif
 
 				if ( szStringBuf.Base()[0] == '\0' )
 				{
@@ -657,7 +797,11 @@ public:
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
+#else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
 		Assert( pInventory );
 		if ( !pInventory )
 		{
@@ -665,7 +809,11 @@ public:
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamInventoryUpdateHandle_t hUpdate = pInventory->StartUpdateProperties();
+#else
+		SteamInventoryUpdateHandle_t hUpdate = pInventory->StartUpdateProperties();
+#endif
 
 		if ( rd_debug_inventory.GetBool() )
 		{
@@ -682,7 +830,11 @@ public:
 					m_PendingDynamicPropertyUpdates[i]->PropertyIndex, szProperty, m_PendingDynamicPropertyUpdates[i]->NewValue );
 			}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			bool ok = pInventory->SetProperty( hUpdate, m_PendingDynamicPropertyUpdates[i]->ItemInstanceID, szProperty, m_PendingDynamicPropertyUpdates[i]->NewValue );
+#else
+			bool ok = pInventory->SetProperty( hUpdate, m_PendingDynamicPropertyUpdates[i]->ItemInstanceID, szProperty, m_PendingDynamicPropertyUpdates[i]->NewValue );
+#endif
 			Assert( ok );
 			if ( !ok )
 			{
@@ -690,7 +842,11 @@ public:
 			}
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bool ok = pInventory->SubmitUpdateProperties( hUpdate, &m_DynamicPropertyUpdateResult );
+#else
+		bool ok = pInventory->SubmitUpdateProperties( hUpdate, &m_DynamicPropertyUpdateResult );
+#endif
 		Assert( ok );
 		if ( !ok )
 		{
@@ -1319,11 +1475,19 @@ public:
 	{
 		~CraftItemTask_t()
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			ISteamInventory *pInventory = SteamInventory();
+#else
+			ISteamInventory *pInventory = SteamInventory();
+#endif
 			Assert( pInventory );
 			if ( pInventory )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->DestroyResult( m_hResult );
+#else
+				pInventory->DestroyResult( m_hResult );
+#endif
 			}
 		}
 
@@ -1440,7 +1604,11 @@ public:
 			DebugPrintResult( pTask->m_hResult );
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		EResult eResult = pInventory->GetResultStatus( pTask->m_hResult );
+#else
+		EResult eResult = pInventory->GetResultStatus( pTask->m_hResult );
+#endif
 		if ( eResult != k_EResultOK )
 		{
 			Warning( "Crafting task (type %d) failed with EResult %d %s\n", pTask->m_Type, eResult, UTIL_RD_EResultToString( eResult ) );
@@ -1449,7 +1617,11 @@ public:
 			if ( pTask->m_Type == CRAFT_DYNAMIC_PROPERTY_INIT && pTask->m_RetryItemList.Count() )
 			{
 				// silently retry the init after re-obtaining a snapshot of the items
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetItemsByID( AddCraftItemTask( CRAFT_DYNAMIC_PROPERTY_INIT_RETRY, pTask->m_iAccessoryDef, pTask->m_iReplaceItemInstance ), pTask->m_RetryItemList.Base(), pTask->m_RetryItemList.Count() );
+#else
+				pInventory->GetItemsByID( AddCraftItemTask( CRAFT_DYNAMIC_PROPERTY_INIT_RETRY, pTask->m_iAccessoryDef, pTask->m_iReplaceItemInstance ), pTask->m_RetryItemList.Base(), pTask->m_RetryItemList.Count() );
+#endif
 				return;
 			}
 
@@ -1553,10 +1725,18 @@ public:
 				}
 
 				uint32 nCount{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetResultItems( pTask->m_hResult, NULL, &nCount );
+#else
+				pInventory->GetResultItems( pTask->m_hResult, NULL, &nCount );
+#endif
 				CUtlVector<SteamItemDetails_t> diff;
 				diff.AddMultipleToTail( nCount );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetResultItems( pTask->m_hResult, diff.Base(), &nCount );
+#else
+				pInventory->GetResultItems( pTask->m_hResult, diff.Base(), &nCount );
+#endif
 
 				int added = 0;
 				FOR_EACH_VEC( diff, i )
@@ -1569,7 +1749,11 @@ public:
 					char buf[12]{};
 					uint32 len = sizeof( buf );
 					int32 quantity = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					if ( pInventory->GetResultItemProperty( pTask->m_hResult, i, "quantity", buf, &len ) )
+#else
+					if ( pInventory->GetResultItemProperty( pTask->m_hResult, i, "quantity", buf, &len ) )
+#endif
 					{
 						quantity = strtol( buf, NULL, 10 );
 					}
@@ -1607,13 +1791,21 @@ public:
 			if ( engine->IsInGame() )
 			{
 				uint32_t nItems = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetResultItems( pTask->m_hResult, NULL, &nItems );
+#else
+				pInventory->GetResultItems( pTask->m_hResult, NULL, &nItems );
+#endif
 				if ( nItems > 0 )
 				{
 					// make sure the first item is real and not a "no new items granted" error message
 					char szOrigin[128]{};
 					uint32_t nOriginSize = sizeof( szOrigin );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pInventory->GetResultItemProperty( pTask->m_hResult, 0, "origin", szOrigin, &nOriginSize );
+#else
+					pInventory->GetResultItemProperty( pTask->m_hResult, 0, "origin", szOrigin, &nOriginSize );
+#endif
 
 					if ( !V_strcmp( szOrigin, "promo" ) )
 					{
@@ -1648,10 +1840,18 @@ public:
 			if ( pTask->m_RetryItemList.Count() != 0 )
 			{
 				uint32 nCount{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetResultItems( pTask->m_hResult, NULL, &nCount );
+#else
+				pInventory->GetResultItems( pTask->m_hResult, NULL, &nCount );
+#endif
 				CUtlVector<SteamItemDetails_t> items;
 				items.AddMultipleToTail( nCount );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetResultItems( pTask->m_hResult, items.Base(), &nCount );
+#else
+				pInventory->GetResultItems( pTask->m_hResult, items.Base(), &nCount );
+#endif
 
 				SteamItemInstanceID_t iStacked = k_SteamItemInstanceIDInvalid;
 				FOR_EACH_VEC( items, i )
@@ -1664,7 +1864,11 @@ public:
 					char buf[12]{};
 					uint32 len = sizeof( buf );
 					int32 quantity = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					if ( pInventory->GetResultItemProperty( pTask->m_hResult, i, "quantity", buf, &len ) )
+#else
+					if ( pInventory->GetResultItemProperty( pTask->m_hResult, i, "quantity", buf, &len ) )
+#endif
 					{
 						quantity = strtol( buf, NULL, 10 );
 					}
@@ -1685,7 +1889,11 @@ public:
 						Msg( "Have %d remaining stacks of auto-stack item %d; merging\n", pTask->m_RetryItemList.Count() + 1, pTask->m_iAccessoryDef );
 					}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pInventory->TransferItemQuantity( AddCraftItemTask( CRAFT_AUTO_STACK, pTask->m_iAccessoryDef ), pTask->m_RetryItemList[0], GetLocalItemCache( pTask->m_RetryItemList[0] )->Quantity, iStacked );
+#else
+					pInventory->TransferItemQuantity( AddCraftItemTask( CRAFT_AUTO_STACK, pTask->m_iAccessoryDef ), pTask->m_RetryItemList[0], GetLocalItemCache( pTask->m_RetryItemList[0] )->Quantity, iStacked );
+#endif
 					m_CraftingQueue.Tail()->m_RetryItemList.AddVectorToTail( pTask->m_RetryItemList );
 					m_CraftingQueue.Tail()->m_RetryItemList.FastRemove( 0 );
 				}
@@ -1696,11 +1904,23 @@ public:
 			break;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUser *pUser = SteamUser();
+#else
+		ISteamUser *pUser = SteamUser();
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pUser && pInventory->CheckResultSteamID( pTask->m_hResult, pUser->GetSteamID() ) )
+#else
+		if ( pUser && pInventory->CheckResultSteamID( pTask->m_hResult, pUser->GetSteamID() ) )
+#endif
 		{
 			uint32 nCount{ 0 };
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->GetResultItems( pTask->m_hResult, NULL, &nCount );
+#else
+			pInventory->GetResultItems( pTask->m_hResult, NULL, &nCount );
+#endif
 			if ( nCount > 0 )
 			{
 				m_bWantFullInventoryRefresh = true;
@@ -1715,10 +1935,18 @@ public:
 
 		if ( m_bWantFullInventoryRefresh && m_CraftingQueue.Count() == 0 && ( !ASWGameRules() || ASWGameRules()->GetGameState() != ASW_GS_INGAME ) )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->DestroyResult( m_GetFullInventoryForCacheResult );
+#else
+			pInventory->DestroyResult( m_GetFullInventoryForCacheResult );
+#endif
 			m_GetFullInventoryForCacheResult = k_SteamInventoryResultInvalid;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->GetAllItems( &m_GetFullInventoryForCacheResult );
+#else
+			pInventory->GetAllItems( &m_GetFullInventoryForCacheResult );
+#endif
 
 			if ( ValidatePlayerEquipmentResult() )
 			{
@@ -1733,13 +1961,21 @@ public:
 		GET_INVENTORY_OR_BAIL;
 
 		uint32_t nItems = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pInventory->GetResultItems( hResult, NULL, &nItems ) )
+#else
+		if ( !pInventory->GetResultItems( hResult, NULL, &nItems ) )
+#endif
 		{
 			return;
 		}
 
 		SteamItemDetails_t *pItems = ( SteamItemDetails_t * )stackalloc( nItems * sizeof( SteamItemDetails_t ) );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pInventory->GetResultItems( hResult, pItems, &nItems ) )
+#else
+		if ( !pInventory->GetResultItems( hResult, pItems, &nItems ) )
+#endif
 		{
 			return;
 		}
@@ -1769,10 +2005,18 @@ public:
 		SteamInventoryUpdateHandle_t hUpdate = k_SteamInventoryUpdateHandleInvalid;
 
 		uint32 nCount{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetResultItems( pTask->m_hResult, NULL, &nCount );
+#else
+		pInventory->GetResultItems( pTask->m_hResult, NULL, &nCount );
+#endif
 		CUtlVector<SteamItemDetails_t> items;
 		items.AddMultipleToTail( nCount );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetResultItems( pTask->m_hResult, items.Base(), &nCount );
+#else
+		pInventory->GetResultItems( pTask->m_hResult, items.Base(), &nCount );
+#endif
 		CUtlVector<SteamItemInstanceID_t> itemsForInit;
 
 		FOR_EACH_VEC( items, i )
@@ -1797,7 +2041,11 @@ public:
 						Assert( ReactiveDropInventory::DynamicPropertyDataType( pDef->CompressedDynamicProps[j] ) == FIELD_INTEGER64 );
 						if ( hUpdate == k_SteamInventoryUpdateHandleInvalid )
 						{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 							hUpdate = pInventory->StartUpdateProperties();
+#else
+							hUpdate = pInventory->StartUpdateProperties();
+#endif
 							Assert( hUpdate != k_SteamInventoryUpdateHandleInvalid );
 						}
 
@@ -1819,7 +2067,11 @@ public:
 							Msg( "[C] Initializing missing dynamic property '%s' on item %llu (%d %s) to %lld.\n", pDef->CompressedDynamicProps[j], instance.ItemID, instance.ItemDefID, pDef->Name.Get(), iDefaultValue );
 
 						bHeldBack = true;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 						pInventory->SetProperty( hUpdate, instance.ItemID, pDef->CompressedDynamicProps[j], iDefaultValue );
+#else
+						pInventory->SetProperty( hUpdate, instance.ItemID, pDef->CompressedDynamicProps[j], iDefaultValue );
+#endif
 					}
 				}
 
@@ -1850,7 +2102,11 @@ public:
 									Msg( "[C] Initializing missing dynamic property '%s' on item %llu (%d %s) (from accessory %d %s) to 0.\n", pAccessoryDef->CompressedDynamicProps[k], instance.ItemID, instance.ItemDefID, pDef->Name.Get(), accessoryID, pAccessoryDef->Name.Get() );
 
 								bHeldBack = true;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 								pInventory->SetProperty( hUpdate, instance.ItemID, pAccessoryDef->CompressedDynamicProps[k], 0ll );
+#else
+								pInventory->SetProperty( hUpdate, instance.ItemID, pAccessoryDef->CompressedDynamicProps[k], 0ll );
+#endif
 							}
 						}
 					}
@@ -1873,7 +2129,11 @@ public:
 
 		if ( hUpdate != k_SteamInventoryUpdateHandleInvalid )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->SubmitUpdateProperties( hUpdate, AddCraftItemTask( bSilenceNotification ? CRAFT_DYNAMIC_PROPERTY_UPDATE : CRAFT_DYNAMIC_PROPERTY_INIT, SteamItemDef_t( iMode ) ) );
+#else
+			pInventory->SubmitUpdateProperties( hUpdate, AddCraftItemTask( bSilenceNotification ? CRAFT_DYNAMIC_PROPERTY_UPDATE : CRAFT_DYNAMIC_PROPERTY_INIT, SteamItemDef_t( iMode ) ) );
+#endif
 			if ( !bIsRetry )
 			{
 				m_CraftingQueue.Tail()->m_RetryItemList.AddVectorToTail( itemsForInit );
@@ -1905,7 +2165,11 @@ public:
 
 	void DebugPrintResult( SteamInventoryResult_t hResult )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
+#else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
 		Assert( pInventory );
 		if ( !pInventory )
 		{
@@ -1914,16 +2178,33 @@ public:
 		}
 
 		uint32_t count{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItems( hResult, NULL, &count ) )
 			Msg( "Result %08x (%s, age %d sec) has %d items:\n", hResult, UTIL_RD_EResultToString( pInventory->GetResultStatus( hResult ) ), SteamUtils()->GetServerRealTime() - pInventory->GetResultTimestamp( hResult ), count );
+#else
+		if ( pInventory->GetResultItems( hResult, NULL, &count ) )
+			Msg( "Result %08x (%s, age %d sec) has %d items:\n", hResult, UTIL_RD_EResultToString( pInventory->GetResultStatus( hResult ) ), SteamUtils()->GetServerRealTime() - pInventory->GetResultTimestamp( hResult ), count );
+#endif
 		else
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			Msg( "Result %08x (%s, age %d sec) has ERR items:\n", hResult, UTIL_RD_EResultToString( pInventory->GetResultStatus( hResult ) ), SteamUtils()->GetServerRealTime() - pInventory->GetResultTimestamp( hResult ) );
+#else
+			Msg( "Result %08x (%s, age %d sec) has ERR items:\n", hResult, UTIL_RD_EResultToString( pInventory->GetResultStatus( hResult ) ), SteamUtils()->GetServerRealTime() - pInventory->GetResultTimestamp( hResult ) );
+#endif
 
 		uint32 nSerializedBufferSize{};
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->SerializeResult( hResult, NULL, &nSerializedBufferSize ) )
+#else
+		if ( pInventory->SerializeResult( hResult, NULL, &nSerializedBufferSize ) )
+#endif
 		{
 			byte *pSerialized = ( byte * )stackalloc( nSerializedBufferSize );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->SerializeResult( hResult, pSerialized, &nSerializedBufferSize );
+#else
+			pInventory->SerializeResult( hResult, pSerialized, &nSerializedBufferSize );
+#endif
 			char *szSerialized = ( char * )stackalloc( nSerializedBufferSize * 2 + 1 );
 
 			// V_binarytohex is O(n^2); use an O(n) algorithm instead.
@@ -1938,7 +2219,11 @@ public:
 		}
 
 		CUtlMemory<SteamItemDetails_t> itemDetails( 0, count );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pInventory->GetResultItems( hResult, itemDetails.Base(), &count ) )
+#else
+		if ( !pInventory->GetResultItems( hResult, itemDetails.Base(), &count ) )
+#endif
 		{
 			Warning( "Failed to get item details for result.\n" );
 			count = 0;
@@ -1954,18 +2239,34 @@ public:
 			szStringBuf[0] = '\0';
 
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetResultItemProperty( hResult, i, NULL, NULL, &size );
+#else
+				pInventory->GetResultItemProperty( hResult, i, NULL, NULL, &size );
+#endif
 				szStringBuf.EnsureCapacity( size + 1 );
 				size = szStringBuf.Count();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetResultItemProperty( hResult, i, NULL, szStringBuf.Base(), &size );
+#else
+				pInventory->GetResultItemProperty( hResult, i, NULL, szStringBuf.Base(), &size );
+#endif
 				Msg( "ResultProperties: %s\n", szStringBuf.Base() );
 				CSplitString propertyNames( szStringBuf.Base(), "," );
 				FOR_EACH_VEC( propertyNames, j )
 				{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pInventory->GetResultItemProperty( hResult, i, propertyNames[j], NULL, &size );
+#else
+					pInventory->GetResultItemProperty( hResult, i, propertyNames[j], NULL, &size );
+#endif
 					szStringBuf.EnsureCapacity( size + 1 );
 					size = szStringBuf.Count();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pInventory->GetResultItemProperty( hResult, i, propertyNames[j], szStringBuf.Base(), &size );
+#else
+					pInventory->GetResultItemProperty( hResult, i, propertyNames[j], szStringBuf.Base(), &size );
+#endif
 					Msg( "ResultProperties[%s] = %s\n", propertyNames[j], szStringBuf.Base() );
 				}
 			}
@@ -1981,21 +2282,37 @@ public:
 	}
 #endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Inventory_Manager, OnSteamInventoryResultReady, SteamInventoryResultReady_t )
+#else
+	STEAM_CALLBACK( CRD_Inventory_Manager, OnSteamInventoryResultReady, SteamInventoryResultReady_t )
+#endif
 	{
 		DevMsg( 2, "[%c] Steam Inventory result for %08x received: EResult %d (%s)\n", IsClientDll() ? 'C' : 'S', pParam->m_handle, pParam->m_result, UTIL_RD_EResultToString( pParam->m_result ) );
 
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
 #else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
+#else
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = engine->IsDedicatedServer() ? SteamGameServerInventory() : SteamInventory();
+#else
+		ISteamInventory *pInventory = engine->IsDedicatedServer() ? SteamGameServerInventory() : SteamInventory();
+#endif
 #endif
 		Assert( pInventory );
 
 		if ( pParam->m_handle == m_DebugPrintInventoryResult )
 		{
 			DebugPrintResult( m_DebugPrintInventoryResult );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->DestroyResult( m_DebugPrintInventoryResult );
+#else
+			pInventory->DestroyResult( m_DebugPrintInventoryResult );
+#endif
 			m_DebugPrintInventoryResult = k_SteamInventoryResultInvalid;
 
 			return;
@@ -2011,7 +2328,11 @@ public:
 		{
 			CacheUserInventory( m_GetFullInventoryForCacheResult );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->DestroyResult( m_GetFullInventoryForCacheResult );
+#else
+			pInventory->DestroyResult( m_GetFullInventoryForCacheResult );
+#endif
 			m_GetFullInventoryForCacheResult = k_SteamInventoryResultInvalid;
 
 			return;
@@ -2022,9 +2343,17 @@ public:
 			bool bAnyPlayerEquipChanged = false;
 
 			uint32_t nItems = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->GetResultItems( pParam->m_handle, NULL, &nItems );
+#else
+			pInventory->GetResultItems( pParam->m_handle, NULL, &nItems );
+#endif
 			SteamItemDetails_t *pDetails = ( SteamItemDetails_t * )stackalloc( sizeof( SteamItemDetails_t ) * nItems );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->GetResultItems( pParam->m_handle, pDetails, &nItems );
+#else
+			pInventory->GetResultItems( pParam->m_handle, pDetails, &nItems );
+#endif
 
 			for ( int i = 0; i < NELEMS( ReactiveDropInventory::g_PlayerInventorySlotNames ); i++ )
 			{
@@ -2046,7 +2375,11 @@ public:
 					break;
 			}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->DestroyResult( m_DynamicPropertyUpdateResult );
+#else
+			pInventory->DestroyResult( m_DynamicPropertyUpdateResult );
+#endif
 			m_DynamicPropertyUpdateResult = k_SteamInventoryResultInvalid;
 
 			if ( m_bWantExtraDynamicPropertyCommit )
@@ -2058,8 +2391,16 @@ public:
 			{
 				// TODO: can we just slot in the updated items?
 				if ( m_GetFullInventoryForCacheResult != k_SteamInventoryResultInvalid )
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pInventory->DestroyResult( m_GetFullInventoryForCacheResult );
+#else
+					pInventory->DestroyResult( m_GetFullInventoryForCacheResult );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->GetAllItems( &m_GetFullInventoryForCacheResult );
+#else
+				pInventory->GetAllItems( &m_GetFullInventoryForCacheResult );
+#endif
 
 				ValidatePlayerEquipmentResult( bAnyPlayerEquipChanged );
 			}
@@ -2082,7 +2423,11 @@ public:
 			{
 				m_iCraftingMaterialSpawnCommand = UTIL_RD_SendInventoryCommand( INVCMD_MATERIAL_SPAWN, m_CraftingMaterialSpawnArgs, m_CraftingMaterialLocationsResult );
 			}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->DestroyResult( m_CraftingMaterialLocationsResult );
+#else
+			pInventory->DestroyResult( m_CraftingMaterialLocationsResult );
+#endif
 			m_CraftingMaterialLocationsResult = k_SteamInventoryResultInvalid;
 			return;
 		}
@@ -2142,7 +2487,11 @@ public:
 		GET_INVENTORY_OR_BAIL( false );
 
 		// we need SteamUtils so we can check the server time to see if our result is near the 1 hour expiration time.
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUtils *pUtils = SteamUtils();
+		#else
+		ISteamUtils *pUtils = SteamUtils();
+		#endif
 		Assert( pUtils );
 		if ( !pUtils )
 			return false;
@@ -2171,7 +2520,11 @@ public:
 
 		if ( m_PlayerEquipmentResult != k_SteamInventoryResultInvalid && !bForceReset )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			EResult eResult = pInventory->GetResultStatus( m_PlayerEquipmentResult );
+#else
+			EResult eResult = pInventory->GetResultStatus( m_PlayerEquipmentResult );
+#endif
 
 			// if the result is pending, don't touch it.
 			if ( eResult == k_EResultPending )
@@ -2181,7 +2534,11 @@ public:
 			if ( eResult == k_EResultOK )
 			{
 				// result expires 60 minutes after being created; catch it 5 minutes early and fetch a new one.
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				int iAge = pUtils->GetServerRealTime() - pInventory->GetResultTimestamp( m_PlayerEquipmentResult );
+#else
+				int iAge = pUtils->GetServerRealTime() - pInventory->GetResultTimestamp( m_PlayerEquipmentResult );
+#endif
 				if ( iAge < 55 * 60 )
 					return true;
 			}
@@ -2213,7 +2570,11 @@ public:
 
 		if ( m_PlayerEquipmentResult != k_SteamInventoryResultInvalid )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->DestroyResult( m_PlayerEquipmentResult );
+#else
+			pInventory->DestroyResult( m_PlayerEquipmentResult );
+#endif
 			m_PlayerEquipmentResult = k_SteamInventoryResultInvalid;
 		}
 
@@ -2223,7 +2584,11 @@ public:
 			return true;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetItemsByID( &m_PlayerEquipmentResult, items.Base(), items.Count() );
+#else
+		pInventory->GetItemsByID( &m_PlayerEquipmentResult, items.Base(), items.Count() );
+#endif
 		Assert( m_PlayerEquipmentResult != k_SteamInventoryResultInvalid );
 
 		return false;
@@ -2252,9 +2617,17 @@ public:
 		GET_INVENTORY_OR_BAIL;
 
 		uint32_t nItems = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetResultItems( m_PlayerEquipmentResult, NULL, &nItems );
+#else
+		pInventory->GetResultItems( m_PlayerEquipmentResult, NULL, &nItems );
+#endif
 		SteamItemDetails_t *pDetails = ( SteamItemDetails_t * )stackalloc( sizeof( SteamItemDetails_t ) * nItems );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GetResultItems( m_PlayerEquipmentResult, pDetails, &nItems );
+#else
+		pInventory->GetResultItems( m_PlayerEquipmentResult, pDetails, &nItems );
+#endif
 
 		for ( int i = 0; i < RD_NUM_STEAM_INVENTORY_EQUIP_SLOTS_PLAYER; i++ )
 		{
@@ -2443,7 +2816,11 @@ public:
 
 		if ( m_CraftingMaterialLocationsResult != k_SteamInventoryResultInvalid )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->DestroyResult( m_CraftingMaterialLocationsResult );
+#else
+			pInventory->DestroyResult( m_CraftingMaterialLocationsResult );
+#endif
 			m_CraftingMaterialLocationsResult = k_SteamInventoryResultInvalid;
 		}
 
@@ -2456,7 +2833,11 @@ public:
 		else
 		{
 			m_iCraftingMaterialSpawnCommand = 0;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->GetItemsByID( &m_CraftingMaterialLocationsResult, toSend.Base(), toSend.Count() );
+#else
+			pInventory->GetItemsByID( &m_CraftingMaterialLocationsResult, toSend.Base(), toSend.Count() );
+#endif
 		}
 
 		if ( rd_debug_inventory.GetBool() )
@@ -2503,7 +2884,11 @@ public:
 		uint32 one[1] = { 1 };
 
 		SteamInventoryResult_t *pResult = AddCraftItemTask( CRAFT_PICKUP_MATERIAL, iLocation, m_CraftingMaterialToken[iLocation] );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->ExchangeItems( pResult, generate, one, 1, consume, one, 1 );
+#else
+		pInventory->ExchangeItems( pResult, generate, one, 1, consume, one, 1 );
+#endif
 
 		if ( rd_debug_inventory.GetBool() )
 		{
@@ -2572,7 +2957,11 @@ public:
 		}
 
 		SteamInventoryResult_t *pResult = AddCraftItemTask( CRAFT_PICKUP_MATERIAL_ASSIST, eMaterial, consume[0] );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->ExchangeItems( pResult, generate, one, 1, consume, one, 1 );
+#else
+		pInventory->ExchangeItems( pResult, generate, one, 1, consume, one, 1 );
+#endif
 
 		if ( rd_debug_inventory.GetBool() )
 		{
@@ -2594,7 +2983,11 @@ public:
 	CUtlVector<NotificationSeenUpdate_t> m_QueuedNotificationSeen;
 	CUtlVector<NotificationSeenUpdate_t> m_InFlightNotificationSeen;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Inventory_Manager, OnSteamInventoryFullUpdate, SteamInventoryFullUpdate_t )
+#else
+	STEAM_CALLBACK( CRD_Inventory_Manager, OnSteamInventoryFullUpdate, SteamInventoryFullUpdate_t )
+#endif
 	{
 		// don't write the same cache twice in a row
 		if ( pParam->m_handle == m_GetFullInventoryForCacheResult )
@@ -2609,7 +3002,11 @@ public:
 	}
 #endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CRD_Inventory_Manager, OnSteamInventoryDefinitionUpdate, SteamInventoryDefinitionUpdate_t )
+#else
+	STEAM_CALLBACK( CRD_Inventory_Manager, OnSteamInventoryDefinitionUpdate, SteamInventoryDefinitionUpdate_t )
+#endif
 	{
 		s_bLoadedItemDefs = true;
 		if ( s_pItemDefCache )
@@ -2641,11 +3038,19 @@ static void RD_Equipped_Item_Changed( IConVar *var, const char *pOldValue, float
 
 	if ( ReactiveDropInventory::CheckMedalEquipCache() )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUserStats *pUserStats = SteamUserStats();
+#else
+		ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 		Assert( pUserStats );
 		if ( pUserStats )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			bool bOK = pUserStats->StoreStats();
+#else
+			bool bOK = pUserStats->StoreStats();
+#endif
 			Assert( bOK );
 			( void )bOK;
 		}
@@ -2660,12 +3065,20 @@ ConVar rd_equipped_medal[RD_STEAM_INVENTORY_NUM_MEDAL_SLOTS]
 
 CON_COMMAND( rd_debug_print_inventory, "" )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamInventory()->GetAllItems( &s_RD_Inventory_Manager.m_DebugPrintInventoryResult );
+#else
+	SteamInventory()->GetAllItems( &s_RD_Inventory_Manager.m_DebugPrintInventoryResult );
+#endif
 }
 
 CON_COMMAND( rd_debug_inspect_entire_inventory, "inspect every item in your inventory" )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamInventory()->GetAllItems( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_INSPECT ) );
+#else
+	SteamInventory()->GetAllItems( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_INSPECT ) );
+#endif
 }
 
 CON_COMMAND( rd_debug_inspect_own_item, "inspect an item you own by ID" )
@@ -2677,7 +3090,11 @@ CON_COMMAND( rd_debug_inspect_own_item, "inspect an item you own by ID" )
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamInventory()->GetItemsByID( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_INSPECT ), &id, 1 );
+#else
+	SteamInventory()->GetItemsByID( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_INSPECT ), &id, 1 );
+#endif
 }
 
 CON_COMMAND( rd_econ_item_preview, "inspect an item using a code from the Steam Community backpack" )
@@ -2688,7 +3105,11 @@ CON_COMMAND( rd_econ_item_preview, "inspect an item using a code from the Steam 
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamInventory()->InspectItem( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_INSPECT ), args.Arg( 1 ) );
+#else
+	SteamInventory()->InspectItem( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_INSPECT ), args.Arg( 1 ) );
+#endif
 }
 #endif
 
@@ -2854,57 +3275,101 @@ namespace ReactiveDropInventory
 
 		char buf[1536]{};
 		uint32 len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "accountid", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "accountid", buf, &len ) )
+#endif
 		{
 			AccountID.SetFromUint64( strtoull( buf, NULL, 10 ) );
 		}
 		len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "itemid", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "itemid", buf, &len ) )
+#endif
 		{
 			ItemID = strtoull( buf, NULL, 10 );
 		}
 		len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "originalitemid", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "originalitemid", buf, &len ) )
+#endif
 		{
 			OriginalItemID = strtoull( buf, NULL, 10 );
 		}
 		len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "itemdefid", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "itemdefid", buf, &len ) )
+#endif
 		{
 			ItemDefID = strtol( buf, NULL, 10 );
 		}
 		len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "quantity", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "quantity", buf, &len ) )
+#endif
 		{
 			Quantity = strtol( buf, NULL, 10 );
 		}
 		len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "acquired", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "acquired", buf, &len ) )
+#endif
 		{
 			Acquired = ParseTimestamp( buf );
 		}
 		len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "state_changed_timestamp", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "state_changed_timestamp", buf, &len ) )
+#endif
 		{
 			StateChangedTimestamp = ParseTimestamp( buf );
 		}
 		len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "state", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "state", buf, &len ) )
+#endif
 		{
 			State = buf;
 		}
 		len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "origin", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "origin", buf, &len ) )
+#endif
 		{
 			Origin = buf;
 		}
 		len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "dynamic_props", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "dynamic_props", buf, &len ) )
+#endif
 		{
 			ParseDynamicProps( DynamicProps, buf );
 		}
 		len = sizeof( buf );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pInventory->GetResultItemProperty( hResult, index, "tags", buf, &len ) )
+#else
+		if ( pInventory->GetResultItemProperty( hResult, index, "tags", buf, &len ) )
+#endif
 		{
 			ParseTags( Tags, buf );
 		}
@@ -3057,11 +3522,19 @@ namespace ReactiveDropInventory
 			return s_ItemDefs[index];
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamInventory *pInventory = SteamInventory();
+#else
+		ISteamInventory *pInventory = SteamInventory();
+#endif
 #ifdef GAME_DLL
 		if ( engine->IsDedicatedServer() )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory = SteamGameServerInventory();
+#else
+			pInventory = SteamGameServerInventory();
+#endif
 		}
 #endif
 		KeyValues *pCachedDef = NULL;
@@ -3113,7 +3586,11 @@ namespace ReactiveDropInventory
 			}
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		const char *szLang = SteamApps() ? SteamApps()->GetCurrentGameLanguage() : "english";
+#else
+		const char *szLang = SteamApps() ? SteamApps()->GetCurrentGameLanguage() : "english";
+#endif
 #ifdef GAME_DLL
 		if ( engine->IsDedicatedServer() )
 		{
@@ -3124,7 +3601,11 @@ namespace ReactiveDropInventory
 		uint32_t count{};
 		if ( s_bLoadedItemDefs )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->GetItemDefinitionProperty( id, NULL, NULL, &count );
+#else
+			pInventory->GetItemDefinitionProperty( id, NULL, NULL, &count );
+#endif
 			Assert( count );
 			if ( !count )
 			{
@@ -3139,6 +3620,16 @@ namespace ReactiveDropInventory
 		CUtlMemory<char> szBuf( 0, 1024 );
 		const char *szValue;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
+#define RD_FETCH_PROPERTY_ITEM_DEF_SIZE( szPropertyName ) pInventory->GetItemDefinitionProperty( id, szPropertyName, NULL, &count )
+#else
+#define RD_FETCH_PROPERTY_ITEM_DEF_SIZE( szPropertyName ) pInventory->GetItemDefinitionProperty( id, szPropertyName, NULL, &count )
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
+#define RD_FETCH_PROPERTY_ITEM_DEF_VALUE( szPropertyName ) pInventory->GetItemDefinitionProperty( id, szPropertyName, szBuf.Base(), &count )
+#else
+#define RD_FETCH_PROPERTY_ITEM_DEF_VALUE( szPropertyName ) pInventory->GetItemDefinitionProperty( id, szPropertyName, szBuf.Base(), &count )
+#endif
 #define FETCH_PROPERTY( szPropertyName ) \
 		if ( pCachedDef ) \
 		{ \
@@ -3146,10 +3637,10 @@ namespace ReactiveDropInventory
 		} \
 		else \
 		{ \
-			pInventory->GetItemDefinitionProperty( id, szPropertyName, NULL, &count ); \
+			RD_FETCH_PROPERTY_ITEM_DEF_SIZE( szPropertyName ); \
 			szBuf.EnsureCapacity( count + 1 ); \
 			count = szBuf.Count(); \
-			pInventory->GetItemDefinitionProperty( id, szPropertyName, szBuf.Base(), &count ); \
+			RD_FETCH_PROPERTY_ITEM_DEF_VALUE( szPropertyName ); \
 			szValue = szBuf.Base(); \
 		}
 
@@ -3440,6 +3931,8 @@ namespace ReactiveDropInventory
 		}
 #endif
 #undef FETCH_PROPERTY
+#undef RD_FETCH_PROPERTY_ITEM_DEF_VALUE
+#undef RD_FETCH_PROPERTY_ITEM_DEF_SIZE
 
 		s_ItemDefs.Insert( id, pItemDef );
 
@@ -3450,7 +3943,11 @@ namespace ReactiveDropInventory
 	{
 		GET_INVENTORY_OR_BAIL( false );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->DestroyResult( hResult );
+#else
+		pInventory->DestroyResult( hResult );
+#endif
 		hResult = k_SteamInventoryResultInvalid;
 
 		size_t nEncodedChars = V_strlen( szEncodedData );
@@ -3462,7 +3959,11 @@ namespace ReactiveDropInventory
 		CUtlMemory<byte> decodedData{ 0, int( nEncodedChars / 2 ) };
 		V_hextobinary( szEncodedData, nEncodedChars, decodedData.Base(), decodedData.Count() );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pInventory->DeserializeResult( &hResult, decodedData.Base(), decodedData.Count() ) )
+#else
+		if ( !pInventory->DeserializeResult( &hResult, decodedData.Base(), decodedData.Count() ) )
+#endif
 		{
 			Warning( "ISteamInventory::DeserializeResult failed to create a result.\n" );
 			return false;
@@ -3475,7 +3976,11 @@ namespace ReactiveDropInventory
 	{
 		GET_INVENTORY_OR_BAIL( false );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		EResult eResultStatus = pInventory->GetResultStatus( hResult );
+#else
+		EResult eResultStatus = pInventory->GetResultStatus( hResult );
+#endif
 		if ( eResultStatus == k_EResultPending )
 		{
 			return false;
@@ -3489,7 +3994,11 @@ namespace ReactiveDropInventory
 			return true;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( requiredSteamID.IsValid() && !pInventory->CheckResultSteamID( hResult, requiredSteamID ) )
+#else
+		if ( requiredSteamID.IsValid() && !pInventory->CheckResultSteamID( hResult, requiredSteamID ) )
+#endif
 		{
 			Warning( "ReactiveDropInventory::ValidateItemData: not from SteamID %llu\n", requiredSteamID.ConvertToUint64() );
 
@@ -3519,14 +4028,22 @@ namespace ReactiveDropInventory
 	{
 		GET_INVENTORY_OR_BAIL;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->AddPromoItem( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_PROMO ), id );
+#else
+		pInventory->AddPromoItem( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_PROMO ), id );
+#endif
 	}
 
 	void RequestGenericPromoItems()
 	{
 		GET_INVENTORY_OR_BAIL;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->GrantPromoItems( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_PROMO ) );
+#else
+		pInventory->GrantPromoItems( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_PROMO ) );
+#endif
 	}
 
 	void CheckPlaytimeItemGenerators()
@@ -3534,8 +4051,16 @@ namespace ReactiveDropInventory
 #if defined( RD_7A_DROPS ) || defined( RD_7A_DROPS_PRE )
 		GET_INVENTORY_OR_BAIL;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->TriggerItemDrop( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_DROP ), 7000 ); // Playtime Random Material Tokens Weekly
+#else
+		pInventory->TriggerItemDrop( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_DROP ), 7000 ); // Playtime Random Material Tokens Weekly
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->TriggerItemDrop( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_DROP ), 7002 ); // Playtime Random Material Tokens Extended
+#else
+		pInventory->TriggerItemDrop( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_DROP ), 7002 ); // Playtime Random Material Tokens Extended
+#endif
 #endif
 	}
 
@@ -3677,13 +4202,25 @@ namespace ReactiveDropInventory
 
 	bool CheckMedalEquipCache()
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUtils *pUtils = SteamUtils();
+		#else
+		ISteamUtils *pUtils = SteamUtils();
+		#endif
 		Assert( pUtils );
 		// If we're not running as Alien Swarm: Reactive Drop (for example, if we're a mod or running through the SDK), don't check the medal cache because we'll fail.
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pUtils || pUtils->GetAppID() != 563560 )
+		#else
+		if ( !pUtils || pUtils->GetAppID() != 563560 )
+		#endif
 			return false;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUserStats *pUserStats = SteamUserStats();
+#else
+		ISteamUserStats *pUserStats = SteamUserStats();
+#endif
 		Assert( pUserStats );
 		if ( !pUserStats )
 			return false;
@@ -3704,7 +4241,11 @@ namespace ReactiveDropInventory
 		{
 			CFmtStr szLowBitsStatName{ "equipped_medal_%da", i + 1 };
 			CFmtStr szHighBitsStatName{ "equipped_medal_%db", i + 1 };
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			bool bGotEquippedMedal = pUserStats->GetStat( szLowBitsStatName, &MedalID.Bits.iLowBits ) && pUserStats->GetStat( szHighBitsStatName, &MedalID.Bits.iHighBits );
+#else
+			bool bGotEquippedMedal = pUserStats->GetStat( szLowBitsStatName, &MedalID.Bits.iLowBits ) && pUserStats->GetStat( szHighBitsStatName, &MedalID.Bits.iHighBits );
+#endif
 			Assert( bGotEquippedMedal );
 			if ( bGotEquippedMedal )
 			{
@@ -3718,9 +4259,17 @@ namespace ReactiveDropInventory
 				{
 					bAnyChanged = true;
 					MedalID.iItemInstance = iCurrentInstance;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					bool bSetEquippedMedal = pUserStats->SetStat( szLowBitsStatName, MedalID.Bits.iLowBits );
+#else
+					bool bSetEquippedMedal = pUserStats->SetStat( szLowBitsStatName, MedalID.Bits.iLowBits );
+#endif
 					Assert( bSetEquippedMedal ); ( void )bSetEquippedMedal;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					bSetEquippedMedal = pUserStats->SetStat( szHighBitsStatName, MedalID.Bits.iHighBits );
+#else
+					bSetEquippedMedal = pUserStats->SetStat( szHighBitsStatName, MedalID.Bits.iHighBits );
+#endif
 					Assert( bSetEquippedMedal ); ( void )bSetEquippedMedal;
 				}
 			}
@@ -3733,15 +4282,27 @@ namespace ReactiveDropInventory
 	{
 		GET_INVENTORY_OR_BAIL;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamInventoryUpdateHandle_t hUpdate = pInventory->StartUpdateProperties();
+#else
+		SteamInventoryUpdateHandle_t hUpdate = pInventory->StartUpdateProperties();
+#endif
 		Assert( hUpdate != k_SteamInventoryUpdateHandleInvalid );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bool bOK = pInventory->SetProperty( hUpdate, id, "style", int64( iStyle ) );
+#else
+		bool bOK = pInventory->SetProperty( hUpdate, id, "style", int64( iStyle ) );
+#endif
 		Assert( bOK );
 		if ( !bOK )
 			Warning( "Inventory item style property update failed!\n" );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bOK = pInventory->SubmitUpdateProperties( hUpdate, s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_USER_DYNAMIC_PROPERTY_UPDATE ) );
+#else
+		bOK = pInventory->SubmitUpdateProperties( hUpdate, s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_USER_DYNAMIC_PROPERTY_UPDATE ) );
+#endif
 		Assert( bOK );
 		if ( !bOK )
 			Warning( "Inventory item style update submit failed!\n" );
@@ -3804,7 +4365,11 @@ namespace ReactiveDropInventory
 		if ( hResult )
 		{
 			// we're likely going to fail due to an update conflict, but we need to move the queue
-			pInventory->DestroyResult( *hResult );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
+		pInventory->DestroyResult( *hResult );
+#else
+		pInventory->DestroyResult( *hResult );
+#endif
 			*hResult = k_SteamInventoryResultInvalid;
 		}
 
@@ -3842,12 +4407,24 @@ namespace ReactiveDropInventory
 			s_RD_Inventory_Manager.m_InFlightNotificationSeen.RemoveMultipleFromHead( s_RD_Inventory_Manager.m_InFlightNotificationSeen.Count() - 100 );
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamInventoryUpdateHandle_t hUpdate = pInventory->StartUpdateProperties();
+#else
+		SteamInventoryUpdateHandle_t hUpdate = pInventory->StartUpdateProperties();
+#endif
 		FOR_EACH_VEC( s_RD_Inventory_Manager.m_InFlightNotificationSeen, i )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->SetProperty( hUpdate, s_RD_Inventory_Manager.m_InFlightNotificationSeen[i].NotificationID, "notification_seen", int64_t( s_RD_Inventory_Manager.m_InFlightNotificationSeen[i].Seen ) );
+#else
+			pInventory->SetProperty( hUpdate, s_RD_Inventory_Manager.m_InFlightNotificationSeen[i].NotificationID, "notification_seen", int64_t( s_RD_Inventory_Manager.m_InFlightNotificationSeen[i].Seen ) );
+#endif
 		}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->SubmitUpdateProperties( hUpdate, hResult );
+#else
+		pInventory->SubmitUpdateProperties( hUpdate, hResult );
+#endif
 	}
 
 	void DeleteNotificationItem( SteamItemInstanceID_t id )
@@ -3906,7 +4483,11 @@ namespace ReactiveDropInventory
 			}
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->ConsumeItem( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_DELETE_SILENT, 0, id ), id, 1 );
+#else
+		pInventory->ConsumeItem( s_RD_Inventory_Manager.AddCraftItemTask( CRAFT_DELETE_SILENT, 0, id ), id, 1 );
+#endif
 	}
 
 #ifdef RD_7A_DROPS
@@ -3966,8 +4547,13 @@ namespace ReactiveDropInventory
 		GET_INVENTORY_OR_BAIL;
 
 		const uint32 one = 1;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pInventory->ExchangeItems( s_RD_Inventory_Manager.AddCraftItemTask( eCraftType, iAccessoryDef, iReplaceItemInstance ),
 			&recipe, &one, 1, ingredient.begin(), quantity.begin(), ingredient.size() );
+#else
+		pInventory->ExchangeItems( s_RD_Inventory_Manager.AddCraftItemTask( eCraftType, iAccessoryDef, iReplaceItemInstance ),
+			&recipe, &one, 1, ingredient.begin(), quantity.begin(), ingredient.size() );
+#endif
 	}
 	void RequestFullInventoryRefresh()
 	{
@@ -3977,7 +4563,11 @@ namespace ReactiveDropInventory
 		{
 			if ( s_RD_Inventory_Manager.m_GetFullInventoryForCacheResult != k_SteamInventoryResultInvalid )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pInventory->DestroyResult( s_RD_Inventory_Manager.m_GetFullInventoryForCacheResult );
+#else
+				pInventory->DestroyResult( s_RD_Inventory_Manager.m_GetFullInventoryForCacheResult );
+#endif
 				s_RD_Inventory_Manager.m_GetFullInventoryForCacheResult = k_SteamInventoryResultInvalid;
 			}
 
@@ -3987,7 +4577,11 @@ namespace ReactiveDropInventory
 		{
 			s_RD_Inventory_Manager.m_bWantFullInventoryRefresh = false;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pInventory->GetAllItems( &s_RD_Inventory_Manager.m_GetFullInventoryForCacheResult );
+#else
+			pInventory->GetAllItems( &s_RD_Inventory_Manager.m_GetFullInventoryForCacheResult );
+#endif
 		}
 	}
 #endif

--- a/src/game/shared/swarm/rd_loadout.cpp
+++ b/src/game/shared/swarm/rd_loadout.cpp
@@ -300,12 +300,28 @@ namespace ReactiveDropLoadout
 		KeyValues::AutoDelete pKV{ "SavedLoadouts" };
 		bool bLoaded;
 		ConVarRef cl_cloud_settings{ "cl_cloud_settings" };
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamRemoteStorage *pSteamRemoteStorage = SteamRemoteStorage();
+		#else
+		ISteamRemoteStorage *pSteamRemoteStorage = SteamRemoteStorage();
+		#endif
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( ( cl_cloud_settings.GetInt() & STEAMREMOTESTORAGE_CLOUD_SAVED_LOADOUTS ) && pSteamRemoteStorage && pSteamRemoteStorage->FileExists( "reactivedrop/cfg/saved_loadouts.txt" ) )
+		#else
+		if ( ( cl_cloud_settings.GetInt() & STEAMREMOTESTORAGE_CLOUD_SAVED_LOADOUTS ) && pSteamRemoteStorage && pSteamRemoteStorage->FileExists( "reactivedrop/cfg/saved_loadouts.txt" ) )
+		#endif
 		{
 			CUtlBuffer buf;
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			int32 iSize = pSteamRemoteStorage->GetFileSize( "reactivedrop/cfg/saved_loadouts.txt" );
+			#else
+			int32 iSize = pSteamRemoteStorage->GetFileSize( "reactivedrop/cfg/saved_loadouts.txt" );
+			#endif
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamRemoteStorage->FileRead( "reactivedrop/cfg/saved_loadouts.txt", buf.AccessForDirectRead( iSize ), iSize );
+			#else
+			pSteamRemoteStorage->FileRead( "reactivedrop/cfg/saved_loadouts.txt", buf.AccessForDirectRead( iSize ), iSize );
+			#endif
 			buf.SeekPut( CUtlBuffer::SEEK_HEAD, iSize );
 			filesystem->WriteFile( "cfg/saved_loadouts.txt", "MOD", buf );
 			buf.SetBufferType( true, true );
@@ -350,12 +366,20 @@ namespace ReactiveDropLoadout
 		pKV->SaveToFile( g_pFullFileSystem, "cfg/saved_loadouts.txt", "MOD" );
 
 		ConVarRef cl_cloud_settings{ "cl_cloud_settings" };
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamRemoteStorage *pSteamRemoteStorage = SteamRemoteStorage();
+		#else
+		ISteamRemoteStorage *pSteamRemoteStorage = SteamRemoteStorage();
+		#endif
 		if ( ( cl_cloud_settings.GetInt() & STEAMREMOTESTORAGE_CLOUD_SAVED_LOADOUTS ) && pSteamRemoteStorage )
 		{
 			CUtlBuffer buf;
 			pKV->RecursiveSaveToFile( buf, 0 );
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamRemoteStorage->FileWrite( "reactivedrop/cfg/saved_loadouts.txt", buf.Base(), buf.TellPut() );
+			#else
+			pSteamRemoteStorage->FileWrite( "reactivedrop/cfg/saved_loadouts.txt", buf.Base(), buf.TellPut() );
+			#endif
 		}
 	}
 	void WriteLoadoutsForSharing( CUtlBuffer &buf, const CUtlDict<ReactiveDropLoadout::LoadoutData_t> &loadouts )
@@ -458,9 +482,18 @@ namespace ReactiveDropLoadout
 			MarineIncluded[i] = true;
 		}
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUtils *pUtils = SteamUtils();
+		#else
+		ISteamUtils *pUtils = SteamUtils();
+		#endif
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pUtils )
 			LastModified = pUtils->GetServerRealTime();
+		#else
+		if ( pUtils )
+			LastModified = pUtils->GetServerRealTime();
+		#endif
 	}
 	bool LoadoutData_t::ReplaceItemID( SteamItemInstanceID_t oldID, SteamItemInstanceID_t newID, const char *szDebugLoadoutName )
 	{
@@ -627,12 +660,20 @@ namespace ReactiveDropLoadout
 
 	void MarkIntegratedGuideAsUsed( PublishedFileId_t id )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+		#else
+		ISteamRemoteStorage *pRemoteStorage = SteamRemoteStorage();
+		#endif
 		Assert( pRemoteStorage );
 		if ( pRemoteStorage )
 		{
 			// we don't really care about the result of this call because we can't do anything either way
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pRemoteStorage->SetUserPublishedFileAction( id, k_EWorkshopFileActionPlayed );
+			#else
+			pRemoteStorage->SetUserPublishedFileAction( id, k_EWorkshopFileActionPlayed );
+			#endif
 		}
 	}
 #endif

--- a/src/game/shared/swarm/rd_lobby_utils.cpp
+++ b/src/game/shared/swarm/rd_lobby_utils.cpp
@@ -23,10 +23,18 @@ static void SDRDebugCallback( ESteamNetworkingSocketsDebugOutputType nType, cons
 
 void SDRSpewLevelChanged( IConVar *var, const char *pOldValue, float flOldValue )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( ISteamNetworkingUtils *pUtils = SteamNetworkingUtils() )
+#else
+	if ( ISteamNetworkingUtils *pUtils = SteamNetworkingUtils() )
+#endif
 	{
 		ESteamNetworkingSocketsDebugOutputType level = ESteamNetworkingSocketsDebugOutputType( ConVarRef( var ).GetInt() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUtils->SetDebugOutputFunction( level, &SDRDebugCallback );
+#else
+		pUtils->SetDebugOutputFunction( level, &SDRDebugCallback );
+#endif
 	}
 }
 
@@ -34,14 +42,26 @@ ConVar sdr_spew_level( IsServerDll() ? "sdr_spew_level_server" : "sdr_spew_level
 
 void UTIL_RD_InitSteamNetworking()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamNetworkingUtils *pUtils = SteamNetworkingUtils();
+#else
+	ISteamNetworkingUtils *pUtils = SteamNetworkingUtils();
+#endif
 	Assert( pUtils );
 	if ( !pUtils )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUtils->InitRelayNetworkAccess();
+#else
+	pUtils->InitRelayNetworkAccess();
+#endif
 	ESteamNetworkingSocketsDebugOutputType level = ESteamNetworkingSocketsDebugOutputType( sdr_spew_level.GetInt() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUtils->SetDebugOutputFunction( level, &SDRDebugCallback );
+#else
+	pUtils->SetDebugOutputFunction( level, &SDRDebugCallback );
+#endif
 }
 
 CSteamID UTIL_RD_GetCurrentLobbyID()
@@ -81,13 +101,25 @@ void UTIL_RD_JoinByLobbyID( CSteamID lobby )
 bool UTIL_RD_IsLobbyOwner()
 {
 	CSteamID lobby = UTIL_RD_GetCurrentLobbyID();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !lobby.IsValid() || !SteamMatchmaking() || !SteamUser() )
+#else
+	if ( !lobby.IsValid() || !SteamMatchmaking() || !SteamUser() )
+#endif
 	{
 		return false;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CSteamID owner = SteamMatchmaking()->GetLobbyOwner( lobby );
+#else
+	CSteamID owner = SteamMatchmaking()->GetLobbyOwner( lobby );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	return owner == SteamUser()->GetSteamID();
+#else
+	return owner == SteamUser()->GetSteamID();
+#endif
 }
 
 KeyValues *UTIL_RD_LobbyToLegacyKeyValues( CSteamID lobby )
@@ -102,12 +134,20 @@ KeyValues *UTIL_RD_LobbyToLegacyKeyValues( CSteamID lobby )
 	KeyValues *pGameKey = pKV->FindKey( "game", true );
 	if (pGameKey)
 		pGameKey->Clear();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	int nCount = SteamMatchmaking()->GetLobbyDataCount( lobby );
+#else
+	int nCount = SteamMatchmaking()->GetLobbyDataCount( lobby );
+#endif
 	for ( int i = 0; i < nCount; i++ )
 	{
 		char szKey[256];
 		char szValue[1024];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamMatchmaking()->GetLobbyDataByIndex( lobby, i, szKey, sizeof( szKey ), szValue, sizeof( szValue ) ) )
+#else
+		if ( SteamMatchmaking()->GetLobbyDataByIndex( lobby, i, szKey, sizeof( szKey ), szValue, sizeof( szValue ) ) )
+#endif
 		{
 			if ( StringHasPrefix( szKey, "game:" ) || StringHasPrefix( szKey, "system:" ) )
 			{
@@ -136,7 +176,11 @@ const char *UTIL_RD_GetCurrentLobbyData( const char *pszKey, const char *pszDefa
 		return pszDefaultValue;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	const char *pszValue = SteamMatchmaking()->GetLobbyData( lobby, pszKey );
+#else
+	const char *pszValue = SteamMatchmaking()->GetLobbyData( lobby, pszKey );
+#endif
 	if ( *pszValue )
 	{
 		return pszValue;
@@ -153,7 +197,11 @@ void UTIL_RD_UpdateCurrentLobbyData( const char *pszKey, const char *pszValue )
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamMatchmaking()->SetLobbyData( lobby, pszKey, pszValue );
+#else
+	SteamMatchmaking()->SetLobbyData( lobby, pszKey, pszValue );
+#endif
 }
 
 void UTIL_RD_UpdateCurrentLobbyData( const char *pszKey, int iValue )
@@ -179,16 +227,32 @@ void UTIL_RD_RemoveCurrentLobbyData( const char *pszKey )
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamMatchmaking()->DeleteLobbyData( lobby, pszKey );
+#else
+	SteamMatchmaking()->DeleteLobbyData( lobby, pszKey );
+#endif
 }
 
 int UTIL_RD_PingLobby( CSteamID lobby )
 {
 	SteamNetworkPingLocation_t location;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	const char *szLocation = SteamMatchmaking()->GetLobbyData( lobby, "system:rd_lobby_location" );
+#else
+	const char *szLocation = SteamMatchmaking()->GetLobbyData( lobby, "system:rd_lobby_location" );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamNetworkingUtils() && SteamNetworkingUtils()->ParsePingLocationString( szLocation, location ) )
+#else
+	if ( SteamNetworkingUtils() && SteamNetworkingUtils()->ParsePingLocationString( szLocation, location ) )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		int iPing = SteamNetworkingUtils()->EstimatePingTimeFromLocalHost( location );
+#else
+		int iPing = SteamNetworkingUtils()->EstimatePingTimeFromLocalHost( location );
+#endif
 		return MAX( iPing, 0 );
 	}
 
@@ -224,7 +288,11 @@ static int __cdecl SortScoreboardPlayersByTime( const RD_Lobby_Scoreboard_Entry_
 
 void UTIL_RD_ReadLobbyScoreboard( CSteamID lobby, CUtlVector<RD_Lobby_Scoreboard_Entry_t> &scoreboard, bool bSortPlayersByTime )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	const char *szScoreboard = SteamMatchmaking()->GetLobbyData( lobby, "system:rd_players" );
+#else
+	const char *szScoreboard = SteamMatchmaking()->GetLobbyData( lobby, "system:rd_players" );
+#endif
 	if ( !szScoreboard || *szScoreboard == '\0' )
 		return;
 
@@ -272,12 +340,20 @@ void UTIL_RD_ReadLobbyScoreboard( CSteamID lobby, CUtlVector<RD_Lobby_Scoreboard
 
 static void DebugSpewLobby( CSteamID lobby )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamMatchmaking *pMatchmaking = SteamMatchmaking();
+#else
+	ISteamMatchmaking *pMatchmaking = SteamMatchmaking();
+#endif
 	Assert( pMatchmaking );
 	if ( !pMatchmaking )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamFriends *pFriends = SteamFriends();
+#else
+	ISteamFriends *pFriends = SteamFriends();
+#endif
 	Assert( pFriends );
 	if ( !pFriends )
 		return;
@@ -294,7 +370,11 @@ static void DebugSpewLobby( CSteamID lobby )
 		uint32 serverIP;
 		uint16 serverPort;
 		CSteamID serverID;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( pMatchmaking->GetLobbyGameServer( lobby, &serverIP, &serverPort, &serverID ) )
+#else
+		if ( pMatchmaking->GetLobbyGameServer( lobby, &serverIP, &serverPort, &serverID ) )
+#endif
 		{
 			netadr_t serverAddr( serverIP, serverPort );
 			DevMsg( 3, "server: %s (%llu)\n", serverAddr.ToString(), serverID.ConvertToUint64() );
@@ -309,17 +389,37 @@ static void DebugSpewLobby( CSteamID lobby )
 			DevMsg( 3, "estimated ping: %dms\n", iPing );
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		int iMembers = pMatchmaking->GetNumLobbyMembers( lobby );
+#else
+		int iMembers = pMatchmaking->GetNumLobbyMembers( lobby );
+#endif
 		DevMsg( 3, "members: %d\n", iMembers );
 		if ( lobby == UTIL_RD_GetCurrentLobbyID() )
 		{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			CSteamID owner = pMatchmaking->GetLobbyOwner( lobby );
+#else
+			CSteamID owner = pMatchmaking->GetLobbyOwner( lobby );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			DevMsg( 3, "owner: %llu \"%s\"\n", owner.ConvertToUint64(), owner.IsValid() ? pFriends->GetFriendPersonaName( owner ) : "(invalid)" );
+#else
+			DevMsg( 3, "owner: %llu \"%s\"\n", owner.ConvertToUint64(), owner.IsValid() ? pFriends->GetFriendPersonaName( owner ) : "(invalid)" );
+#endif
 
 			for ( int i = 0; i < iMembers; i++ )
 			{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				CSteamID member = pMatchmaking->GetLobbyMemberByIndex( lobby, i );
+#else
+				CSteamID member = pMatchmaking->GetLobbyMemberByIndex( lobby, i );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				DevMsg( 3, "member %d: %llu \"%s\"\n", i, member.ConvertToUint64(), pFriends->GetFriendPersonaName( member ) );
+#else
+				DevMsg( 3, "member %d: %llu \"%s\"\n", i, member.ConvertToUint64(), pFriends->GetFriendPersonaName( member ) );
+#endif
 			}
 		}
 
@@ -332,13 +432,25 @@ static void DebugSpewLobby( CSteamID lobby )
 			DevMsg( 3, "player %d: \"%s\" | score: %d | connected for %d:%05.3f\n", i, szName, scoreboard[i].Score, int( scoreboard[i].Connected / 60 ), fmodf( scoreboard[i].Connected, 60.0f ) );
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		int iCount = pMatchmaking->GetLobbyDataCount( lobby );
+#else
+		int iCount = pMatchmaking->GetLobbyDataCount( lobby );
+#endif
 		for ( int i = 0; i < iCount; i++ )
 		{
 			char szKey[k_nMaxLobbyKeyLength];
 			char szValue[1]; // only big enough to hold the null terminator
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pMatchmaking->GetLobbyDataByIndex( lobby, i, szKey, sizeof( szKey ), szValue, sizeof( szValue ) );
+#else
+			pMatchmaking->GetLobbyDataByIndex( lobby, i, szKey, sizeof( szKey ), szValue, sizeof( szValue ) );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			const char *pszValue = pMatchmaking->GetLobbyData( lobby, szKey );
+#else
+			const char *pszValue = pMatchmaking->GetLobbyData( lobby, szKey );
+#endif
 
 			DevMsg( 3, "\"%s\" \"%s\"\n", szKey, pszValue );
 		}
@@ -368,8 +480,16 @@ void CReactiveDropLobbySearch::WantUpdatedLobbyList( bool bForce )
 		return;
 
 	// we need relay network access initialized to estimate lobby pings
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( ISteamNetworkingUtils *pUtils = SteamNetworkingUtils() )
+#else
+	if ( ISteamNetworkingUtils *pUtils = SteamNetworkingUtils() )
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUtils->InitRelayNetworkAccess();
+#else
+		pUtils->InitRelayNetworkAccess();
+#endif
 
 	m_flNextUpdate = Plat_FloatTime() + LOBBY_SEARCH_INTERVAL;
 
@@ -416,7 +536,11 @@ static const char *LobbyDistanceFilterName( ELobbyDistanceFilter distance )
 
 void CReactiveDropLobbySearch::UpdateSearch()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamMatchmaking *pMatchmaking = SteamMatchmaking();
+#else
+	ISteamMatchmaking *pMatchmaking = SteamMatchmaking();
+#endif
 	if ( !pMatchmaking )
 	{
 		AssertOnce( !"Missing Steam Matchmaking context" );
@@ -435,21 +559,37 @@ void CReactiveDropLobbySearch::UpdateSearch()
 
 	FOR_EACH_VEC( m_StringFilters, i )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pMatchmaking->AddRequestLobbyListStringFilter( m_StringFilters[i].m_Name, m_StringFilters[i].m_Value, m_StringFilters[i].m_Compare );
+#else
+		pMatchmaking->AddRequestLobbyListStringFilter( m_StringFilters[i].m_Name, m_StringFilters[i].m_Value, m_StringFilters[i].m_Compare );
+#endif
 		if ( rd_lobby_search_debug.GetBool() )
 			DevMsg( 3, "%s: filter: \"%s\" %s \"%s\"\n", m_pszDebugName, m_StringFilters[i].m_Name.Get(), LobbyComparisonName( m_StringFilters[i].m_Compare ), m_StringFilters[i].m_Value.Get() );
 	}
 	FOR_EACH_VEC( m_NumericalFilters, i )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pMatchmaking->AddRequestLobbyListNumericalFilter( m_NumericalFilters[i].m_Name, m_NumericalFilters[i].m_Value, m_NumericalFilters[i].m_Compare );
+#else
+		pMatchmaking->AddRequestLobbyListNumericalFilter( m_NumericalFilters[i].m_Name, m_NumericalFilters[i].m_Value, m_NumericalFilters[i].m_Compare );
+#endif
 		if ( rd_lobby_search_debug.GetBool() )
 			DevMsg( 3, "%s: filter: \"%s\" %s %d\n", m_pszDebugName, m_NumericalFilters[i].m_Name.Get(), LobbyComparisonName( m_NumericalFilters[i].m_Compare ), m_NumericalFilters[i].m_Value );
 	}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pMatchmaking->AddRequestLobbyListDistanceFilter( m_DistanceFilter );
+#else
+	pMatchmaking->AddRequestLobbyListDistanceFilter( m_DistanceFilter );
+#endif
 	if ( rd_lobby_search_debug.GetBool() )
 		DevMsg( 3, "%s: distance filter: %s\n", m_pszDebugName, LobbyDistanceFilterName( m_DistanceFilter ) );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = pMatchmaking->RequestLobbyList();
+#else
+	SteamAPICall_t hAPICall = pMatchmaking->RequestLobbyList();
+#endif
 	m_LobbyMatchListResult.Set( hAPICall, this, &CReactiveDropLobbySearch::LobbyMatchListResult );
 }
 
@@ -470,13 +610,21 @@ void CReactiveDropLobbySearch::LobbyMatchListResult( LobbyMatchList_t *pResult, 
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamMatchmaking *pMatchmaking = SteamMatchmaking();
+#else
+	ISteamMatchmaking *pMatchmaking = SteamMatchmaking();
+#endif
 	Assert( pMatchmaking );
 
 	m_MatchingLobbies.SetCount( pResult->m_nLobbiesMatching );
 	for ( uint32 i = 0; i < pResult->m_nLobbiesMatching; i++ )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_MatchingLobbies[i] = pMatchmaking->GetLobbyByIndex( i );
+#else
+		m_MatchingLobbies[i] = pMatchmaking->GetLobbyByIndex( i );
+#endif
 	}
 
 	if ( rd_lobby_search_debug.GetBool() )
@@ -591,15 +739,27 @@ CReactiveDropServerListHelper::CReactiveDropServerListHelper( const char *szDebu
 
 CReactiveDropServerListHelper::~CReactiveDropServerListHelper()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamMatchmakingServers *pServers = SteamMatchmakingServers();
+#else
+	ISteamMatchmakingServers *pServers = SteamMatchmakingServers();
+#endif
 	if ( pServers && m_hServerListRequest )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pServers->ReleaseRequest( m_hServerListRequest );
+#else
+		pServers->ReleaseRequest( m_hServerListRequest );
+#endif
 		m_hServerListRequest = NULL;
 	}
 	if ( pServers && m_hServerListRequestNext )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pServers->ReleaseRequest( m_hServerListRequestNext );
+#else
+		pServers->ReleaseRequest( m_hServerListRequestNext );
+#endif
 		m_hServerListRequestNext = NULL;
 	}
 }
@@ -612,32 +772,64 @@ void CReactiveDropServerListHelper::WantUpdatedServerList()
 	if ( m_hServerListRequestNext || m_flSoonestServerListRequest > Plat_FloatTime() )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamMatchmakingServers *pServers = SteamMatchmakingServers();
+#else
+	ISteamMatchmakingServers *pServers = SteamMatchmakingServers();
+#endif
 	Assert( pServers );
 	if ( !pServers )
 		return;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	static const AppId_t iAppID = SteamUtils()->GetAppID();
+#else
+	static const AppId_t iAppID = SteamUtils()->GetAppID();
+#endif
 
 	switch ( m_eMode )
 	{
 	case MODE_INTERNET:
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hServerListRequestNext = pServers->RequestInternetServerList( iAppID, m_Filters.Base(), m_Filters.Count(), this );
+#else
+		m_hServerListRequestNext = pServers->RequestInternetServerList( iAppID, m_Filters.Base(), m_Filters.Count(), this );
+#endif
 		break;
 	case MODE_LAN:
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hServerListRequestNext = pServers->RequestLANServerList( iAppID, this );
+#else
+		m_hServerListRequestNext = pServers->RequestLANServerList( iAppID, this );
+#endif
 		break;
 	case MODE_FRIENDS:
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hServerListRequestNext = pServers->RequestFriendsServerList( iAppID, m_Filters.Base(), m_Filters.Count(), this );
+#else
+		m_hServerListRequestNext = pServers->RequestFriendsServerList( iAppID, m_Filters.Base(), m_Filters.Count(), this );
+#endif
 		break;
 	case MODE_FAVORITES:
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hServerListRequestNext = pServers->RequestFavoritesServerList( iAppID, m_Filters.Base(), m_Filters.Count(), this );
+#else
+		m_hServerListRequestNext = pServers->RequestFavoritesServerList( iAppID, m_Filters.Base(), m_Filters.Count(), this );
+#endif
 		break;
 	case MODE_HISTORY:
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hServerListRequestNext = pServers->RequestHistoryServerList( iAppID, m_Filters.Base(), m_Filters.Count(), this );
+#else
+		m_hServerListRequestNext = pServers->RequestHistoryServerList( iAppID, m_Filters.Base(), m_Filters.Count(), this );
+#endif
 		break;
 	case MODE_SPECTATOR:
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		m_hServerListRequestNext = pServers->RequestSpectatorServerList( iAppID, m_Filters.Base(), m_Filters.Count(), this );
+#else
+		m_hServerListRequestNext = pServers->RequestSpectatorServerList( iAppID, m_Filters.Base(), m_Filters.Count(), this );
+#endif
 		break;
 	default:
 		Assert( 0 );
@@ -649,27 +841,51 @@ void CReactiveDropServerListHelper::WantUpdatedServerList()
 
 int CReactiveDropServerListHelper::Count() const
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamMatchmakingServers *pServers = SteamMatchmakingServers();
+#else
+	ISteamMatchmakingServers *pServers = SteamMatchmakingServers();
+#endif
 	Assert( pServers );
 	if ( !pServers || !m_hServerListRequest )
 		return 0;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	return pServers->GetServerCount( m_hServerListRequest );
+#else
+	return pServers->GetServerCount( m_hServerListRequest );
+#endif
 }
 
 gameserveritem_t *CReactiveDropServerListHelper::GetDetails( int iServer ) const
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamMatchmakingServers *pServers = SteamMatchmakingServers();
+#else
+	ISteamMatchmakingServers *pServers = SteamMatchmakingServers();
+#endif
 	Assert( pServers );
 	if ( !pServers || !m_hServerListRequest )
 		return NULL;
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	gameserveritem_t *pDetails = pServers->GetServerDetails( m_hServerListRequest, iServer );
+#else
+	gameserveritem_t *pDetails = pServers->GetServerDetails( m_hServerListRequest, iServer );
+#endif
 	Assert( pDetails );
 
 	// favorite servers aren't filtering (bug in Steam API)
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	Assert( SteamUtils() && pDetails->m_nAppID == SteamUtils()->GetAppID() );
+#else
+	Assert( SteamUtils() && pDetails->m_nAppID == SteamUtils()->GetAppID() );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamUtils() && pDetails->m_nAppID != SteamUtils()->GetAppID() )
+#else
+	if ( SteamUtils() && pDetails->m_nAppID != SteamUtils()->GetAppID() )
+#endif
 		return NULL;
 
 	return pDetails;
@@ -753,7 +969,11 @@ void CReactiveDropServerListHelper::RefreshComplete( HServerListRequest hRequest
 	Assert( m_hServerListRequestNext == hRequest );
 
 	if ( m_hServerListRequest )
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamMatchmakingServers()->ReleaseRequest( m_hServerListRequest );
+	#else
+		SteamMatchmakingServers()->ReleaseRequest( m_hServerListRequest );
+	#endif
 
 	m_hServerListRequest = m_hServerListRequestNext;
 	m_hServerListRequestNext = NULL;

--- a/src/game/shared/swarm/rd_lobby_utils.h
+++ b/src/game/shared/swarm/rd_lobby_utils.h
@@ -97,7 +97,11 @@ public:
 
 private:
 	void UpdateSearch();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CReactiveDropLobbySearch, LobbyMatchList_t> m_LobbyMatchListResult;
+#else
+	CCallResult<CReactiveDropLobbySearch, LobbyMatchList_t> m_LobbyMatchListResult;
+#endif
 	void LobbyMatchListResult( LobbyMatchList_t *pResult, bool bIOFailure );
 
 	const char *m_pszDebugName;

--- a/src/game/shared/swarm/rd_workshop.cpp
+++ b/src/game/shared/swarm/rd_workshop.cpp
@@ -91,25 +91,41 @@ bool CReactiveDropWorkshop::Init()
 
 	InitNonWorkshopAddons();
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pSteamUGC = SteamUGC();
+#else
+	ISteamUGC *pSteamUGC = SteamUGC();
+#endif
 	if ( !pSteamUGC )
 	{
 		Warning( "No Steam connection. Skipping workshop.\n" );
 		return true;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	uint32 nSubscribed = pSteamUGC->GetNumSubscribedItems();
+#else
+	uint32 nSubscribed = pSteamUGC->GetNumSubscribedItems();
+#endif
 	if ( nSubscribed != 0 && !CommandLine()->FindParm( "-skiploadingworkshopaddons" ) )
 	{
 		int iStart = m_EnabledAddonsForQuery.AddMultipleToTail( nSubscribed );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		nSubscribed = pSteamUGC->GetSubscribedItems( m_EnabledAddonsForQuery.Base() + iStart, nSubscribed );
+#else
+		nSubscribed = pSteamUGC->GetSubscribedItems( m_EnabledAddonsForQuery.Base() + iStart, nSubscribed );
+#endif
 		m_EnabledAddonsForQuery.SetCountNonDestructively( iStart + nSubscribed );
 
 #ifdef DBGFLAG_ASSERT
 		for ( uint32 i = 0; i < nSubscribed; i++ )
 		{
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			uint32 iState = pSteamUGC->GetItemState( m_EnabledAddonsForQuery[i + iStart] );
+			#else
+			uint32 iState = pSteamUGC->GetItemState( m_EnabledAddonsForQuery[i + iStart] );
+			#endif
 			Assert( iState & k_EItemStateSubscribed );
 		}
 #endif
@@ -117,13 +133,29 @@ bool CReactiveDropWorkshop::Init()
 		KeyValues::AutoDelete pKV( "WorkshopAddons" );
 		ConVarRef cl_cloud_settings( "cl_cloud_settings" );
 		bool bLoaded = false;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamRemoteStorage *pSteamRemoteStorage = SteamRemoteStorage();
+#else
+		ISteamRemoteStorage *pSteamRemoteStorage = SteamRemoteStorage();
+#endif
 		Assert( pSteamRemoteStorage );
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( ( cl_cloud_settings.GetInt() & STEAMREMOTESTORAGE_CLOUD_DISABLED_WORKSHOP_ITEMS ) && pSteamRemoteStorage && pSteamRemoteStorage->FileExists( WORKSHOP_DISABLED_ADDONS_FILENAME ) )
+		#else
+		if ( ( cl_cloud_settings.GetInt() & STEAMREMOTESTORAGE_CLOUD_DISABLED_WORKSHOP_ITEMS ) && pSteamRemoteStorage && pSteamRemoteStorage->FileExists( WORKSHOP_DISABLED_ADDONS_FILENAME ) )
+		#endif
 		{
 			CUtlBuffer buf;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			int32 iSize = pSteamRemoteStorage->GetFileSize( WORKSHOP_DISABLED_ADDONS_FILENAME );
+#else
+			int32 iSize = pSteamRemoteStorage->GetFileSize( WORKSHOP_DISABLED_ADDONS_FILENAME );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pSteamRemoteStorage->FileRead( WORKSHOP_DISABLED_ADDONS_FILENAME, buf.AccessForDirectRead( iSize ), iSize );
+#else
+			pSteamRemoteStorage->FileRead( WORKSHOP_DISABLED_ADDONS_FILENAME, buf.AccessForDirectRead( iSize ), iSize );
+#endif
 			buf.SeekPut( CUtlBuffer::SEEK_HEAD, iSize );
 			filesystem->WriteFile( WORKSHOP_DISABLED_ADDONS_FILENAME, "MOD", buf );
 			buf.SetBufferType( true, true );
@@ -232,6 +264,7 @@ void CReactiveDropWorkshop::SaveDisabledAddons()
 	}
 
 	ConVarRef cl_cloud_settings( "cl_cloud_settings" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( ( cl_cloud_settings.GetInt() & STEAMREMOTESTORAGE_CLOUD_DISABLED_WORKSHOP_ITEMS ) && SteamRemoteStorage() )
 	{
 		CUtlBuffer buf;
@@ -246,6 +279,22 @@ void CReactiveDropWorkshop::SaveDisabledAddons()
 			return;
 		}
 	}
+#else
+	if ( ( cl_cloud_settings.GetInt() & STEAMREMOTESTORAGE_CLOUD_DISABLED_WORKSHOP_ITEMS ) && SteamRemoteStorage() )
+	{
+		CUtlBuffer buf;
+		if ( !filesystem->ReadFile( WORKSHOP_DISABLED_ADDONS_FILENAME, "MOD", buf ) )
+		{
+			Warning( "Could not load disabled workshop addons list!\n" );
+			return;
+		}
+		if ( !SteamRemoteStorage()->FileWrite( WORKSHOP_DISABLED_ADDONS_FILENAME, buf.Base(), buf.TellMaxPut() ) )
+		{
+			Warning( "Could not write disabled workshop addons list to Steam Cloud!\n" );
+			return;
+		}
+	}
+#endif
 
 	if ( rd_workshop_debug.GetBool() )
 	{
@@ -263,7 +312,11 @@ public:
 		m_QueryCompletedCall.Set( hCall, this, &LoadWorkshopCollection_t::QueryCompletedCall );
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<LoadWorkshopCollection_t, SteamUGCQueryCompleted_t> m_QueryCompletedCall;
+#else
+	CCallResult<LoadWorkshopCollection_t, SteamUGCQueryCompleted_t> m_QueryCompletedCall;
+#endif
 	void QueryCompletedCall( SteamUGCQueryCompleted_t *pResult, bool bIOFailure )
 	{
 		delete this;
@@ -274,36 +327,64 @@ public:
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		ISteamUGC *pWorkshop = SteamGameServerUGC();
+#else
+		ISteamUGC *pWorkshop = SteamGameServerUGC();
+#endif
 		Assert( pWorkshop );
 
 		if ( pResult->m_eResult != k_EResultOK )
 		{
 			Warning( "Workshop collection query failed: EResult %d (%s)\n", pResult->m_eResult, UTIL_RD_EResultToString( pResult->m_eResult ) );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pWorkshop->ReleaseQueryUGCRequest( pResult->m_handle );
+#else
+			pWorkshop->ReleaseQueryUGCRequest( pResult->m_handle );
+#endif
 			return;
 		}
 
 		if ( !pResult->m_unNumResultsReturned )
 		{
 			Warning( "Workshop collection query failed. (no results)\n" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pWorkshop->ReleaseQueryUGCRequest( pResult->m_handle );
+#else
+			pWorkshop->ReleaseQueryUGCRequest( pResult->m_handle );
+#endif
 			return;
 		}
 
 		SteamUGCDetails_t details;
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pWorkshop->GetQueryUGCResult( pResult->m_handle, 0, &details ) )
+		#else
+		if ( !pWorkshop->GetQueryUGCResult( pResult->m_handle, 0, &details ) )
+		#endif
 		{
 			Warning( "Workshop collection query failed. (failed to get result)\n" );
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pWorkshop->ReleaseQueryUGCRequest( pResult->m_handle );
+			#else
+			pWorkshop->ReleaseQueryUGCRequest( pResult->m_handle );
+			#endif
 			return;
 		}
 
 		PublishedFileId_t *children = ( PublishedFileId_t * )stackalloc( sizeof( PublishedFileId_t ) * details.m_unNumChildren );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pWorkshop->GetQueryUGCChildren( pResult->m_handle, 0, children, details.m_unNumChildren ) )
+#else
+		if ( !pWorkshop->GetQueryUGCChildren( pResult->m_handle, 0, children, details.m_unNumChildren ) )
+#endif
 		{
 			Warning( "Workshop collection query failed. (failed to get children)\n" );
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pWorkshop->ReleaseQueryUGCRequest( pResult->m_handle );
+			#else
+			pWorkshop->ReleaseQueryUGCRequest( pResult->m_handle );
+			#endif
 			return;
 		}
 
@@ -313,18 +394,33 @@ public:
 			g_ReactiveDropWorkshop.EnableServerWorkshopItem( children[i] );
 		}
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pWorkshop->ReleaseQueryUGCRequest( pResult->m_handle );
+		#else
+		pWorkshop->ReleaseQueryUGCRequest( pResult->m_handle );
+		#endif
 	}
 };
 
 bool CReactiveDropWorkshop::DedicatedServerWorkshopSetup()
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamGameServer() || !SteamGameServer()->BLoggedOn() )
 	{
 		return false;
 	}
+#else
+	if ( !SteamGameServer() || !SteamGameServer()->BLoggedOn() )
+	{
+		return false;
+	}
+#endif
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pWorkshop = SteamGameServerUGC();
+#else
+	ISteamUGC *pWorkshop = SteamGameServerUGC();
+#endif
 	if ( !pWorkshop )
 	{
 		Warning( "No Steam connection. Skipping workshop.\n" );
@@ -338,7 +434,11 @@ bool CReactiveDropWorkshop::DedicatedServerWorkshopSetup()
 		char szWorkshopDir[MAX_PATH];
 		V_ComposeFileName( szDir, "workshop", szWorkshopDir, sizeof( szWorkshopDir ) );
 
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bool bInit = pWorkshop->BInitWorkshopForGameServer( 563560, szWorkshopDir );
+		#else
+		bool bInit = pWorkshop->BInitWorkshopForGameServer( 563560, szWorkshopDir );
+		#endif
 		if ( !bInit )
 		{
 			DevWarning( "Workshop init failed! Trying to continue anyway...\n" );
@@ -468,10 +568,18 @@ void CReactiveDropWorkshop::RestartEnabledAddonsQuery()
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pUGC = SteamUGC();
+#else
+	ISteamUGC *pUGC = SteamUGC();
+#endif
 #ifdef GAME_DLL
 	if ( !pUGC )
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC = SteamGameServerUGC();
+#else
+		pUGC = SteamGameServerUGC();
+#endif
 #endif
 	if ( !pUGC )
 	{
@@ -486,7 +594,11 @@ void CReactiveDropWorkshop::RestartEnabledAddonsQuery()
 			DevMsg( "Clearing previous Workshop metadata request\n" );
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->ReleaseQueryUGCRequest( m_hEnabledAddonsQuery );
+#else
+		pUGC->ReleaseQueryUGCRequest( m_hEnabledAddonsQuery );
+#endif
 	}
 
 	if ( rd_workshop_debug.GetBool() )
@@ -494,11 +606,27 @@ void CReactiveDropWorkshop::RestartEnabledAddonsQuery()
 		DevMsg( "Sending Workshop metadata request\n" );
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	UGCQueryHandle_t hQuery = pUGC->CreateQueryUGCDetailsRequest( m_EnabledAddonsForQuery.Base(), m_EnabledAddonsForQuery.Count() );
+#else
+	UGCQueryHandle_t hQuery = pUGC->CreateQueryUGCDetailsRequest( m_EnabledAddonsForQuery.Base(), m_EnabledAddonsForQuery.Count() );
+#endif
 	m_hEnabledAddonsQuery = hQuery;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->SetReturnLongDescription( hQuery, true );
+#else
+	pUGC->SetReturnLongDescription( hQuery, true );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->SetReturnKeyValueTags( hQuery, true );
+#else
+	pUGC->SetReturnKeyValueTags( hQuery, true );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = pUGC->SendQueryUGCRequest( hQuery );
+#else
+	SteamAPICall_t hAPICall = pUGC->SendQueryUGCRequest( hQuery );
+#endif
 	m_SteamUGCQueryCompleted.Set( hAPICall, this, &CReactiveDropWorkshop::SteamUGCQueryCompletedCallback );
 }
 
@@ -514,23 +642,55 @@ void CReactiveDropWorkshop::RequestNextPublishedAddonsPage()
 
 	if ( m_hPublishedAddonsQuery != k_UGCQueryHandleInvalid )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->ReleaseQueryUGCRequest( m_hPublishedAddonsQuery );
+		#else
+		pUGC->ReleaseQueryUGCRequest( m_hPublishedAddonsQuery );
+		#endif
 	}
 
 	m_iPublishedAddonsPage++;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	AccountID_t iAccount = SteamUser()->GetSteamID().GetAccountID();
+#else
+	AccountID_t iAccount = SteamUser()->GetSteamID().GetAccountID();
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	AppId_t iApp = SteamUtils()->GetAppID();
+#else
+	AppId_t iApp = SteamUtils()->GetAppID();
+#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_hPublishedAddonsQuery = pUGC->CreateQueryUserUGCRequest( iAccount, k_EUserUGCList_Published, k_EUGCMatchingUGCType_Items_ReadyToUse, k_EUserUGCListSortOrder_CreationOrderAsc, iApp, iApp, m_iPublishedAddonsPage );
+	#else
+	m_hPublishedAddonsQuery = pUGC->CreateQueryUserUGCRequest( iAccount, k_EUserUGCList_Published, k_EUGCMatchingUGCType_Items_ReadyToUse, k_EUserUGCListSortOrder_CreationOrderAsc, iApp, iApp, m_iPublishedAddonsPage );
+	#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->SetReturnLongDescription( m_hPublishedAddonsQuery, true );
+	#else
+	pUGC->SetReturnLongDescription( m_hPublishedAddonsQuery, true );
+	#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->SetReturnKeyValueTags( m_hPublishedAddonsQuery, true );
+	#else
+	pUGC->SetReturnKeyValueTags( m_hPublishedAddonsQuery, true );
+	#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = pUGC->SendQueryUGCRequest( m_hPublishedAddonsQuery );
+#else
+	SteamAPICall_t hAPICall = pUGC->SendQueryUGCRequest( m_hPublishedAddonsQuery );
+#endif
 	m_SteamPublishedAddonsRequestCompleted.Set( hAPICall, this, &CReactiveDropWorkshop::SteamPublishedAddonsRequestCompleted );
 }
 #endif
 
 void CReactiveDropWorkshop::OnSubscribed( RemoteStoragePublishedFileSubscribed_t *pSubscribed )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( pSubscribed->m_nAppID != SteamUtils()->GetAppID() )
+#else
+	if ( pSubscribed->m_nAppID != SteamUtils()->GetAppID() )
+#endif
 	{
 		return;
 	}
@@ -550,7 +710,11 @@ void CReactiveDropWorkshop::OnSubscribed( RemoteStoragePublishedFileSubscribed_t
 
 void CReactiveDropWorkshop::OnUnsubscribed( RemoteStoragePublishedFileUnsubscribed_t *pUnsubscribed )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( pUnsubscribed->m_nAppID != SteamUtils()->GetAppID() )
+#else
+	if ( pUnsubscribed->m_nAppID != SteamUtils()->GetAppID() )
+#endif
 	{
 		return;
 	}
@@ -575,7 +739,11 @@ void CReactiveDropWorkshop::OnUnsubscribed( RemoteStoragePublishedFileUnsubscrib
 void CReactiveDropWorkshop::OnMissionStart()
 {
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC() )
+#else
+	if ( !SteamUGC() )
+#endif
 	{
 		return;
 	}
@@ -588,7 +756,11 @@ void CReactiveDropWorkshop::OnMissionStart()
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUGC()->StartPlaytimeTracking( active.Base(), active.Count() );
+#else
+	SteamUGC()->StartPlaytimeTracking( active.Base(), active.Count() );
+#endif
 #endif
 }
 
@@ -605,12 +777,20 @@ void CReactiveDropWorkshop::LevelInitPostEntity()
 void CReactiveDropWorkshop::LevelShutdownPreEntity()
 {
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC() )
+#else
+	if ( !SteamUGC() )
+#endif
 	{
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamUGC()->StopPlaytimeTrackingForAllItems();
+#else
+	SteamUGC()->StopPlaytimeTrackingForAllItems();
+#endif
 
 	ClearOldPreviewRequests();
 
@@ -653,7 +833,11 @@ void CReactiveDropWorkshop::SetupThink()
 		g_ReactiveDropWorkshop.RestartEnabledAddonsQuery();
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !m_bWorkshopSetupCompleted || !SteamGameServerUGC() || Plat_FloatTime() < s_flNextDownloadStatusMessage )
+#else
+	if ( !m_bWorkshopSetupCompleted || !SteamGameServerUGC() || Plat_FloatTime() < s_flNextDownloadStatusMessage )
+#endif
 	{
 		return;
 	}
@@ -665,11 +849,19 @@ void CReactiveDropWorkshop::SetupThink()
 	FOR_EACH_VEC( m_ServerWorkshopAddons, i )
 	{
 		PublishedFileId_t id = m_ServerWorkshopAddons[i];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		uint32 iItemState = SteamGameServerUGC()->GetItemState( id );
+#else
+		uint32 iItemState = SteamGameServerUGC()->GetItemState( id );
+#endif
 		if ( iItemState & k_EItemStateDownloading )
 		{
 			uint64 nBytesDownloaded, nBytesTotal;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( SteamGameServerUGC()->GetItemDownloadInfo( id, &nBytesDownloaded, &nBytesTotal ) )
+#else
+			if ( SteamGameServerUGC()->GetItemDownloadInfo( id, &nBytesDownloaded, &nBytesTotal ) )
+#endif
 			{
 				Msg( "Downloading workshop item %llu: %llu / %llu bytes\n", id, nBytesDownloaded, nBytesTotal );
 			}
@@ -687,7 +879,11 @@ void CReactiveDropWorkshop::SetupThink()
 		else if ( iItemState & k_EItemStateNeedsUpdate )
 		{
 			Msg( "Workshop item %llu needs update\n", id );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			SteamGameServerUGC()->DownloadItem( id, false );
+#else
+			SteamGameServerUGC()->DownloadItem( id, false );
+#endif
 			bWaitingForAny = true;
 		}
 		else if ( !( iItemState & k_EItemStateInstalled ) )
@@ -717,7 +913,11 @@ void WorkshopSetupThink()
 #ifdef CLIENT_DLL
 void CReactiveDropWorkshop::ScreenshotReadyCallback( ScreenshotReady_t *pReady )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamScreenshots *pScreenshots = SteamScreenshots();
+#else
+	ISteamScreenshots *pScreenshots = SteamScreenshots();
+#endif
 	Assert( pScreenshots );
 	if ( !engine->IsInGame() || !ASWGameRules() || !pScreenshots )
 	{
@@ -777,7 +977,11 @@ void CReactiveDropWorkshop::ScreenshotReadyCallback( ScreenshotReady_t *pReady )
 		V_snprintf( szName, sizeof( szName ), "%s%s (%s)", szCampaign, szMission, szChallenge );
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pScreenshots->SetLocation( pReady->m_hLocal, szName );
+	#else
+	pScreenshots->SetLocation( pReady->m_hLocal, szName );
+	#endif
 
 	if ( ASWGameRules() && ASWGameRules()->GetGameState() == ASW_GS_INGAME && ASWGameResource() )
 	{
@@ -787,7 +991,11 @@ void CReactiveDropWorkshop::ScreenshotReadyCallback( ScreenshotReady_t *pReady )
 			C_ASW_Marine_Resource *pMR = ASWGameResource()->GetMarineResource( ASWGameRules()->m_nMarineForDeathCam );
 			if ( pMR && pMR->IsInhabited() && pMR->GetCommander() )
 			{
+				#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				pScreenshots->TagUser( pReady->m_hLocal, pMR->GetCommander()->GetSteamID() );
+				#else
+				pScreenshots->TagUser( pReady->m_hLocal, pMR->GetCommander()->GetSteamID() );
+				#endif
 			}
 		}
 
@@ -800,7 +1008,11 @@ void CReactiveDropWorkshop::ScreenshotReadyCallback( ScreenshotReady_t *pReady )
 				Vector screenPos;
 				if ( !debugoverlay->ScreenPosition( pMR->GetMarineEntity()->WorldSpaceCenter(), screenPos ) )
 				{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 					pScreenshots->TagUser( pReady->m_hLocal, pMR->GetCommander()->GetSteamID() );
+#else
+					pScreenshots->TagUser( pReady->m_hLocal, pMR->GetCommander()->GetSteamID() );
+#endif
 				}
 			}
 		}
@@ -810,7 +1022,11 @@ void CReactiveDropWorkshop::ScreenshotReadyCallback( ScreenshotReady_t *pReady )
 	GetActiveAddons( active );
 	FOR_EACH_VEC( active, i )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pScreenshots->TagPublishedFile( pReady->m_hLocal, active[i] );
+		#else
+		pScreenshots->TagPublishedFile( pReady->m_hLocal, active[i] );
+		#endif
 	}
 }
 #endif
@@ -837,18 +1053,30 @@ bool CReactiveDropWorkshop::IsSubscribedToFile( PublishedFileId_t nPublishedFile
 		return false;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	return ( SteamUGC()->GetItemState( nPublishedFileId ) & k_EItemStateSubscribed ) != 0;
+#else
+	return ( SteamUGC()->GetItemState( nPublishedFileId ) & k_EItemStateSubscribed ) != 0;
+#endif
 }
 
 void CReactiveDropWorkshop::SetSubscribedToFile( PublishedFileId_t nPublishedFileId, bool bSubscribe )
 {
 	if ( bSubscribe )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUGC()->SubscribeItem( nPublishedFileId );
+#else
+		SteamUGC()->SubscribeItem( nPublishedFileId );
+#endif
 	}
 	else
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamUGC()->UnsubscribeItem( nPublishedFileId );
+#else
+		SteamUGC()->UnsubscribeItem( nPublishedFileId );
+#endif
 	}
 }
 
@@ -1226,9 +1454,17 @@ const wchar_t *CReactiveDropWorkshop::AddonName( PublishedFileId_t nPublishedFil
 
 void CReactiveDropWorkshop::DownloadItemResultCallback( DownloadItemResult_t *pResult )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( pResult->m_unAppID != SteamUtils()->GetAppID() )
+#else
+	if ( pResult->m_unAppID != SteamUtils()->GetAppID() )
+#endif
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		DevMsg( "DownloadItemResult_t for %llu has AppID %u, but we are %u!\n", pResult->m_nPublishedFileId, pResult->m_unAppID, SteamUtils()->GetAppID() );
+#else
+		DevMsg( "DownloadItemResult_t for %llu has AppID %u, but we are %u!\n", pResult->m_nPublishedFileId, pResult->m_unAppID, SteamUtils()->GetAppID() );
+#endif
 		return;
 	}
 
@@ -1280,10 +1516,18 @@ void CReactiveDropWorkshop::AddAddonsToCache( SteamUGCQueryCompleted_t *pResult,
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pUGC = SteamUGC();
+#else
+	ISteamUGC *pUGC = SteamUGC();
+#endif
 #ifdef GAME_DLL
 	if ( !pUGC )
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC = SteamGameServerUGC();
+#else
+		pUGC = SteamGameServerUGC();
+#endif
 #endif
 	if ( !pUGC )
 	{
@@ -1300,7 +1544,11 @@ void CReactiveDropWorkshop::AddAddonsToCache( SteamUGCQueryCompleted_t *pResult,
 
 	for ( uint32 i = 0; i < pResult->m_unNumResultsReturned; i++ )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		bool bOK = pUGC->GetQueryUGCResult( hQuery, i, &m_EnabledAddons[nextIndex].details );
+#else
+		bool bOK = pUGC->GetQueryUGCResult( hQuery, i, &m_EnabledAddons[nextIndex].details );
+#endif
 		if ( !bOK )
 		{
 			m_EnabledAddons.Remove( m_EnabledAddons.Count() - 1 );
@@ -1324,11 +1572,19 @@ void CReactiveDropWorkshop::AddAddonsToCache( SteamUGCQueryCompleted_t *pResult,
 		{
 			nextIndex++;
 		}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		uint32 nTags = pUGC->GetQueryUGCNumTags( hQuery, i );
+#else
+		uint32 nTags = pUGC->GetQueryUGCNumTags( hQuery, i );
+#endif
 		for ( uint32 j = 0; j < nTags; j++ )
 		{
 			char szTag[1024];
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( pUGC->GetQueryUGCTag( hQuery, i, j, szTag, sizeof( szTag ) ) )
+			#else
+			if ( pUGC->GetQueryUGCTag( hQuery, i, j, szTag, sizeof( szTag ) ) )
+			#endif
 			{
 				if ( FStrEq( szTag, "adminoverride_Bonus" ) )
 				{
@@ -1340,29 +1596,81 @@ void CReactiveDropWorkshop::AddAddonsToCache( SteamUGCQueryCompleted_t *pResult,
 				}
 			}
 		}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumSubscriptions, &m_EnabledAddons[index].nSubscriptions );
+#else
+		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumSubscriptions, &m_EnabledAddons[index].nSubscriptions );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumFavorites, &m_EnabledAddons[index].nFavorites );
+#else
+		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumFavorites, &m_EnabledAddons[index].nFavorites );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumFollowers, &m_EnabledAddons[index].nFollowers );
+#else
+		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumFollowers, &m_EnabledAddons[index].nFollowers );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumUniqueSubscriptions, &m_EnabledAddons[index].nUniqueSubscriptions );
+#else
+		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumUniqueSubscriptions, &m_EnabledAddons[index].nUniqueSubscriptions );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumUniqueFavorites, &m_EnabledAddons[index].nUniqueFavorites );
+#else
+		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumUniqueFavorites, &m_EnabledAddons[index].nUniqueFavorites );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumUniqueFollowers, &m_EnabledAddons[index].nUniqueFollowers );
+#else
+		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumUniqueFollowers, &m_EnabledAddons[index].nUniqueFollowers );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumUniqueWebsiteViews, &m_EnabledAddons[index].nUniqueWebsiteViews );
+#else
+		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumUniqueWebsiteViews, &m_EnabledAddons[index].nUniqueWebsiteViews );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumSecondsPlayed, &m_EnabledAddons[index].nSecondsPlayed );
+#else
+		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumSecondsPlayed, &m_EnabledAddons[index].nSecondsPlayed );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumPlaytimeSessions, &m_EnabledAddons[index].nPlaytimeSessions );
+#else
+		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumPlaytimeSessions, &m_EnabledAddons[index].nPlaytimeSessions );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumComments, &m_EnabledAddons[index].nComments );
+#else
+		pUGC->GetQueryUGCStatistic( hQuery, i, k_EItemStatistic_NumComments, &m_EnabledAddons[index].nComments );
+#endif
 		m_EnabledAddons[index].kvTags.Purge();
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		uint32 nKeyValueTags = pUGC->GetQueryUGCNumKeyValueTags( hQuery, i );
+#else
+		uint32 nKeyValueTags = pUGC->GetQueryUGCNumKeyValueTags( hQuery, i );
+#endif
 		for ( uint32 j = 0; j < nKeyValueTags; j++ )
 		{
 			char szKey[1024];
 			char szValue[1024];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( pUGC->GetQueryUGCKeyValueTag( hQuery, i, j, szKey, sizeof( szKey ), szValue, sizeof( szValue ) ) )
+#else
+			if ( pUGC->GetQueryUGCKeyValueTag( hQuery, i, j, szKey, sizeof( szKey ), szValue, sizeof( szValue ) ) )
+#endif
 			{
 				m_EnabledAddons[index].kvTags[szKey].CopyAndAddToTail( szValue );
 			}
 		}
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamFriends()->RequestUserInformation( CSteamID( m_EnabledAddons[index].details.m_ulSteamIDOwner ), true );
+#else
+		SteamFriends()->RequestUserInformation( CSteamID( m_EnabledAddons[index].details.m_ulSteamIDOwner ), true );
+#endif
 		if ( bExists )
 		{
 			FOR_EACH_VEC( m_PreviewRequests, j )
@@ -1382,7 +1690,11 @@ void CReactiveDropWorkshop::AddAddonsToCache( SteamUGCQueryCompleted_t *pResult,
 #endif
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->ReleaseQueryUGCRequest( hQuery );
+#else
+	pUGC->ReleaseQueryUGCRequest( hQuery );
+#endif
 	hQuery = k_UGCQueryHandleInvalid;
 
 #ifdef CLIENT_DLL
@@ -1435,7 +1747,11 @@ CReactiveDropWorkshop::WorkshopPreviewRequest_t::WorkshopPreviewRequest_t( const
 	m_bCancelled = false;
 	m_nFileID = details.m_nPublishedFileId;
 	m_nPreviewImage = details.m_hPreviewFile;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = SteamRemoteStorage()->UGCDownload( details.m_hPreviewFile, WORKSHOP_PREVIEW_IMAGE_PRIORITY );
+#else
+	SteamAPICall_t hAPICall = SteamRemoteStorage()->UGCDownload( details.m_hPreviewFile, WORKSHOP_PREVIEW_IMAGE_PRIORITY );
+#endif
 	m_hCall.Set( hAPICall, this, &CReactiveDropWorkshop::WorkshopPreviewRequest_t::Callback );
 }
 
@@ -1468,7 +1784,11 @@ void CReactiveDropWorkshop::WorkshopPreviewRequest_t::Callback( RemoteStorageDow
 			}
 
 			CUtlBuffer buf;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			int nRead = SteamRemoteStorage()->UGCRead( m_nPreviewImage, buf.AccessForDirectRead( pResult->m_nSizeInBytes ), pResult->m_nSizeInBytes, 0, k_EUGCRead_Close );
+#else
+			int nRead = SteamRemoteStorage()->UGCRead( m_nPreviewImage, buf.AccessForDirectRead( pResult->m_nSizeInBytes ), pResult->m_nSizeInBytes, 0, k_EUGCRead_Close );
+#endif
 			buf.SeekPut( CUtlBuffer::SEEK_HEAD, nRead );
 			g_ReactiveDropWorkshop.m_EnabledAddons[i].pPreviewImage = new CReactiveDropWorkshopPreviewImage( buf );
 			if ( g_ReactiveDropWorkshop.m_EnabledAddons[i].pPreviewImage->GetID() == -1 )
@@ -1500,7 +1820,11 @@ void CReactiveDropWorkshop::WorkshopPreviewRequest_t::Callback( RemoteStorageDow
 	}
 
 	Warning( "Completed preview request for addon %llu (preview file %llu, size %d bytes), but there is no addon metadata that matches! Discarding.\n", m_nFileID, m_nPreviewImage, pResult->m_nSizeInBytes );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamRemoteStorage()->UGCRead( pResult->m_hFile, NULL, 0, 0, k_EUGCRead_Close );
+#else
+	SteamRemoteStorage()->UGCRead( pResult->m_hFile, NULL, 0, 0, k_EUGCRead_Close );
+#endif
 }
 #endif
 
@@ -1968,7 +2292,11 @@ void CReactiveDropWorkshop::DoClearCaches()
 	missionchooser->LocalMissionSource()->ClearCache();
 
 #ifdef GAME_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pUGC = SteamGameServerUGC();
+#else
+	ISteamUGC *pUGC = SteamGameServerUGC();
+#endif
 	Assert( pUGC );
 	extern CServerGameDLL g_ServerGameDLL;
 	if ( engine->IsDedicatedServer() && g_ServerGameDLL.m_bIsHibernating && pUGC )
@@ -1976,7 +2304,11 @@ void CReactiveDropWorkshop::DoClearCaches()
 		bool bCanReload = true;
 		FOR_EACH_VEC( m_ServerWorkshopAddons, i )
 		{
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			uint32 iItemState = pUGC->GetItemState( m_ServerWorkshopAddons[i] );
+			#else
+			uint32 iItemState = pUGC->GetItemState( m_ServerWorkshopAddons[i] );
+			#endif
 			if ( iItemState & k_EItemStateDownloadPending )
 			{
 				Msg( "Not restarting server: waiting for download of addon %llu\n", m_ServerWorkshopAddons[i] );
@@ -2027,11 +2359,19 @@ static bool ShouldUnconditionalDownload( PublishedFileId_t id )
 
 bool CReactiveDropWorkshop::UpdateAndLoadAddon( PublishedFileId_t id, bool bHighPriority, bool bUnload )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pWorkshop = SteamUGC();
+#else
+	ISteamUGC *pWorkshop = SteamUGC();
+#endif
 #ifdef GAME_DLL
 	if ( engine->IsDedicatedServer() )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pWorkshop = SteamGameServerUGC();
+#else
+		pWorkshop = SteamGameServerUGC();
+#endif
 	}
 #endif
 	if ( !pWorkshop )
@@ -2043,7 +2383,11 @@ bool CReactiveDropWorkshop::UpdateAndLoadAddon( PublishedFileId_t id, bool bHigh
 	// make sure we know the metadata (for admin override tags, mostly)
 	g_ReactiveDropWorkshop.TryQueryAddon( id );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	uint32 iState = pWorkshop->GetItemState( id );
+#else
+	uint32 iState = pWorkshop->GetItemState( id );
+#endif
 	if ( !ShouldUnconditionalDownload( id ) && ( iState & k_EItemStateInstalled ) && !( iState & k_EItemStateNeedsUpdate ) )
 	{
 		if ( rd_workshop_debug.GetBool() )
@@ -2053,7 +2397,11 @@ bool CReactiveDropWorkshop::UpdateAndLoadAddon( PublishedFileId_t id, bool bHigh
 			uint64 sizeOnDisk;
 			char szFolder[MAX_PATH];
 			uint32 timeStamp;
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( pWorkshop->GetItemInstallInfo( id, &sizeOnDisk, szFolder, sizeof( szFolder ), &timeStamp ) )
+			#else
+			if ( pWorkshop->GetItemInstallInfo( id, &sizeOnDisk, szFolder, sizeof( szFolder ), &timeStamp ) )
+			#endif
 			{
 				Msg( "  size: %llu bytes; timestamp: %u; folder: %s\n", sizeOnDisk, timeStamp, szFolder );
 			}
@@ -2064,7 +2412,11 @@ bool CReactiveDropWorkshop::UpdateAndLoadAddon( PublishedFileId_t id, bool bHigh
 	{
 		UnloadAddon( id );
 	}
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( pWorkshop->DownloadItem( id, bHighPriority ) )
+	#else
+	if ( pWorkshop->DownloadItem( id, bHighPriority ) )
+	#endif
 	{
 		Msg( "Downloading addon %llu as it is %s.\n", id, ( iState & k_EItemStateInstalled ) ? ( iState & k_EItemStateNeedsUpdate ) ? "out of date" : "(reportedly) up-to-date" : "not installed" );
 	}
@@ -2127,11 +2479,19 @@ void CReactiveDropWorkshop::RealLoadAddon( PublishedFileId_t id )
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pWorkshop = SteamUGC();
+#else
+	ISteamUGC *pWorkshop = SteamUGC();
+#endif
 #ifdef GAME_DLL
 	if ( engine->IsDedicatedServer() )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pWorkshop = SteamGameServerUGC();
+#else
+		pWorkshop = SteamGameServerUGC();
+#endif
 	}
 #endif
 	if ( !pWorkshop )
@@ -2143,13 +2503,21 @@ void CReactiveDropWorkshop::RealLoadAddon( PublishedFileId_t id )
 	char szFolderName[MAX_PATH];
 	uint64 nSizeOnDisk;
 	uint32 nTimeStamp;
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !pWorkshop->GetItemInstallInfo( id, &nSizeOnDisk, szFolderName, sizeof( szFolderName ), &nTimeStamp ) )
+	#else
+	if ( !pWorkshop->GetItemInstallInfo( id, &nSizeOnDisk, szFolderName, sizeof( szFolderName ), &nTimeStamp ) )
+	#endif
 	{
 		Warning( "Could not get install location for UGC item %llu\n", id );
 		return;
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( pWorkshop->GetItemState( id ) & k_EItemStateLegacyItem )
+	#else
+	if ( pWorkshop->GetItemState( id ) & k_EItemStateLegacyItem )
+	#endif
 	{
 		if ( char cGuideType = IsIntegratedGuide( szFolderName ) )
 		{
@@ -2178,14 +2546,35 @@ void CReactiveDropWorkshop::RealLoadAddon( PublishedFileId_t id )
 #ifdef GAME_DLL
 		if ( engine->IsDedicatedServer() )
 		{
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			UGCQueryHandle_t hQuery = pWorkshop->CreateQueryUGCDetailsRequest( &id, 1 );
+			#else
+			UGCQueryHandle_t hQuery = pWorkshop->CreateQueryUGCDetailsRequest( &id, 1 );
+			#endif
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pWorkshop->SetReturnOnlyIDs( hQuery, true );
+			#else
+			pWorkshop->SetReturnOnlyIDs( hQuery, true );
+			#endif
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			pWorkshop->SetReturnChildren( hQuery, true );
+			#else
+			pWorkshop->SetReturnChildren( hQuery, true );
+			#endif
 
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( rd_workshop_query_cache.GetInt() > 0 )
 				pWorkshop->SetAllowCachedResponse( hQuery, rd_workshop_query_cache.GetInt());
+			#else
+			if ( rd_workshop_query_cache.GetInt() > 0 )
+				pWorkshop->SetAllowCachedResponse( hQuery, rd_workshop_query_cache.GetInt());
+			#endif
 
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			new LoadWorkshopCollection_t( pWorkshop->SendQueryUGCRequest( hQuery ) );
+			#else
+			new LoadWorkshopCollection_t( pWorkshop->SendQueryUGCRequest( hQuery ) );
+			#endif
 		}
 		else
 #endif
@@ -2666,7 +3055,11 @@ bool CReactiveDropWorkshop::PrepareWorkshopVPK( PublishedFileId_t nFileID, const
 		return false;
 	}
 	char szPath[MAX_PATH];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	V_ComposeFileName( szModDir, VarArgs( "steam_ugc_temp_%llu", SteamUser()->GetSteamID().ConvertToUint64() ), szPath, sizeof( szPath ) );
+#else
+	V_ComposeFileName( szModDir, VarArgs( "steam_ugc_temp_%llu", SteamUser()->GetSteamID().ConvertToUint64() ), szPath, sizeof( szPath ) );
+#endif
 	if ( filesystem->FileExists( szPath ) )
 	{
 		filesystem->RemoveFile( CUtlString::PathJoin( szPath, "addon.vpk" ) );
@@ -2737,7 +3130,11 @@ void CReactiveDropWorkshop::UploadWorkshopItem( const char *pszContentPath, cons
 	}
 	RemoveDuplicateTags();
 	Msg( "Sent request to Steam Workshop server...\n" );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = SteamUGC()->CreateItem( SteamUtils()->GetAppID(), k_EWorkshopFileTypeCommunity );
+#else
+	SteamAPICall_t hAPICall = SteamUGC()->CreateItem( SteamUtils()->GetAppID(), k_EWorkshopFileTypeCommunity );
+#endif
 	m_CreateItemResultCallback.Set( hAPICall, this, &CReactiveDropWorkshop::CreateItemResultCallback );
 }
 
@@ -2759,24 +3156,64 @@ void CReactiveDropWorkshop::RemoveDuplicateTags()
 
 void CReactiveDropWorkshop::SetWorkshopKeyValues( UGCUpdateHandle_t hUpdate )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pUGC = SteamUGC();
+#else
+	ISteamUGC *pUGC = SteamUGC();
+#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->RemoveItemKeyValueTags( hUpdate, "campaigns" );
+	#else
+	pUGC->RemoveItemKeyValueTags( hUpdate, "campaigns" );
+	#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->RemoveItemKeyValueTags( hUpdate, "missions" );
+#else
+	pUGC->RemoveItemKeyValueTags( hUpdate, "missions" );
+#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->RemoveItemKeyValueTags( hUpdate, "challenges" );
+	#else
+	pUGC->RemoveItemKeyValueTags( hUpdate, "challenges" );
+	#endif
 
 	for ( int i = 0; i < NELEMS( s_RDWorkshopMissionTags ); i++ )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		pUGC->RemoveItemKeyValueTags( hUpdate, s_RDWorkshopMissionTags[i] );
+		#else
+		pUGC->RemoveItemKeyValueTags( hUpdate, s_RDWorkshopMissionTags[i] );
+		#endif
 	}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->RemoveItemKeyValueTags( hUpdate, "campaign_name" );
+	#else
+	pUGC->RemoveItemKeyValueTags( hUpdate, "campaign_name" );
+	#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->RemoveItemKeyValueTags( hUpdate, "campaign_mission" );
+	#else
+	pUGC->RemoveItemKeyValueTags( hUpdate, "campaign_mission" );
+	#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->RemoveItemKeyValueTags( hUpdate, "mission_name" );
+	#else
+	pUGC->RemoveItemKeyValueTags( hUpdate, "mission_name" );
+	#endif
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	pUGC->RemoveItemKeyValueTags( hUpdate, "challenge_name" );
+	#else
+	pUGC->RemoveItemKeyValueTags( hUpdate, "challenge_name" );
+	#endif
 
 	FOR_EACH_VEC( m_aszIncludedCampaigns, i )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pUGC->AddItemKeyValueTag( hUpdate, "campaigns", m_aszIncludedCampaigns[i] ) )
+#else
+		if ( !pUGC->AddItemKeyValueTag( hUpdate, "campaigns", m_aszIncludedCampaigns[i] ) )
+#endif
 		{
 			Warning( "Adding campaign %s failed!\n", m_aszIncludedCampaigns[i] );
 		}
@@ -2784,7 +3221,11 @@ void CReactiveDropWorkshop::SetWorkshopKeyValues( UGCUpdateHandle_t hUpdate )
 
 	FOR_EACH_VEC( m_aszIncludedMissions, i )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pUGC->AddItemKeyValueTag( hUpdate, "missions", m_aszIncludedMissions[i] ) )
+		#else
+		if ( !pUGC->AddItemKeyValueTag( hUpdate, "missions", m_aszIncludedMissions[i] ) )
+		#endif
 		{
 			Warning( "Adding mission %s failed!\n", m_aszIncludedMissions[i] );
 		}
@@ -2792,7 +3233,11 @@ void CReactiveDropWorkshop::SetWorkshopKeyValues( UGCUpdateHandle_t hUpdate )
 
 	FOR_EACH_VEC( m_aszIncludedChallenges, i )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pUGC->AddItemKeyValueTag( hUpdate, "challenges", m_aszIncludedChallenges[i] ) )
+		#else
+		if ( !pUGC->AddItemKeyValueTag( hUpdate, "challenges", m_aszIncludedChallenges[i] ) )
+		#endif
 		{
 			Warning( "Adding challenge %s failed!\n", m_aszIncludedChallenges[i] );
 		}
@@ -2803,7 +3248,11 @@ void CReactiveDropWorkshop::SetWorkshopKeyValues( UGCUpdateHandle_t hUpdate )
 	{
 		FOR_EACH_VEC( m_aszIncludedTaggedCampaigns[i], j )
 		{
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( !pUGC->AddItemKeyValueTag( hUpdate, g_RDWorkshopCampaignTags[i], m_aszIncludedTaggedCampaigns[i][j] ) )
+			#else
+			if ( !pUGC->AddItemKeyValueTag( hUpdate, g_RDWorkshopCampaignTags[i], m_aszIncludedTaggedCampaigns[i][j] ) )
+			#endif
 			{
 				Warning( "Adding %s %s failed!\n", g_RDWorkshopCampaignTags[i], m_aszIncludedTaggedCampaigns[i][j] );
 			}
@@ -2815,7 +3264,11 @@ void CReactiveDropWorkshop::SetWorkshopKeyValues( UGCUpdateHandle_t hUpdate )
 	{
 		FOR_EACH_VEC( m_aszIncludedTaggedMissions[i], j )
 		{
+			#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( !pUGC->AddItemKeyValueTag( hUpdate, s_RDWorkshopMissionTags[i], m_aszIncludedTaggedMissions[i][j] ) )
+			#else
+			if ( !pUGC->AddItemKeyValueTag( hUpdate, s_RDWorkshopMissionTags[i], m_aszIncludedTaggedMissions[i][j] ) )
+			#endif
 			{
 				Warning( "Adding %s %s failed!\n", s_RDWorkshopMissionTags[i], m_aszIncludedTaggedMissions[i][j] );
 			}
@@ -2824,7 +3277,11 @@ void CReactiveDropWorkshop::SetWorkshopKeyValues( UGCUpdateHandle_t hUpdate )
 
 	for ( int i = 0; i < m_IncludedCampaignNames.GetNumStrings(); i++ )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pUGC->AddItemKeyValueTag( hUpdate, "campaign_name", CUtlString( m_IncludedCampaignNames.String( i ) ) + "/" + m_IncludedCampaignNames[i] ) )
+#else
+		if ( !pUGC->AddItemKeyValueTag( hUpdate, "campaign_name", CUtlString( m_IncludedCampaignNames.String( i ) ) + "/" + m_IncludedCampaignNames[i] ) )
+#endif
 		{
 			Warning( "Adding campaign name: %s -> %s failed!\n", m_IncludedCampaignNames.String( i ), m_IncludedCampaignNames[i].Get() );
 		}
@@ -2836,7 +3293,11 @@ void CReactiveDropWorkshop::SetWorkshopKeyValues( UGCUpdateHandle_t hUpdate )
 		FOR_EACH_VEC( m_IncludedCampaignMissions[i], j )
 		{
 			szCampaignMission.Format( "%s/%d/%s", m_IncludedCampaignMissions.String( i ), j, m_IncludedCampaignMissions[i][j] );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 			if ( !pUGC->AddItemKeyValueTag( hUpdate, "campaign_mission",  szCampaignMission ) )
+#else
+			if ( !pUGC->AddItemKeyValueTag( hUpdate, "campaign_mission",  szCampaignMission ) )
+#endif
 			{
 				Warning( "Adding campaign mission: %s -> %d -> %s failed!\n", m_IncludedCampaignMissions.String( i ), j, m_IncludedCampaignMissions[i][j] );
 			}
@@ -2845,7 +3306,11 @@ void CReactiveDropWorkshop::SetWorkshopKeyValues( UGCUpdateHandle_t hUpdate )
 
 	for ( int i = 0; i < m_IncludedMissionNames.GetNumStrings(); i++ )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pUGC->AddItemKeyValueTag( hUpdate, "mission_name", CUtlString( m_IncludedMissionNames.String( i ) ) + "/" + m_IncludedMissionNames[i] ) )
+		#else
+		if ( !pUGC->AddItemKeyValueTag( hUpdate, "mission_name", CUtlString( m_IncludedMissionNames.String( i ) ) + "/" + m_IncludedMissionNames[i] ) )
+		#endif
 		{
 			Warning( "Adding mission name: %s -> %s failed!\n", m_IncludedMissionNames.String( i ), m_IncludedMissionNames[i].Get() );
 		}
@@ -2853,7 +3318,11 @@ void CReactiveDropWorkshop::SetWorkshopKeyValues( UGCUpdateHandle_t hUpdate )
 	
 	for ( int i = 0; i < m_IncludedChallengeNames.GetNumStrings(); i++ )
 	{
+		#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !pUGC->AddItemKeyValueTag( hUpdate, "challenge_name", CUtlString( m_IncludedChallengeNames.String( i ) ) + "/" + m_IncludedChallengeNames[i] ) )
+		#else
+		if ( !pUGC->AddItemKeyValueTag( hUpdate, "challenge_name", CUtlString( m_IncludedChallengeNames.String( i ) ) + "/" + m_IncludedChallengeNames[i] ) )
+		#endif
 		{
 			Warning( "Adding challenge name: %s -> %s failed!\n", m_IncludedChallengeNames.String( i ), m_IncludedChallengeNames[i].Get() );
 		}
@@ -2862,7 +3331,11 @@ void CReactiveDropWorkshop::SetWorkshopKeyValues( UGCUpdateHandle_t hUpdate )
 
 CON_COMMAND_F( ugc_create, "Usage: ugc_create \"C:\\Path\\to\\content.vpk\" \"C:\\Path\\to\\preview\\image.jpeg\" \"Title\" \"Description\" \"Tag1\" \"Tag2\" ...\nCampaign, Challenge, and Deathmatch will automatically be added as tags if applicable.", FCVAR_NOT_CONNECTED )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC() )
+#else
+	if ( !SteamUGC() )
+#endif
 	{
 		Warning( "No Steam connection. Cannot interact with workshop.\n" );
 		return;
@@ -2896,7 +3369,11 @@ CON_COMMAND_F( ugc_create, "Usage: ugc_create \"C:\\Path\\to\\content.vpk\" \"C:
 
 CON_COMMAND_F( ugc_curated_create, "", FCVAR_HIDDEN | FCVAR_NOT_CONNECTED )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	ISteamUGC *pUGC = SteamUGC();
+#else
+	ISteamUGC *pUGC = SteamUGC();
+#endif
 	if ( !pUGC )
 	{
 		Warning( "Could not obtain SteamUGC interface!\n" );
@@ -2909,7 +3386,11 @@ CON_COMMAND_F( ugc_curated_create, "", FCVAR_HIDDEN | FCVAR_NOT_CONNECTED )
 		return;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hCall = pUGC->CreateItem( SteamUtils()->GetAppID(), k_EWorkshopFileTypeMicrotransaction );
+#else
+	SteamAPICall_t hCall = pUGC->CreateItem( SteamUtils()->GetAppID(), k_EWorkshopFileTypeMicrotransaction );
+#endif
 	g_ReactiveDropWorkshop.m_CreateItemResultCallbackCurated.Set( hCall, &g_ReactiveDropWorkshop, &CReactiveDropWorkshop::CreateItemResultCallbackCurated );
 }
 
@@ -2965,12 +3446,24 @@ void CReactiveDropWorkshop::CreateItemResultCallback( CreateItemResult_t *pResul
 
 	m_nLastPublishedFileID = pResult->m_nPublishedFileId;
 	Msg( "Workshop assigned published file ID: %llu\n", pResult->m_nPublishedFileId );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	UGCUpdateHandle_t hUpdate = SteamUGC()->StartItemUpdate( SteamUtils()->GetAppID(), pResult->m_nPublishedFileId );
+#else
+	UGCUpdateHandle_t hUpdate = SteamUGC()->StartItemUpdate( SteamUtils()->GetAppID(), pResult->m_nPublishedFileId );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC()->SetItemTitle( hUpdate, m_szTitle ) )
+#else
+	if ( !SteamUGC()->SetItemTitle( hUpdate, m_szTitle ) )
+#endif
 	{
 		Warning( "Setting title failed!\n" );
 	}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC()->SetItemDescription( hUpdate, m_szDescription ) )
+#else
+	if ( !SteamUGC()->SetItemDescription( hUpdate, m_szDescription ) )
+#endif
 	{
 		Warning( "Setting description failed!\n" );
 	}
@@ -2979,22 +3472,38 @@ void CReactiveDropWorkshop::CreateItemResultCallback( CreateItemResult_t *pResul
 		SteamParamStringArray_t tags;
 		tags.m_nNumStrings = m_aszTags.Count();
 		tags.m_ppStrings = const_cast<const char **>( m_aszTags.Base() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamUGC()->SetItemTags( hUpdate, &tags ) )
+#else
+		if ( !SteamUGC()->SetItemTags( hUpdate, &tags ) )
+#endif
 		{
 			Warning( "Setting tags failed!\n" );
 		}
 	}
 	SetWorkshopKeyValues( hUpdate );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC()->SetItemPreview( hUpdate, m_szPreviewImagePath ) )
+#else
+	if ( !SteamUGC()->SetItemPreview( hUpdate, m_szPreviewImagePath ) )
+#endif
 	{
 		Warning( "Setting preview image failed!\n" );
 	}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC()->SetItemContent( hUpdate, m_szContentPath ) )
+#else
+	if ( !SteamUGC()->SetItemContent( hUpdate, m_szContentPath ) )
+#endif
 	{
 		Warning( "Setting addon VPK failed!\n" );
 	}
 	m_hUpdate = hUpdate;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = SteamUGC()->SubmitItemUpdate( hUpdate, "" );
+#else
+	SteamAPICall_t hAPICall = SteamUGC()->SubmitItemUpdate( hUpdate, "" );
+#endif
 	m_SubmitItemUpdateResultCallback.Set( hAPICall, this, &CReactiveDropWorkshop::SubmitItemUpdateResultCallback );
 	engine->ClientCmd_Unrestricted( "_ugc_update_progress\n" );
 }
@@ -3040,11 +3549,19 @@ void CReactiveDropWorkshop::SubmitItemUpdateResultCallback( SubmitItemUpdateResu
 
 bool CReactiveDropWorkshop::OpenWorkshopPageForFile( PublishedFileId_t nPublishedFileID )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( SteamFriends() && SteamUtils() && SteamUtils()->IsOverlayEnabled() )
 	{
 		SteamFriends()->ActivateGameOverlayToWebPage( VarArgs( "https://steamcommunity.com/sharedfiles/filedetails/?id=%llu", nPublishedFileID ), k_EActivateGameOverlayToWebPageMode_Modal );
 		return true;
 	}
+#else
+	if ( SteamFriends() && SteamUtils() && SteamUtils()->IsOverlayEnabled() )
+	{
+		SteamFriends()->ActivateGameOverlayToWebPage( VarArgs( "https://steamcommunity.com/sharedfiles/filedetails/?id=%llu", nPublishedFileID ), k_EActivateGameOverlayToWebPageMode_Modal );
+		return true;
+	}
+#endif
 
 	vgui::system()->ShellExecute( "open", VarArgs( "steam://url/CommunityFilePage/%llu", nPublishedFileID ) );
 	return false;
@@ -3052,7 +3569,11 @@ bool CReactiveDropWorkshop::OpenWorkshopPageForFile( PublishedFileId_t nPublishe
 
 CON_COMMAND_F( _ugc_update_progress, "", FCVAR_HIDDEN )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC() )
+#else
+	if ( !SteamUGC() )
+#endif
 	{
 		return;
 	}
@@ -3063,7 +3584,11 @@ CON_COMMAND_F( _ugc_update_progress, "", FCVAR_HIDDEN )
 	}
 
 	uint64 nBytesProcessed, nBytesTotal;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	EItemUpdateStatus status = SteamUGC()->GetItemUpdateProgress( g_ReactiveDropWorkshop.m_hUpdate, &nBytesProcessed, &nBytesTotal );
+#else
+	EItemUpdateStatus status = SteamUGC()->GetItemUpdateProgress( g_ReactiveDropWorkshop.m_hUpdate, &nBytesProcessed, &nBytesTotal );
+#endif
 	Msg( "Uploading addon to Steam Workshop..." );
 	if ( nBytesTotal != 0 )
 	{
@@ -3102,21 +3627,41 @@ void CReactiveDropWorkshop::UpdateWorkshopItem( PublishedFileId_t nFileID, const
 	}
 
 	m_nLastPublishedFileID = nFileID;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	UGCUpdateHandle_t hUpdate = SteamUGC()->StartItemUpdate( SteamUtils()->GetAppID(), nFileID );
+#else
+	UGCUpdateHandle_t hUpdate = SteamUGC()->StartItemUpdate( SteamUtils()->GetAppID(), nFileID );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC()->SetItemContent( hUpdate, m_szContentPath ) )
+#else
+	if ( !SteamUGC()->SetItemContent( hUpdate, m_szContentPath ) )
+#endif
 	{
 		Warning( "Setting addon VPK failed!\n" );
 	}
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( *pszPreviewImagePath && !SteamUGC()->SetItemPreview( hUpdate, pszPreviewImagePath ) )
+#else
+	if ( *pszPreviewImagePath && !SteamUGC()->SetItemPreview( hUpdate, pszPreviewImagePath ) )
+#endif
 	{
 		Warning( "Setting preview image failed!\n" );
 	}
 	SetWorkshopKeyValues( hUpdate );
 	m_hUpdate = hUpdate;
 	m_szUpdateChangeDescription = pszChangeDescription;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_hUpdateWorkshopItemQuery = SteamUGC()->CreateQueryUGCDetailsRequest( &nFileID, 1 );
+#else
+	m_hUpdateWorkshopItemQuery = SteamUGC()->CreateQueryUGCDetailsRequest( &nFileID, 1 );
+#endif
 	m_bWantAutoTags = false;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = SteamUGC()->SendQueryUGCRequest( m_hUpdateWorkshopItemQuery );
+#else
+	SteamAPICall_t hAPICall = SteamUGC()->SendQueryUGCRequest( m_hUpdateWorkshopItemQuery );
+#endif
 	m_UpdateWorkshopItemQueryResultCallback.Set( hAPICall, this, &CReactiveDropWorkshop::UpdateWorkshopItemQueryResultCallback );
 }
 
@@ -3149,7 +3694,11 @@ void CReactiveDropWorkshop::UpdateWorkshopItemQueryResultCallback( SteamUGCQuery
 	}
 
 	SteamUGCDetails_t details;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC()->GetQueryUGCResult( pResult->m_handle, 0, &details ) )
+#else
+	if ( !SteamUGC()->GetQueryUGCResult( pResult->m_handle, 0, &details ) )
+#endif
 	{
 		Warning( "Failed to retrieve tags! Manually specified tags may be lost in this update.\n" );
 	}
@@ -3168,12 +3717,20 @@ void CReactiveDropWorkshop::UpdateWorkshopItemQueryResultCallback( SteamUGCQuery
 	SteamParamStringArray_t tags;
 	tags.m_nNumStrings = m_aszTags.Count();
 	tags.m_ppStrings = const_cast<const char **>( m_aszTags.Base() );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC()->SetItemTags( m_hUpdate, &tags ) )
+#else
+	if ( !SteamUGC()->SetItemTags( m_hUpdate, &tags ) )
+#endif
 	{
 		Warning( "Setting tags failed!\n" );
 	}
 	Msg( "Sending update to workshop for addon ID %llu...\n", m_nLastPublishedFileID );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = SteamUGC()->SubmitItemUpdate( m_hUpdate, m_szUpdateChangeDescription );
+#else
+	SteamAPICall_t hAPICall = SteamUGC()->SubmitItemUpdate( m_hUpdate, m_szUpdateChangeDescription );
+#endif
 	m_SubmitItemUpdateResultCallback.Set( hAPICall, this, &CReactiveDropWorkshop::SubmitItemUpdateResultCallback );
 	engine->ClientCmd_Unrestricted( "_ugc_update_progress\n" );
 	m_szUpdateChangeDescription.Purge();
@@ -3181,7 +3738,11 @@ void CReactiveDropWorkshop::UpdateWorkshopItemQueryResultCallback( SteamUGCQuery
 
 CON_COMMAND_F( ugc_update, "Usage: ugc_update 826481632 \"C:\\Path\\to\\content.vpk\" \"C:\\Path\\to\\preview.jpg\" \"Description of changes line 1\" \"Description of changes line 2\" ...\n(the number should be the number in the address of your workshop item after http://steamcommunity.com/sharedfiles/filedetails/?id=)\nIf the preview image should not be updated, use \"\" instead of a path.", FCVAR_NOT_CONNECTED )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC() )
+#else
+	if ( !SteamUGC() )
+#endif
 	{
 		Warning( "No Steam connection. Cannot interact with workshop.\n" );
 		return;
@@ -3282,18 +3843,34 @@ void CReactiveDropWorkshop::SetWorkshopItemTags( PublishedFileId_t nFileID, cons
 	RemoveDuplicateTags();
 
 	m_nLastPublishedFileID = nFileID;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	UGCUpdateHandle_t hUpdate = SteamUGC()->StartItemUpdate( SteamUtils()->GetAppID(), nFileID );
+#else
+	UGCUpdateHandle_t hUpdate = SteamUGC()->StartItemUpdate( SteamUtils()->GetAppID(), nFileID );
+#endif
 	m_hUpdate = hUpdate;
 	m_szUpdateChangeDescription = "";
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	m_hUpdateWorkshopItemQuery = SteamUGC()->CreateQueryUGCDetailsRequest( &nFileID, 1 );
+#else
+	m_hUpdateWorkshopItemQuery = SteamUGC()->CreateQueryUGCDetailsRequest( &nFileID, 1 );
+#endif
 	m_bWantAutoTags = true;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	SteamAPICall_t hAPICall = SteamUGC()->SendQueryUGCRequest( m_hUpdateWorkshopItemQuery );
+#else
+	SteamAPICall_t hAPICall = SteamUGC()->SendQueryUGCRequest( m_hUpdateWorkshopItemQuery );
+#endif
 	m_UpdateWorkshopItemQueryResultCallback.Set( hAPICall, this, &CReactiveDropWorkshop::UpdateWorkshopItemQueryResultCallback );
 }
 
 CON_COMMAND_F( ugc_updatetags, "Usage: ugc_updatetags 826481632 \"Tag1\" \"Tag2\" ...\n(the number should be the number in the address of your workshop item after http://steamcommunity.com/sharedfiles/filedetails/?id=)\nSome tags are automatically determined from the contents of your addon and cannot be added or removed using this command.", FCVAR_NOT_CONNECTED )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( !SteamUGC() )
+#else
+	if ( !SteamUGC() )
+#endif
 	{
 		Warning( "No Steam connection. Cannot interact with workshop.\n" );
 		return;
@@ -3341,18 +3918,30 @@ public:
 		m_nFile = nFile;
 		Msg( "Initializing fix for workshop display names for addon %llu\n", nFile );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUGC()->GetItemState( nFile ) & k_EItemStateDownloadPending )
+#else
+		if ( SteamUGC()->GetItemState( nFile ) & k_EItemStateDownloadPending )
+#endif
 		{
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUGC()->GetItemState( nFile ) & k_EItemStateInstalled )
+#else
+		if ( SteamUGC()->GetItemState( nFile ) & k_EItemStateInstalled )
+#endif
 		{
 			PerformFix();
 			return;
 		}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamUGC()->DownloadItem( nFile, false ) )
+#else
+		if ( !SteamUGC()->DownloadItem( nFile, false ) )
+#endif
 		{
 			Warning( "Failed to apply fix: DownloadItem returned false for %llu\n", nFile );
 			delete this;
@@ -3364,7 +3953,11 @@ public:
 		uint64 nSizeOnDisk;
 		uint32 nTimeStamp;
 		char szFolder[MAX_PATH];
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( !SteamUGC()->GetItemInstallInfo( m_nFile, &nSizeOnDisk, szFolder, sizeof( szFolder ), &nTimeStamp ) )
+#else
+		if ( !SteamUGC()->GetItemInstallInfo( m_nFile, &nSizeOnDisk, szFolder, sizeof( szFolder ), &nTimeStamp ) )
+#endif
 		{
 			Warning( "Failed to apply fix: GetItemInstallInfo returned false for %llu\n", m_nFile );
 			delete this;
@@ -3382,9 +3975,17 @@ public:
 			return;
 		}
 
+	#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		UGCUpdateHandle_t hUpdate = SteamUGC()->StartItemUpdate( SteamUtils()->GetAppID(), m_nFile );
+	#else
+		UGCUpdateHandle_t hUpdate = SteamUGC()->StartItemUpdate( SteamUtils()->GetAppID(), m_nFile );
+		#endif
 		g_ReactiveDropWorkshop.SetWorkshopKeyValues( hUpdate );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		SteamAPICall_t hCall = SteamUGC()->SubmitItemUpdate( hUpdate, "[automated update to fix display names on leaderboards]" );
+#else
+		SteamAPICall_t hCall = SteamUGC()->SubmitItemUpdate( hUpdate, "[automated update to fix display names on leaderboards]" );
+#endif
 		m_SubmitCall.Set( hCall, this, &CFixWorkshopKeyValueNames::SubmitCompleted );
 	}
 
@@ -3408,15 +4009,27 @@ public:
 		delete this;
 	}
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CFixWorkshopKeyValueNames, Steam_DownloadItemResult, DownloadItemResult_t );
+#else
+	STEAM_CALLBACK( CFixWorkshopKeyValueNames, Steam_DownloadItemResult, DownloadItemResult_t );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CFixWorkshopKeyValueNames, SubmitItemUpdateResult_t> m_SubmitCall;
+#else
+	CCallResult<CFixWorkshopKeyValueNames, SubmitItemUpdateResult_t> m_SubmitCall;
+#endif
 
 	PublishedFileId_t m_nFile;
 };
 
 void CFixWorkshopKeyValueNames::Steam_DownloadItemResult( DownloadItemResult_t *pResult )
 {
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	if ( pResult->m_unAppID != SteamUtils()->GetAppID() || pResult->m_nPublishedFileId != m_nFile )
+#else
+	if ( pResult->m_unAppID != SteamUtils()->GetAppID() || pResult->m_nPublishedFileId != m_nFile )
+#endif
 	{
 		return;
 	}
@@ -3435,7 +4048,11 @@ void CReactiveDropWorkshop::CheckPublishedAddonConsistency()
 {
 	FOR_EACH_VEC( m_EnabledAddons, i )
 	{
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		if ( SteamUser()->GetSteamID() != m_EnabledAddons[i].details.m_ulSteamIDOwner )
+#else
+		if ( SteamUser()->GetSteamID() != m_EnabledAddons[i].details.m_ulSteamIDOwner )
+#endif
 		{
 			continue;
 		}

--- a/src/game/shared/swarm/rd_workshop.h
+++ b/src/game/shared/swarm/rd_workshop.h
@@ -151,7 +151,11 @@ private:
 		bool m_bCancelled;
 		PublishedFileId_t m_nFileID;
 		UGCHandle_t m_nPreviewImage;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 		CCallResult<CReactiveDropWorkshop::WorkshopPreviewRequest_t, RemoteStorageDownloadUGCResult_t> m_hCall;
+#else
+		CCallResult<CReactiveDropWorkshop::WorkshopPreviewRequest_t, RemoteStorageDownloadUGCResult_t> m_hCall;
+#endif
 	};
 	CUtlVectorAutoPurge<WorkshopPreviewRequest_t *> m_PreviewRequests;
 	void ClearOldPreviewRequests();
@@ -247,24 +251,52 @@ private:
 	CUtlVector<PublishedFileId_t> m_DisabledAddons;
 
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
+	STEAM_CALLBACK( CReactiveDropWorkshop, ScreenshotReadyCallback, ScreenshotReady_t );
+#else
 	STEAM_CALLBACK( CReactiveDropWorkshop, ScreenshotReadyCallback, ScreenshotReady_t );
 #endif
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CReactiveDropWorkshop, DownloadItemResultCallback, DownloadItemResult_t );
+#else
+	STEAM_CALLBACK( CReactiveDropWorkshop, DownloadItemResultCallback, DownloadItemResult_t );
+#endif
 #ifdef GAME_DLL
 	STEAM_GAMESERVER_CALLBACK( CReactiveDropWorkshop, DownloadItemResultCallback_Server, DownloadItemResult_t );
 #endif
 	void AddAddonsToCache( SteamUGCQueryCompleted_t *pResult, bool bIOFailure, UGCQueryHandle_t & hQuery );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CReactiveDropWorkshop, SteamUGCQueryCompleted_t> m_SteamUGCQueryCompleted;
+#else
+	CCallResult<CReactiveDropWorkshop, SteamUGCQueryCompleted_t> m_SteamUGCQueryCompleted;
+#endif
 	void SteamUGCQueryCompletedCallback( SteamUGCQueryCompleted_t *pResult, bool bIOFailure );
 #ifdef CLIENT_DLL
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CReactiveDropWorkshop, SteamUGCQueryCompleted_t> m_SteamPublishedAddonsRequestCompleted;
+#else
+	CCallResult<CReactiveDropWorkshop, SteamUGCQueryCompleted_t> m_SteamPublishedAddonsRequestCompleted;
+#endif
 	void SteamPublishedAddonsRequestCompleted( SteamUGCQueryCompleted_t *pResult, bool bIOFailure );
 #endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CReactiveDropWorkshop, SteamUGCQueryCompleted_t> m_SteamFavoritedAddonsRequestCompleted;
+#else
+	CCallResult<CReactiveDropWorkshop, SteamUGCQueryCompleted_t> m_SteamFavoritedAddonsRequestCompleted;
+#endif
 	void SteamFavoritedAddonsRequestCompleted( SteamUGCQueryCompleted_t *pResult, bool bIOFailure );
 
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CReactiveDropWorkshop, OnSubscribed, RemoteStoragePublishedFileSubscribed_t );
+#else
+	STEAM_CALLBACK( CReactiveDropWorkshop, OnSubscribed, RemoteStoragePublishedFileSubscribed_t );
+#endif
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	STEAM_CALLBACK( CReactiveDropWorkshop, OnUnsubscribed, RemoteStoragePublishedFileUnsubscribed_t );
+#else
+	STEAM_CALLBACK( CReactiveDropWorkshop, OnUnsubscribed, RemoteStoragePublishedFileUnsubscribed_t );
+#endif
 
 #ifdef CLIENT_DLL
 	void UploadWorkshopItem( const char *pszContentPath, const char *pszPreviewImagePath, const char *pszTitle, const char *pszDescription, const CUtlVector<const char *> & tags );
@@ -299,13 +331,29 @@ private:
 	UGCUpdateHandle_t m_hUpdate;
 	PublishedFileId_t m_nLastPublishedFileID;
 	bool m_bWantAutoTags;
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CReactiveDropWorkshop, CreateItemResult_t> m_CreateItemResultCallback;
+#else
+	CCallResult<CReactiveDropWorkshop, CreateItemResult_t> m_CreateItemResultCallback;
+#endif
 	void CreateItemResultCallback( CreateItemResult_t *pResult, bool bIOFailure );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CReactiveDropWorkshop, SubmitItemUpdateResult_t> m_SubmitItemUpdateResultCallback;
+#else
+	CCallResult<CReactiveDropWorkshop, SubmitItemUpdateResult_t> m_SubmitItemUpdateResultCallback;
+#endif
 	void SubmitItemUpdateResultCallback( SubmitItemUpdateResult_t *pResult, bool bIOFailure );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CReactiveDropWorkshop, SteamUGCQueryCompleted_t> m_UpdateWorkshopItemQueryResultCallback;
+#else
+	CCallResult<CReactiveDropWorkshop, SteamUGCQueryCompleted_t> m_UpdateWorkshopItemQueryResultCallback;
+#endif
 	void UpdateWorkshopItemQueryResultCallback( SteamUGCQueryCompleted_t *pResult, bool bIOFailure );
+#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 	CCallResult<CReactiveDropWorkshop, CreateItemResult_t> m_CreateItemResultCallbackCurated;
+#else
+	CCallResult<CReactiveDropWorkshop, CreateItemResult_t> m_CreateItemResultCallbackCurated;
+#endif
 	void CreateItemResultCallbackCurated( CreateItemResult_t *pResult, bool bIOFailure );
 	friend static void ugc_create(const CCommand & args);
 	friend static void ugc_curated_create(const CCommand & args);

--- a/src/public/engine/thinktracecounter.h
+++ b/src/public/engine/thinktracecounter.h
@@ -36,7 +36,11 @@
 				// done as a static var to defer initialization until Steam is ready,
 				// but also to have the fastest check at runtime (rather than calling through
 				// the API each time)
+				#if defined( STEAMAPPS_INTERFACE_VERSION008 )
 				static bool bIsPublic = SteamUtils() != NULL && SteamUtils()->GetConnectedUniverse() == k_EUniversePublic;
+				#else
+				static bool bIsPublic = SteamUtils() != NULL && SteamUtils()->GetConnectedUniverse() == k_EUniversePublic;
+				#endif
 				return !bIsPublic;
 			}
 		#else


### PR DESCRIPTION
This is a follow-up to #1088 and is intentionally based on its head branch.

## Steam SDK 1.65 migration update

### Progress

- The follow-up implementation is consolidated into one commit on top of the PR head base `574e27fbf3dd228e347d21e60ae430867f0cee3c`: [`6742f4d1d6300ea98ea71111a3372019ca80659e`](https://github.com/ywgATustcbbs/reactivedrop_public_src/commit/6742f4d1d6300ea98ea71111a3372019ca80659e).
- The original PR branch could not be updated directly because upstream rejected the push with HTTP 403. This follow-up uses my fork branch [`task/steam-sdk-pr1088`](https://github.com/ywgATustcbbs/reactivedrop_public_src/tree/task/steam-sdk-pr1088).
- Phase 4: **46/46 packages** reached final independent PASS.
- Phase 5: one canonical solution-level `Release|Win32 Rebuild` completed with exit code 0 and 0 errors. The new SDK `#else` path and the x86 Steam SDK 1.65 `steam_api.lib` link were verified. The deployable build outputs are exactly `client.dll`, `server.dll`, and `missionchooser.dll`.
- Warning closure: 88,542 total warnings across 13 codes; 88,416 were policy-ignored; 126 retained events at 121 locations across 10 codes. All retained warnings were legacy or external-SDK warnings; migration-attributable/actionable warnings: 0. No warning-driven source fixes were needed.

### Change classification

The following ledgers overlap and are not additive. They should not be interpreted as a three-way file/line/code-block count, and there is no trustworthy non-overlapping count for “rewritten compatibility logic” versus “simple call fixes” versus “verbatim copies”.

- **25 semantic compatibility/design-change records** (`A=6`, `B=19`). This is a design-matrix count, not a count of files, lines, or code blocks.
- **9 API branch substitutions already present in PR #1088**: 3 `RequestCurrentStats`, 5 user `RequestUserStats`, and 1 dedicated-server `RequestUserStats`. These remain covered by callback/pump/teardown review and are not claimed as fully accepted simple fixes.
- **1,086 new defensive wrapper units** for business Steam calls, covering both changed and unchanged calls. The unchanged-only subset was not separately aggregated, so no trustworthy unchanged-only number is claimed.
- **4 pre-existing guarded units** (`CB-01` through `CB-04`) retained from the PR structure.
- **Total unique defensive-wrapper scope: 1,090 = 1,086 + 4.** This wrapper ledger is not an additional rewrite count.

### Key user decisions

- Preserve the PR's old/new conditional structure.
- Guard every in-scope business Steam accessor, method, global function, and callback registration explicitly with the `STEAMAPPS_INTERFACE_VERSION008` old/new branches, including calls whose API did not change.
- Preserve the macro expression as-is. Its origin was intentionally not investigated; no extra version detection, fallback, or second ABI was introduced.
- Build and link only the new path. The old path is mirror/static-review-only and remains **Not built by user decision**.
- Treat the patched `engine.dll` and external `steam_api.dll` as runtime inputs. Their provenance, ABI, and package relationship are deferred to runtime validation.
- The build result is one unified Release gate, not nine independent builds.

### Manual smoke testing

Verified by user:

- [x] Game starts normally.
- [x] In-game inventory works.
- [x] A self-hosted lobby can be created and played for approximately 30 seconds without an observed problem.
- [x] Leaderboards are visible.
- [x] Lobby list is visible.

Not yet verified:

- [ ] Long-duration stability, a full level, and repeated map transitions.
- [ ] Joining another player's lobby, invitations, leaving, and reconnecting.
- [ ] Dedicated-server operation.
- [ ] Inventory asynchronous completion, cancellation, error handling, and map-end behavior.
- [ ] Full stats, achievements, and player-reporting callback flows.
- [ ] Workshop/UGC, friends/presence, input, HTTP, and Steam Deck/Proton coverage.
- [ ] Clean shutdown/reinitialization and failure paths.
- [ ] Runtime logs/crash dumps and `engine.dll`/`steam_api.dll` provenance and ABI validation.

Phase 6 therefore has partial smoke evidence, but is not a complete runtime PASS yet.
