### PR TITLE
Adjust sniper penetration value calculation

### DIFF
--- a/src/game/shared/swarm/asw_weapon_sniper_rifle.cpp
+++ b/src/game/shared/swarm/asw_weapon_sniper_rifle.cpp
@@ -192,11 +192,11 @@ void CASW_Weapon_Sniper_Rifle::PrimaryAttack( void )
 	int iPenetration = 1;
 	if ( IsZoomed() )
 	{
-		iPenetration = 2;
+		iPenetration += 1;
 	}
 	if ( pMarine->GetDamageBuffEndTime() > gpGlobals->curtime )		// sniper rifle penetrates more targets when marine is in a damage amp
 	{
-		iPenetration = 3;
+		iPenetration += 2;
 	}
 	pMarine->FirePenetratingBullets( info, iPenetration, 3.5f, 0, true, NULL, false  );
 

--- a/src/game/shared/swarm/asw_weapon_sniper_rifle.cpp
+++ b/src/game/shared/swarm/asw_weapon_sniper_rifle.cpp
@@ -198,7 +198,8 @@ void CASW_Weapon_Sniper_Rifle::PrimaryAttack( void )
 	{
 		iPenetration += 2;
 	}
-	pMarine->FirePenetratingBullets( info, iPenetration, 3.5f, 0, true, NULL, false  );
+	int iWallPenetration = 1 + iPenetration;
+	pMarine->FirePenetratingBullets( info, iPenetration, iWallPenetration + 0.5f, 0, true, NULL, false  );
 
 	// increment shooting stats
 #ifndef CLIENT_DLL


### PR DESCRIPTION
## Enemy penetration

- Make damage amp add +2 penetration instead of hard setting it to 3.

I don't think you ever need to hit 5 aliens in a row, but calculating the alt-fire + damage amp bonus seems natural and neatly ties into the new wall penetration calculation.

## Wall penetration

- primary: nerfed
- secondary: unchanged
- amped: buffed

Wall penetration used to be bugged, so I guess players won't notice the nerf to the primary attack. It also reduces unnecessary wall penetration caused by random fire and makes the secondary attack feel stronger (more reliable than primary) when you're deliberately trying to hit an enemy behind a wall.

 