### PR TITLE
Fix sniper rifle wall and shieldbug penetration

### DIFF
--- a/src/game/shared/swarm/asw_marine_shared.cpp
+++ b/src/game/shared/swarm/asw_marine_shared.cpp
@@ -1465,9 +1465,11 @@ void CASW_Marine::FirePenetratingBullets( const FireBulletsInfo_t &info, int iMa
 			{
 				if ( tr.m_pEnt->Classify() == CLASS_ASW_SHIELDBUG )		// don't let bullets pass through shieldbugs
 				{
-					bPierce = false;
+					bool bShieldbugBlocked = false;
+					bShieldbugBlocked = ( tr.hitgroup == HITGROUP_BONE_SHIELD || tr.hitbox == 1 ); // see CASW_Shieldbug::BlockedDamage
+					bPierce = !bShieldbugBlocked; // allow piercing vulnerable body parts
 				}
-				else if ( ( info.m_nFlags & FIRE_BULLETS_NO_PIERCING_SPARK ) == 0 )
+				if ( bPierce && !( info.m_nFlags & FIRE_BULLETS_NO_PIERCING_SPARK ) )
 				{
 					CEffectData	data;
 					data.m_vOrigin = tr.endpos;
@@ -1483,7 +1485,8 @@ void CASW_Marine::FirePenetratingBullets( const FireBulletsInfo_t &info, int iMa
 			}
 		}
 
-		if ( ( tr.m_pEnt != NULL ) && fPenetrateChance > 1.0f )
+		if ( ( tr.m_pEnt != NULL ) && fPenetrateChance > 1.0f &&
+				( tr.m_pEnt->Classify() != CLASS_ASW_SHIELDBUG || bPierce ) )
 		{
 			// We can only penetrate a few walls
 			fPenetrateChance -= 1.0f;

--- a/src/game/shared/swarm/asw_marine_shared.cpp
+++ b/src/game/shared/swarm/asw_marine_shared.cpp
@@ -1263,6 +1263,21 @@ void CASW_Marine::FirePenetratingBullets( const FireBulletsInfo_t &info, int iMa
 		}
 		VectorNormalize( vecFinalDir );
 
+		// if ( tr.startsolid )
+		// 	Msg( ">> startsolid fraction left:%f full:%f %s\n", tr.fractionleftsolid, tr.fraction, tr.m_pEnt ? tr.m_pEnt->GetClassname() : "" );
+		// started trace inside a cursed solid? // Fix sniper rifle world penetration #241
+		if ( tr.startsolid && tr.fraction != 0.0f && tr.DidHitWorld() )
+		{
+			// Could calculate new start point here with tr.fractionleftsolid,
+			// but the code down below already handles next penetration.
+			// Just prevent bad TraceLine escaping the solid causing seemingly
+			// infitite tracer with tr.m_Ent = solid it started in.
+			AI_TraceLine(info.m_vecSrc, info.m_vecSrc, MASK_SHOT, &traceFilter, &tr);
+			vecEnd = tr.endpos;
+		}
+		// else if ( tr.startsolid )
+		// 	Msg( "  ... but it was ok I guess\n" );
+
 #ifdef GAME_DLL
 		if ( ai_debug_shoot_positions.GetBool() )
 		{
@@ -1521,11 +1536,13 @@ void CASW_Marine::FirePenetratingBullets( const FireBulletsInfo_t &info, int iMa
 					int iNextMaxPenetrate = iMaxPenetrate;
 					if ( !tr.DidHitWorld() )
 					{
+						// Msg ( "Penetrate %.2f %d entity %s\n", fPenetrateChance, iMaxPenetrate, tr.m_pEnt->GetClassname() );
 						behindNPCInfo.m_pAdditionalIgnoreEnt = tr.m_pEnt;
 						iNextMaxPenetrate--;
 					}
 					else
 					{
+						// Msg ( "Penetrate %.2f %d world entity %s\n", fPenetrateChance, iMaxPenetrate, tr.m_pEnt->GetClassname() );
 						// Penetrate past the solid
 						behindNPCInfo.m_vecSrc = behindNPCInfo.m_vecSrc + behindNPCInfo.m_vecDirShooting * 28.0f;
 						behindNPCInfo.m_pAdditionalIgnoreEnt = NULL;

--- a/src/game/shared/swarm/asw_marine_shared.cpp
+++ b/src/game/shared/swarm/asw_marine_shared.cpp
@@ -1412,6 +1412,12 @@ void CASW_Marine::FirePenetratingBullets( const FireBulletsInfo_t &info, int iMa
 			}
 		}
 
+		if ( bShowHitboxes && IsInhabited() && tr.DidHit() )
+		{
+			CFmtStr text( "%.2f %d", fPenetrateChance, iMaxPenetrate );
+			NDebugOverlay::Text( tr.endpos, text, false, 4 );
+		}
+
 		// See if we hit glass
 		if ( tr.m_pEnt != NULL )
 		{


### PR DESCRIPTION
Close #241.

- Add piercing info to `sv_showimpact` debug overlay
- Fix piercing some world objects like walls
- Fix piercing shieldbugs

If you damage a shieldbug from behind you will pierce its shield regardless, but that would be hard to fix.

Running around with `sv_showimpact 1` and shooting through things and bots at `rd-bio3biogenlabs` and at the spawn zone of `rd-ocs3uscmedusa` didn't expose any problem.

---

- Add `rd_shieldbug_pierce` for penetrating sb shield. Not a separate PR because it's a small change and Github's stacked PRs not working :sad:
- `rd_shieldbug_pierce_wall` (effectively) limit sb shield piercing to sniper rifles.